### PR TITLE
Set cursorlineopt=both in the builtin previewer

### DIFF
--- a/lua/fzf-lua/previewer/builtin.lua
+++ b/lua/fzf-lua/previewer/builtin.lua
@@ -96,6 +96,7 @@ function Previewer:gen_winopts()
     number          = true,
     relativenumber  = false,
     cursorline      = true,
+    cursorlineopt   = 'both',
     cursorcolumn    = false,
     signcolumn      = 'no',
     foldenable      = false,


### PR DESCRIPTION
This way, if the user has defined cursorlineopt=number elsewhere, we
override it to behave as intended.