### PR TITLE
Improve git commands so they always run in the git root directory

### DIFF
--- a/lua/fzf-lua/actions.lua
+++ b/lua/fzf-lua/actions.lua
@@ -252,20 +252,22 @@ end
 
 M.git_buf_edit = function(selected, opts)
   local cmd = path.git_cwd("git show ", opts.cwd)
+  local git_root = path.git_root(opts.cwd, true)
   -- there's an empty string in position 1 for some reason?
   table.remove(selected,1)
   local win = vim.api.nvim_get_current_win()
   local buffer_filetype = vim.bo.filetype
-  local file = path.relative(vim.fn.expand("%"), vim.loop.cwd())
+  local file = path.relative(vim.fn.expand("%:p"), git_root)
   local commit_hash = selected[1]:match("[^ ]+")
   local git_file_contents = vim.fn.systemlist(cmd .. commit_hash .. ":" .. file)
-  local buf = vim.api.nvim_create_buf(true, false)
-  local file_name = string.gsub(file,"%.","[" .. commit_hash .. "]%.")
+  local buf = vim.api.nvim_create_buf(true, true)
+  local file_name = string.gsub(file,"$","[" .. commit_hash .. "]")
   vim.api.nvim_buf_set_lines(buf,0,0,true,git_file_contents)
   vim.api.nvim_buf_set_name(buf,file_name)
   vim.api.nvim_buf_set_option(buf, 'buftype', 'nofile')
   vim.api.nvim_buf_set_option(buf, 'bufhidden', 'wipe')
-  vim.api.nvim_buf_set_option(buf, 'filetype',buffer_filetype)
+  vim.api.nvim_buf_set_option(buf, 'filetype', buffer_filetype)
+  vim.api.nvim_buf_set_option(buf, 'modifiable', false)
   vim.api.nvim_win_set_buf(win, buf)
 end
 

--- a/lua/fzf-lua/path.lua
+++ b/lua/fzf-lua/path.lua
@@ -156,20 +156,23 @@ end
 function M.git_cwd(cmd, cwd)
   if not cwd then return cmd end
   cwd = vim.fn.expand(cwd)
-  local arg_cwd = (" --git-dir=%s --work-tree=%s "):format(
-    vim.fn.shellescape(M.join({cwd, ".git"})),
-    vim.fn.shellescape(cwd))
-  return cmd:gsub("^git ", "git " ..  arg_cwd)
+  local arg_cwd = ("-C %s "):format(vim.fn.shellescape(cwd))
+  cmd = cmd:gsub("^git ", "git " ..  arg_cwd)
+  return cmd
 end
 
 function M.is_git_repo(cwd, noerr)
-  local cmd = M.git_cwd("git rev-parse --is-inside-work-tree", cwd)
-  local output = vim.fn.systemlist(cmd)
-  if utils.shell_error() then
-    if not noerr then utils.info(unpack(output)) end
-    return false
-  end
-  return true
+    return not not M.git_root(cwd, noerr)
+end
+
+function M.git_root(cwd, noerr)
+    local cmd = M.git_cwd("git rev-parse --show-toplevel", cwd)
+    local output = vim.fn.systemlist(cmd)
+    if utils.shell_error() then
+        if not noerr then utils.info(unpack(output)) end
+        return nil
+    end
+    return output[1]
 end
 
 return M


### PR DESCRIPTION
This matches the behavior of both fzf.vim and telescope.nvim.

It also fixes a bug with the "git_buf_edit" action if the cwd is not in
the git root.