### PR TITLE
Add support for fzf --color option

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,8 @@ require'fzf-lua'.setup {
     hl_border        = 'FloatBorder',   -- window border color
   },
   -- fzf_bin             = 'sk',        -- use skim instead of fzf?
-  fzf_layout          = 'reverse',      -- fzf '--layout='
+  fzf_colors          = nil,            -- fzf '--color=' options
+  fzf_layout          = 'reverse',      -- fzf '--layout=' options
   fzf_args            = '',             -- adv: fzf extra args, empty unless adv
   fzf_binds           = {               -- fzf '--bind=' options
       'f2:toggle-preview',

--- a/lua/fzf-lua/config.lua
+++ b/lua/fzf-lua/config.lua
@@ -35,6 +35,7 @@ M.globals = {
   },
   default_prompt      = '> ',
   fzf_bin             = nil,
+  fzf_colors          = nil,
   fzf_layout          = 'reverse',
   fzf_binds = {
     -- <F2>        toggle preview


### PR DESCRIPTION
`fzf.vim` provides the global option `fzf_colors`, which allows the user to match some of the fzf highlight groups with vim highlight groups. Without `--color`, the fzf colorscheme doesn't always acceptably match the vim one (for example when using light themes). Setting the enviroment option `$FZF_DEFAULT_OPS` can help, but only if you are not changing vim colorschemes often. This PR should help in this regard. We should also probably discuss which vim highlight groups should match to which fzf `--color` options.

Great plugin, btw! I've decided to switch to it completely today, after using `fzf.vim` for a while now and it's been nothing but smooth sailing.