### PR TITLE
More performance improvements 

### DIFF
--- a/lua/fzf-lua/core.lua
+++ b/lua/fzf-lua/core.lua
@@ -41,7 +41,7 @@ end
 M.get_devicon = function(file, ext)
   local icon, hl
   if config._has_devicons and config._devicons then
-    icon, hl  = config._devicons.get_icon(file, ext, {default = true})
+    icon, hl  = config._devicons.get_icon(file, ext:lower(), {default = true})
   else
     icon, hl = '', 'dark_grey'
   end

--- a/lua/fzf-lua/path.lua
+++ b/lua/fzf-lua/path.lua
@@ -1,4 +1,5 @@
 local utils = require "fzf-lua.utils"
+local string_byte = string.byte
 
 local M = {}
 
@@ -11,22 +12,23 @@ M.starts_with_separator = function(path)
 end
 
 function M.tail(path)
-  local os_sep = M.separator()
-  local match_string = '[^' .. os_sep .. ']+'
+  local os_sep = string_byte(M.separator())
 
-  local tail = path
-  for s in string.gmatch(path, match_string) do
-      tail = s
+  for i=#path,1,-1 do
+    if string_byte(path, i) == os_sep then
+      return path:sub(i+1)
+    end
   end
-  return tail
+  return path
 end
 
 function M.extension(path)
-  local ext = path
-  for s in string.gmatch(path, '[^.]+') do
-      ext = s
+  for i=#path,1,-1 do
+    if string_byte(path, i) == 46 then
+      return path:sub(i+1)
+    end
   end
-  return ext
+  return path
 end
 
 function M.to_matching_str(path)

--- a/lua/fzf-lua/providers/git.lua
+++ b/lua/fzf-lua/providers/git.lua
@@ -21,10 +21,11 @@ M.files = function(opts)
   if not opts then return end
   opts.cwd = path.git_root(opts.cwd)
   if not opts.cwd then return end
+  local make_entry_file = core.make_entry_file
   opts.fzf_fn = fzf_helpers.cmd_line_transformer(
     {cmd = opts.cmd, cwd = opts.cwd},
     function(x)
-      return core.make_entry_file(opts, x)
+      return make_entry_file(opts, x)
     end)
   return core.fzf_files(opts)
 end


### PR DESCRIPTION
Couple improvements here:

- `path.tail()` and `path.extension()` can just look backward from the end for the first separator and take a substring. No pattern matching is done and they only have to look at the number of characters that is the size of the result instead of the size of the input sub the size of the result. This is even faster than the current method.
- improve get_devicon() to be case-insensitive