### PR TITLE
Add actions to checkout and inspect previous git commits

### DIFF
--- a/lua/fzf-lua/actions.lua
+++ b/lua/fzf-lua/actions.lua
@@ -216,14 +216,16 @@ end
 
 M.git_checkout = function(selected)
   local commit_hash = selected[1]:match("[^ ]+")
-  local current_commit = vim.fn.systemlist("git rev-parse --short HEAD")
-  if(commit_hash == current_commit) then return end
-  local output = vim.fn.systemlist("git checkout " .. commit_hash)
-  if utils.shell_error() then
-    utils.err(unpack(output))
-  else
-    utils.info(unpack(output))
-    vim.cmd("edit!")
+  if vim.fn.input("Checkout commit " .. commit_hash .. "? ") == "y" then
+    local current_commit = vim.fn.systemlist("git rev-parse --short HEAD")
+    if(commit_hash == current_commit) then return end
+    local output = vim.fn.systemlist("git checkout " .. commit_hash)
+    if utils.shell_error() then
+      utils.err(unpack(output))
+    else
+      utils.info(unpack(output))
+      vim.cmd("edit!")
+    end
   end
 end
 

--- a/lua/fzf-lua/actions.lua
+++ b/lua/fzf-lua/actions.lua
@@ -216,7 +216,7 @@ end
 
 M.git_checkout = function(selected)
   local commit_hash = selected[1]:match("[^ ]+")
-  if vim.fn.input("Checkout commit " .. commit_hash .. "? ") == "y" then
+  if vim.fn.input("Checkout commit " .. commit_hash .. "? [y/n] ") == "y" then
     local current_commit = vim.fn.systemlist("git rev-parse --short HEAD")
     if(commit_hash == current_commit) then return end
     local output = vim.fn.systemlist("git checkout " .. commit_hash)

--- a/lua/fzf-lua/actions.lua
+++ b/lua/fzf-lua/actions.lua
@@ -1,4 +1,5 @@
 local utils = require "fzf-lua.utils"
+local path = require "fzf-lua.path"
 
 local M = {}
 
@@ -196,6 +197,7 @@ M.man_tab = function(selected)
   M.vimcmd(vimcmd, selected)
 end
 
+
 M.git_switch = function(selected)
   -- remove anything past space
   local branch = selected[1]:match("[^ ]+")
@@ -210,6 +212,51 @@ M.git_switch = function(selected)
     utils.info(unpack(output))
     vim.cmd("edit!")
   end
+end
+
+M.git_checkout = function(selected)
+  local commit_hash = selected[1]:match("[^ ]+")
+  local current_commit = vim.fn.systemlist("git rev-parse --short HEAD")
+  if(commit_hash == current_commit) then return end
+  local output = vim.fn.systemlist("git checkout " .. commit_hash)
+  if utils.shell_error() then
+    utils.err(unpack(output))
+  else
+    utils.info(unpack(output))
+    vim.cmd("edit!")
+  end
+end
+
+M.git_buf_edit = function(selected)
+  -- there's an empty string in position 1 for some reason?
+  table.remove(selected,1)
+  local win = vim.api.nvim_get_current_win()
+  local buffer_filetype = vim.bo.filetype
+  local file = path.relative(vim.fn.expand("%"), vim.loop.cwd())
+  local commit_hash = selected[1]:match("[^ ]+")
+  local git_file_contents = vim.fn.systemlist("git show " .. commit_hash .. ":" .. file)
+  local buf = vim.api.nvim_create_buf(true, false) 
+  local file_name = string.gsub(file,"%.","[" .. commit_hash .. "]%.")
+  vim.api.nvim_buf_set_lines(buf,0,0,true,git_file_contents)
+  vim.api.nvim_buf_set_name(buf,file_name)
+  vim.api.nvim_buf_set_option(buf, 'buftype', 'nofile')
+  vim.api.nvim_buf_set_option(buf, 'filetype',buffer_filetype)
+  vim.api.nvim_win_set_buf(win, buf)
+end
+
+M.git_buf_tabedit = function(selected)
+  vim.cmd('tab split')
+  M.git_buf_edit(selected)
+end
+
+M.git_buf_split = function(selected)
+  vim.cmd('split')
+  M.git_buf_edit(selected)
+end
+
+M.git_buf_vsplit = function(selected)
+  vim.cmd('vsplit')
+  M.git_buf_edit(selected)
 end
 
 return M

--- a/lua/fzf-lua/config.lua
+++ b/lua/fzf-lua/config.lua
@@ -150,7 +150,7 @@ M.globals.git = {
       cmd           = "git log --pretty=oneline --abbrev-commit --color",
       preview       = "git show --pretty='%Cred%H%n%Cblue%an%n%Cgreen%s' --color {1}",
       actions = {
-        ["default"] = nil,
+        ["default"] = actions.git_checkout,
       },
     },
     bcommits = {
@@ -158,7 +158,10 @@ M.globals.git = {
       cmd           = "git log --pretty=oneline --abbrev-commit --color --",
       preview       = "git show --pretty='%Cred%H%n%Cblue%an%n%Cgreen%s' --color {1}",
       actions = {
-        ["default"] = nil,
+        ["default"] = actions.git_buf_edit,
+        ["ctrl-s"]  = actions.git_buf_split,
+        ["ctrl-v"]  = actions.git_buf_vsplit,
+        ["ctrl-t"]  = actions.git_buf_tabedit,
       },
     },
     branches = {


### PR DESCRIPTION
Addresses #51. Implements opening previous commits in a read only buffer/split/tab and corresponding actions for b_commits. Also implements checkout action for git commits.