### PR TITLE
File icons: use colors from nvim-web-devicons if available

### DIFF
--- a/lua/fzf-lua/config.lua
+++ b/lua/fzf-lua/config.lua
@@ -442,8 +442,24 @@ M.globals.nvim = {
       },
     },
   }
+
 M.globals.file_icon_padding = ''
-M.globals.file_icon_colors = {
+
+if M._has_devicons then
+  M.globals.file_icon_colors = {}
+
+  local function hex(hex)
+    local r,g,b = hex:match('.(..)(..)(..)')
+    r, g, b = tonumber(r, 16), tonumber(g, 16), tonumber(b, 16)
+    return r, g, b
+  end
+
+  for ext, info in pairs(M._devicons.get_icons()) do
+    local r, g, b = hex(info.color)
+    utils.add_ansi_code('DevIcon' .. info.name, string.format('[38;2;%s;%s;%sm', r, g, b))
+  end
+else
+  M.globals.file_icon_colors = {
     ["lua"]       = "blue",
     ["rockspec"]  = "magenta",
     ["vim"]       = "green",
@@ -492,7 +508,8 @@ M.globals.file_icon_colors = {
     ["svg"]       = "green",
     ["otf"]       = "green",
     ["ttf"]       = "green",
-}
+  }
+end
 
 function M.normalize_opts(opts, defaults)
   if not opts then opts = {} end

--- a/lua/fzf-lua/core.lua
+++ b/lua/fzf-lua/core.lua
@@ -155,7 +155,12 @@ end
 M.make_entry_file = function(opts, x)
   local icon, hl
   local ret = {}
-  local file = utils.strip_ansi_coloring(string.match(x, '[^:]*'))
+  local file = x
+  for s in string.gmatch(x, '[^:]+') do
+    file = s
+    break
+  end
+  file = utils.strip_ansi_coloring(file)
   if opts.cwd_only and path.starts_with_separator(file) then
     local cwd = opts.cwd or vim.loop.cwd()
     if not path.is_relative(file, cwd) then

--- a/lua/fzf-lua/core.lua
+++ b/lua/fzf-lua/core.lua
@@ -155,12 +155,7 @@ end
 M.make_entry_file = function(opts, x)
   local icon, hl
   local ret = {}
-  local file = x
-  for s in string.gmatch(x, '[^:]+') do
-    file = s
-    break
-  end
-  file = utils.strip_ansi_coloring(file)
+  local file = utils.strip_ansi_coloring(string.match(x, '[^:]*'))
   if opts.cwd_only and path.starts_with_separator(file) then
     local cwd = opts.cwd or vim.loop.cwd()
     if not path.is_relative(file, cwd) then

--- a/lua/fzf-lua/path.lua
+++ b/lua/fzf-lua/path.lua
@@ -10,14 +10,16 @@ M.starts_with_separator = function(path)
   return path:find(M.separator()) == 1
 end
 
-M.tail = (function()
+function M.tail(path)
   local os_sep = M.separator()
   local match_string = '[^' .. os_sep .. ']*$'
 
-  return function(path)
-    return string.match(path, match_string)
-  end
-end)()
+  return string.match(path, match_string)
+end
+
+function M.extension(path)
+  return string.match(path, '[%w_+$]*$')
+end
 
 function M.to_matching_str(path)
   return path:gsub('(%-)', '(%%-)'):gsub('(%.)', '(%%.)'):gsub('(%_)', '(%%_)')
@@ -41,15 +43,6 @@ function M.basename(path)
   local i = path:match("^.*()" .. M.separator())
   if not i then return path end
   return path:sub(i + 1, #path)
-end
-
-function M.extension(path)
-  -- path = M.basename(path)
-  -- return path:match(".+%.(.*)")
-  -- 1. match anything before the first ':'
-  -- 2. greedy match anything after the last dot
-  -- 3. remove coloring escape sequence
-  return utils.strip_ansi_coloring(path:match("[^:]*"):match("[^.]*$"))
 end
 
 ---Get the path to the parent directory of the given path. Returns `nil` if the

--- a/lua/fzf-lua/path.lua
+++ b/lua/fzf-lua/path.lua
@@ -12,13 +12,21 @@ end
 
 function M.tail(path)
   local os_sep = M.separator()
-  local match_string = '[^' .. os_sep .. ']*$'
+  local match_string = '[^' .. os_sep .. ']+'
 
-  return string.match(path, match_string)
+  local tail = path
+  for s in string.gmatch(path, match_string) do
+      tail = s
+  end
+  return tail
 end
 
 function M.extension(path)
-  return string.match(path, '[%w_+$]*$')
+  local ext = path
+  for s in string.gmatch(path, '[^.]+') do
+      ext = s
+  end
+  return ext
 end
 
 function M.to_matching_str(path)

--- a/lua/fzf-lua/providers/buffers.lua
+++ b/lua/fzf-lua/providers/buffers.lua
@@ -116,8 +116,9 @@ M.buffers = function(opts)
           -- get shell-like icon for terminal buffers
           buficon, hl = core.get_devicon(buf.info.name, "sh")
         else
-          local extension = path.extension(buf.info.name)
-          buficon, hl = core.get_devicon(buf.info.name, extension)
+          local filename = path.tail(buf.info.name)
+          local extension = path.extension(filename)
+          buficon, hl = core.get_devicon(filename, extension)
         end
         if opts.color_icons then
           buficon = utils.ansi_codes[hl](buficon)

--- a/lua/fzf-lua/providers/buffers.lua
+++ b/lua/fzf-lua/providers/buffers.lua
@@ -110,16 +110,17 @@ M.buffers = function(opts)
       local bufnrstr = string.format("%s%s%s", leftbr,
         utils.ansi_codes.yellow(string.format(buf.bufnr)), rightbr)
       local buficon = ''
+      local hl = ''
       if opts.file_icons then
-        local extension = path.extension(buf.info.name)
         if utils.is_term_bufname(buf.info.name) then
           -- get shell-like icon for terminal buffers
-          buficon = core.get_devicon(buf.info.name, "sh")
+          buficon, hl = core.get_devicon(buf.info.name, "sh")
         else
-          buficon = core.get_devicon(buf.info.name, extension)
+          local extension = path.extension(buf.info.name)
+          buficon, hl = core.get_devicon(buf.info.name, extension)
         end
         if opts.color_icons then
-          buficon = utils.ansi_codes[config.globals.file_icon_colors[extension] or "dark_grey"](buficon)
+          buficon = utils.ansi_codes[hl](buficon)
         end
       end
       local item_str = string.format("%s%s%s%s%s%s%s",

--- a/lua/fzf-lua/utils.lua
+++ b/lua/fzf-lua/utils.lua
@@ -173,12 +173,17 @@ M.ansi_colors = {
     white       = "[0;98m",
 }
 
-for color, escseq in pairs(M.ansi_colors) do
-    M.ansi_codes[color] = function(string)
-        if string == nil or #string == 0 then return '' end
-        return escseq .. string .. M.ansi_colors.clear
-    end
+M.add_ansi_code = function(name, escseq)
+  M.ansi_codes[name] = function(string)
+    if string == nil or #string == 0 then return '' end
+    return escseq .. string .. M.ansi_colors.clear
+  end
 end
+
+for color, escseq in pairs(M.ansi_colors) do
+  M.add_ansi_code(color, escseq)
+end
+
 
 function M.strip_ansi_coloring(str)
   if not str then return str end


### PR DESCRIPTION
This improves the colors for file icons if nvim-web-devicons is available. If it is, fzf-lua now uses colors defined by the plugin for the file icons.

This should also improve the performance of `make_entry_file()` by simplifying the regex(es) applied to each line from the callback. It avoids pattern matching with the end of string character (`$`) which in my testing is slower than looping through matches with `gmatch`. It also fixes a bug where ansi escape codes could affect cwd/relative path logic.

This is an alternate attempt to fix the same issue as #100 but also improves the colors.