### PR TITLE
Builtin previewer: improve mechanism for backing up/restoring winopts

### DIFF
--- a/lua/fzf-lua/win.lua
+++ b/lua/fzf-lua/win.lua
@@ -387,6 +387,7 @@ function FzfWin:create()
   -- save sending bufnr/winid
   self.src_bufnr = vim.api.nvim_get_current_buf()
   self.src_winid = vim.api.nvim_get_current_win()
+
   if self.winopts.split then
     vim.cmd(self.winopts.split)
     self.fzf_bufnr = vim.api.nvim_get_current_buf()


### PR DESCRIPTION
See :help local-options for more details, but essentially, we have to be
very careful with how we set window-local options on popup windows,
because buffers might take some window-local options from the last
window they were displayed in with them to the new window in certain
circumstances.

This commit changes the backup/restore for the window options so that
the possible window-local options that might get clobbered are saved
from the original active window and reapplied to the preview window just
before it's closed. This ensures any buffers loaded from the picker will
have the same window options applied that were in the active window when
fzf was opened.