### PR TITLE
Optimize git performance

### DIFF
--- a/lua/fzf-lua/core.lua
+++ b/lua/fzf-lua/core.lua
@@ -166,7 +166,7 @@ M.fzf_files = function(opts)
 
   -- reset git tracking
   opts.diff_files, opts.untracked_files = nil, nil
-  if not utils.is_git_repo() then opts.git_icons = false end
+  if opts.git_icons and not utils.is_git_repo() then opts.git_icons = false end
 
   if opts.cwd and #opts.cwd > 0 then
     opts.cwd = vim.fn.expand(opts.cwd)

--- a/lua/fzf-lua/utils.lua
+++ b/lua/fzf-lua/utils.lua
@@ -50,7 +50,7 @@ function M.shell_error()
 end
 
 function M.is_git_repo()
-  vim.fn.system("git status")
+  vim.fn.system("git rev-parse --git-dir")
   return M._if(M.shell_error(), false, true)
 end
 


### PR DESCRIPTION
1) Faster method to determine if in git repo
2) Bypass entirely if git icons disabled

These two changes make fzf-lua perform _much_ faster when run in large codebases. `git status` takes between half a second a second to run on our large codebase, but this change makes fzf-lua nearly as snappy as fzf.vim.