### PR TITLE
Fix empty line in the builtin previewer

### DIFF
--- a/lua/fzf-lua/previewer/builtin.lua
+++ b/lua/fzf-lua/previewer/builtin.lua
@@ -314,7 +314,16 @@ function Previewer:display_entry(entry)
       if not vim.api.nvim_buf_is_valid(bufnr) then
         return
       end
-      local ok = pcall(vim.api.nvim_buf_set_lines, bufnr, 0, -1, false, vim.split(data, "[\r]?\n"))
+
+      local lines = vim.split(data, "[\r]?\n")
+
+      -- if file ends in new line, don't write an empty string as the last
+      -- line.
+      if data:sub(#data, #data) == "\n" or data:sub(#data-1,#data) == "\r\n" then
+        table.remove(lines)
+      end
+
+      local ok = pcall(vim.api.nvim_buf_set_lines, bufnr, 0, -1, false, lines)
       if not ok then
         return
       end


### PR DESCRIPTION
Whenever the file ends with newline, the builtin previewer was adding an
empty line at the end of the file. That's a side effect splitting and
rejoining the lines with \n. Basically, when we split a\nb\nc\n we get
{'a', 'b', 'c', ''}, then nvim_buf_set_lines treats each item in the
table as a line, and inserts an empty line at the end.

We do need to account for files that don't end with a new line though,
hence the check.

I don't have a way to test the \r\n logic locally, no Windows hosts
around, but it should work too.

Before:

<img width="1782" alt="image" src="https://user-images.githubusercontent.com/108725/131397967-d5d30c5b-97d8-4b79-9f60-6cb1ed5a074b.png">

(line 23 doesn't really exist, file only has 22 lines: https://github.com/fsouza/dotfiles/blob/main/.github/dependabot.yml)

After:

<img width="1782" alt="image" src="https://user-images.githubusercontent.com/108725/131398048-ff1ec1d8-1ea5-4e32-bba1-2e118e1cab21.png">
