### PR TITLE
Add file_icon_padding option

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,6 +449,7 @@ require'fzf-lua'.setup {
   file_icon_colors = {
     ["lua"]   = "blue",
   },
+  file_icon_padding = '',
 }
 ```
 

--- a/lua/fzf-lua/config.lua
+++ b/lua/fzf-lua/config.lua
@@ -492,6 +492,7 @@ M.globals.file_icon_colors = {
     ["otf"]       = "green",
     ["ttf"]       = "green",
 }
+M.globals.file_icon_padding = ''
 
 function M.normalize_opts(opts, defaults)
   if not opts then opts = {} end

--- a/lua/fzf-lua/core.lua
+++ b/lua/fzf-lua/core.lua
@@ -44,7 +44,7 @@ M.get_devicon = function(file, ext)
     local devicon = config._devicons.get_icon(file, ext)
     if devicon then icon = devicon end
   end
-  return icon
+  return icon..config.globals.file_icon_padding
 end
 
 M.preview_window = function(opts)


### PR DESCRIPTION
Fixes #98 
This option helps kitty terminal users to render double-width icons.