### PR TITLE
Add open in background file buffer

### DIFF
--- a/lua/fzf-lua/actions.lua
+++ b/lua/fzf-lua/actions.lua
@@ -69,6 +69,11 @@ M.file_tabedit = function(selected)
   M.vimcmd_file(vimcmd, selected)
 end
 
+M.file_open_in_background = function(selected)
+  local vimcmd = "badd"
+  M.vimcmd_file(vimcmd, selected)
+end
+
 M.file_sel_to_qf = function(selected)
   if not selected or #selected < 2 then return end
   local qf_list = {}


### PR DESCRIPTION
Hi, 

First, thanks for making this plugin! It is such a nice lua version of fzf.vim :) 

I'm interested in opening selections in "the background", i.e. just adding them to the buffer list but not switching to them. What are your thoughts about adding it to such an action? I didn't add them any default keybindings since if someone wants to use this they can create keybinding in their user config. 