### PR TITLE
Fix loss of git records after checking out older commits

### DIFF
--- a/lua/fzf-lua/config.lua
+++ b/lua/fzf-lua/config.lua
@@ -171,7 +171,7 @@ M.globals.git = {
     },
     commits = {
       prompt        = 'Commits> ',
-      cmd           = "git log --pretty=oneline --abbrev-commit --color",
+      cmd           = "git log --pretty=oneline --abbrev-commit --color --reflog",
       preview       = "git show --pretty='%Cred%H%n%Cblue%an%n%Cgreen%s' --color {1}",
       actions = {
         ["default"] = actions.git_checkout,
@@ -179,7 +179,7 @@ M.globals.git = {
     },
     bcommits = {
       prompt        = 'BCommits> ',
-      cmd           = "git log --pretty=oneline --abbrev-commit --color --",
+      cmd           = "git log --pretty=oneline --abbrev-commit --color --reflog",
       preview       = "git show --pretty='%Cred%H%n%Cblue%an%n%Cgreen%s' --color {1}",
       actions = {
         ["default"] = actions.git_buf_edit,
@@ -191,7 +191,7 @@ M.globals.git = {
     branches = {
       prompt        = 'Branches> ',
       cmd           = "git branch --all --color",
-      preview       = "git log --graph --pretty=oneline --abbrev-commit --color {1}",
+      preview       = "git log --graph --pretty=oneline --abbrev-commit --reflog --color {1}",
       actions = {
         ["default"] = actions.git_switch,
       },


### PR DESCRIPTION
Addresses #86 by adding --reflog flag to the "git log" command which populates the list of commits. See [reflog docs](https://git-scm.com/docs/git-reflog) for more info.