### PR TITLE
add lsp.workspace_diag_only_cwd option to filter out diagnostics entries from files outside of the current working directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,6 +360,7 @@ require'fzf-lua'.setup {
   lsp = {
     prompt            = '❯ ',
     -- cwd               = vim.loop.cwd(),
+    cwd_only          = false, -- show workspace diagnostics only for the files in cwd
     file_icons        = true,
     git_icons         = false,
     lsp_icons         = true,

--- a/lua/fzf-lua/config.lua
+++ b/lua/fzf-lua/config.lua
@@ -302,6 +302,7 @@ M.globals.lsp = {
           ["Information"] = { icon = "", color = "blue" },      -- info
           ["Hint"]        = { icon = "", color = "magenta" },   -- hint
       },
+      workspace_diag_only_cwd = false,
   }
 M.globals.builtin = {
       prompt              = 'Builtin> ',

--- a/lua/fzf-lua/config.lua
+++ b/lua/fzf-lua/config.lua
@@ -302,7 +302,7 @@ M.globals.lsp = {
           ["Information"] = { icon = "", color = "blue" },      -- info
           ["Hint"]        = { icon = "", color = "magenta" },   -- hint
       },
-      workspace_diag_only_cwd = false,
+      cwd_only = false,
   }
 M.globals.builtin = {
       prompt              = 'Builtin> ',

--- a/lua/fzf-lua/providers/lsp.lua
+++ b/lua/fzf-lua/providers/lsp.lua
@@ -315,6 +315,10 @@ M.diagnostics = function(opts)
   local lsp_type_diagnostic = vim.lsp.protocol.DiagnosticSeverity
   local current_buf = vim.api.nvim_get_current_buf()
 
+  if opts.cwd_only then
+    opts.cwd = vim.loop.cwd()
+  end
+
   -- save this so handler can get the lsp icon
   opts.cfg = config.globals.lsp
 
@@ -384,14 +388,12 @@ M.diagnostics = function(opts)
         end
       end
       for bufnr, diags in pairs(buffer_diags) do
-        if not opts.workspace_diag_only_cwd or (opts.workspace_diag_only_cwd and string.find(vim.api.nvim_buf_get_name(bufnr), vim.loop.cwd(), 1, true) ) then
-          for _, diag in ipairs(diags) do
-            -- workspace diagnostics may include empty tables for unused bufnr
-            if not vim.tbl_isempty(diag) then
-              if filter_diag_severity(opts, diag.severity) then
-                diagnostics_handler(opts, cb, co,
-                  preprocess_diag(diag, bufnr))
-              end
+        for _, diag in ipairs(diags) do
+          -- workspace diagnostics may include empty tables for unused bufnr
+          if not vim.tbl_isempty(diag) then
+            if filter_diag_severity(opts, diag.severity) then
+              diagnostics_handler(opts, cb, co,
+                preprocess_diag(diag, bufnr))
             end
           end
         end

--- a/lua/fzf-lua/providers/lsp.lua
+++ b/lua/fzf-lua/providers/lsp.lua
@@ -384,12 +384,14 @@ M.diagnostics = function(opts)
         end
       end
       for bufnr, diags in pairs(buffer_diags) do
-        for _, diag in ipairs(diags) do
-          -- workspace diagnostics may include empty tables for unused bufnr
-          if not vim.tbl_isempty(diag) then
-            if filter_diag_severity(opts, diag.severity) then
-              diagnostics_handler(opts, cb, co,
-                preprocess_diag(diag, bufnr))
+        if not opts.workspace_diag_only_cwd or (opts.workspace_diag_only_cwd and string.find(vim.api.nvim_buf_get_name(bufnr), vim.loop.cwd(), 1, true) ) then
+          for _, diag in ipairs(diags) do
+            -- workspace diagnostics may include empty tables for unused bufnr
+            if not vim.tbl_isempty(diag) then
+              if filter_diag_severity(opts, diag.severity) then
+                diagnostics_handler(opts, cb, co,
+                  preprocess_diag(diag, bufnr))
+              end
             end
           end
         end

--- a/lua/fzf-lua/providers/lsp.lua
+++ b/lua/fzf-lua/providers/lsp.lua
@@ -315,10 +315,6 @@ M.diagnostics = function(opts)
   local lsp_type_diagnostic = vim.lsp.protocol.DiagnosticSeverity
   local current_buf = vim.api.nvim_get_current_buf()
 
-  if opts.cwd_only then
-    opts.cwd = vim.loop.cwd()
-  end
-
   -- save this so handler can get the lsp icon
   opts.cfg = config.globals.lsp
 
@@ -388,12 +384,14 @@ M.diagnostics = function(opts)
         end
       end
       for bufnr, diags in pairs(buffer_diags) do
-        for _, diag in ipairs(diags) do
-          -- workspace diagnostics may include empty tables for unused bufnr
-          if not vim.tbl_isempty(diag) then
-            if filter_diag_severity(opts, diag.severity) then
-              diagnostics_handler(opts, cb, co,
-                preprocess_diag(diag, bufnr))
+        if not opts.cwd_only or (opts.cwd_only and string.find(vim.api.nvim_buf_get_name(bufnr), vim.loop.cwd(), 1, true) ) then
+          for _, diag in ipairs(diags) do
+            -- workspace diagnostics may include empty tables for unused bufnr
+            if not vim.tbl_isempty(diag) then
+              if filter_diag_severity(opts, diag.severity) then
+                diagnostics_handler(opts, cb, co,
+                  preprocess_diag(diag, bufnr))
+              end
             end
           end
         end


### PR DESCRIPTION
### Motivation
`rust-analyzer` LSP server loads a new LSP server instance and pushes diagnostics for dependencies (external crates) when you open their files (via "jump to definition", etc.).