### PR TITLE
Improved the execution speed of external commands.

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,6 +469,9 @@ require'fzf-lua'.setup {
   file_icon_colors = {
     ["lua"]   = "blue",
   },
+  -- If true, use io (lua standard library) for runnig shell command (ex. git)
+  -- If git-based commands are slow, it might improve things.
+  lua_io = false,
 }
 ```
 

--- a/lua/fzf-lua/cmd.lua
+++ b/lua/fzf-lua/cmd.lua
@@ -68,7 +68,7 @@ end
 local function run_command(args)
   local user_opts = args or {}
   if next(user_opts) == nil and not user_opts.cmd then
-    utils.info("[Fzf-lua] missing command args")
+    utils.info("missing command args")
     return
   end
 

--- a/lua/fzf-lua/config.lua
+++ b/lua/fzf-lua/config.lua
@@ -118,6 +118,9 @@ M.globals = {
       _ctor           = previewers.builtin.buffer_or_file,
     },
   },
+  -- Use the standard library io to execute external commands?
+  -- If false, use vim.fn.systemlist()
+  lua_io = false,
 }
 M.globals.files = {
     previewer           = function() return M.globals.default_previewer end,
@@ -435,7 +438,7 @@ if M._has_devicons then
     return r, g, b
   end
 
-  for ext, info in pairs(M._devicons.get_icons()) do
+  for _, info in pairs(M._devicons.get_icons()) do
     local r, g, b = hex(info.color)
     utils.add_ansi_code('DevIcon' .. info.name, string.format('[38;2;%s;%s;%sm', r, g, b))
   end

--- a/lua/fzf-lua/core.lua
+++ b/lua/fzf-lua/core.lua
@@ -158,23 +158,15 @@ end
 local get_diff_files = function(opts)
     local diff_files = {}
 
-    local status = stdio.get_stdout(path.git_cwd(
-      config.globals.files.git_diff_cmd, opts.cwd))
-    for _, v in ipairs(status) do
-      local icon, file = v:match("^([MUDAR])%s+(.*)")
-      if icon and file then
-        diff_files[file] = icon
+    local status, err = stdio.get_stdout(path.git_cwd(config.globals.files.git_diff_cmd, opts.cwd))
+    if not err then
+      for _, v in ipairs(status) do
+        local icon, file = v:match("^([MUDAR])%s+(.*)")
+        if icon and file then
+          diff_files[file] = icon
+        end
       end
     end
-
-    --local status = vim.fn.systemlist(path.git_cwd(
-    --  config.globals.files.git_diff_cmd, opts.cwd))
-    --if not utils.shell_error() then
-    --    for i = 1, #status do
-    --      local icon, file = status[i]:match("^([MUDAR])%s+(.*)")
-    --      if icon and file then diff_files[file] = icon end
-    --    end
-    --end
 
     return diff_files
 end
@@ -182,21 +174,13 @@ end
 local get_untracked_files = function(opts)
     local untracked_files = {}
 
-    local status = stdio.get_stdout(path.git_cwd(
-      config.globals.files.git_untracked_cmd, opts.cwd))
+    local status, err = stdio.get_stdout(path.git_cwd(config.globals.files.git_untracked_cmd, opts.cwd))
 
-    for _, v in ipairs(status) do
-      untracked_files[v] = "?"
+    if not err then
+      for _, v in ipairs(status) do
+        untracked_files[v] = "?"
+      end
     end
-
-    --local status = vim.fn.systemlist(path.git_cwd(
-    --  config.globals.files.git_untracked_cmd, opts.cwd))
-    --if vim.v.shell_error == 0 then
-    --    for i = 1, #status do
-    --        local file = status[i]
-    --        untracked_files[file] = "?"
-    --    end
-    --end
 
     return untracked_files
 end

--- a/lua/fzf-lua/core.lua
+++ b/lua/fzf-lua/core.lua
@@ -4,6 +4,7 @@ local utils = require "fzf-lua.utils"
 local config = require "fzf-lua.config"
 local actions = require "fzf-lua.actions"
 local win = require "fzf-lua.win"
+local stdio = require "fzf-lua.stdio"
 
 local M = {}
 
@@ -156,28 +157,46 @@ end
 
 local get_diff_files = function(opts)
     local diff_files = {}
-    local status = vim.fn.systemlist(path.git_cwd(
+
+    local status = stdio.get_stdout(path.git_cwd(
       config.globals.files.git_diff_cmd, opts.cwd))
-    if not utils.shell_error() then
-        for i = 1, #status do
-          local icon, file = status[i]:match("^([MUDAR])%s+(.*)")
-          if icon and file then diff_files[file] = icon end
-        end
+    for _, v in ipairs(status) do
+      local icon, file = v:match("^([MUDAR])%s+(.*)")
+      if icon and file then
+        diff_files[file] = icon
+      end
     end
+
+    --local status = vim.fn.systemlist(path.git_cwd(
+    --  config.globals.files.git_diff_cmd, opts.cwd))
+    --if not utils.shell_error() then
+    --    for i = 1, #status do
+    --      local icon, file = status[i]:match("^([MUDAR])%s+(.*)")
+    --      if icon and file then diff_files[file] = icon end
+    --    end
+    --end
 
     return diff_files
 end
 
 local get_untracked_files = function(opts)
     local untracked_files = {}
-    local status = vim.fn.systemlist(path.git_cwd(
+
+    local status = stdio.get_stdout(path.git_cwd(
       config.globals.files.git_untracked_cmd, opts.cwd))
-    if vim.v.shell_error == 0 then
-        for i = 1, #status do
-            local file = status[i]
-            untracked_files[file] = "?"
-        end
+
+    for _, v in ipairs(status) do
+      untracked_files[v] = "?"
     end
+
+    --local status = vim.fn.systemlist(path.git_cwd(
+    --  config.globals.files.git_untracked_cmd, opts.cwd))
+    --if vim.v.shell_error == 0 then
+    --    for i = 1, #status do
+    --        local file = status[i]
+    --        untracked_files[file] = "?"
+    --    end
+    --end
 
     return untracked_files
 end

--- a/lua/fzf-lua/init.lua
+++ b/lua/fzf-lua/init.lua
@@ -2,9 +2,9 @@ if not pcall(require, "fzf") then
   return
 end
 
-local fzf = require "fzf"
 local utils = require "fzf-lua.utils"
 local config = require "fzf-lua.config"
+local stdio = require "fzf-lua.stdio"
 
 
 local M = {}
@@ -35,6 +35,7 @@ function M.setup(opts)
   -- reset our globals based on user opts
   -- this doesn't happen automatically
   config.globals = globals
+  stdio.set_flag(globals.lua_io)
   globals = nil
 end
 

--- a/lua/fzf-lua/path.lua
+++ b/lua/fzf-lua/path.lua
@@ -1,4 +1,5 @@
 local utils = require "fzf-lua.utils"
+local stdio = require "fzf-lua.stdio"
 local string_byte = string.byte
 
 local M = {}
@@ -172,10 +173,10 @@ end
 
 function M.git_root(cwd, noerr)
     local cmd = M.git_cwd("git rev-parse --show-toplevel", cwd)
-    local output = vim.fn.systemlist(cmd)
-    if utils.shell_error() then
-        if not noerr then utils.info(unpack(output)) end
-        return nil
+    local output, err = stdio.get_stdout(cmd)
+    if err then
+      if not noerr then utils.info(cmd) end
+      return nil
     end
     return output[1]
 end

--- a/lua/fzf-lua/stdio.lua
+++ b/lua/fzf-lua/stdio.lua
@@ -1,0 +1,11 @@
+local M = {}
+
+M.get_stdout = function(cmd)
+  local stdout = {}
+  for h in io.popen(cmd, "r"):lines() do
+    stdout[#stdout + 1] = h
+  end
+  return stdout
+end
+
+return M

--- a/lua/fzf-lua/stdio.lua
+++ b/lua/fzf-lua/stdio.lua
@@ -1,11 +1,38 @@
 local M = {}
 
+local lua_io
+
+---Set whether to use io or not
+---@param bool boolean
+M.set_flag = function(bool)
+  lua_io = bool
+end
+
+---Run the shell command and get the standard output.
+---If failure, it returns an empty string and true.
+---@param cmd string
+---@return string|table
+---@return boolean
 M.get_stdout = function(cmd)
   local stdout = {}
-  for h in io.popen(cmd, "r"):lines() do
-    stdout[#stdout + 1] = h
+
+  if lua_io then
+    local handle = io.popen(cmd, "r")
+    if handle == nil then
+      return "", true
+    end
+    for h in handle:lines() do
+      stdout[#stdout + 1] = h
+    end
+  else
+    stdout = vim.fn.systemlist(cmd)
+    -- vim.fn.systemlist returns an empty string on error.
+    if vim.v.shell_error ~= 0 then
+      return "", true
+    end
   end
-  return stdout
+
+  return stdout, false
 end
 
 return M


### PR DESCRIPTION
#126
I also fixed some problems that I noticed. For example, `vim.fn.systemlist()` returns an empty string when it fails, so there is no point in displaying it as an error message. So, I made it so that it displays the command that was executed.