### PR TITLE
Remove early return that blocks setting cwd

### DIFF
--- a/lua/fzf-lua/providers/files.lua
+++ b/lua/fzf-lua/providers/files.lua
@@ -13,9 +13,6 @@ local get_files_cmd = function(opts)
   if opts.raw_cmd and #opts.raw_cmd>0 then
     return opts.raw_cmd
   end
-  if opts.cmd and #opts.cmd>0 then
-    return opts.cmd
-  end
   local command = nil
   if vim.fn.executable("fd") == 1 then
     if not opts.cwd or #opts.cwd == 0 then


### PR DESCRIPTION
The early return is blocking the setting of `cwd`.

I guess you are trying not modify the command, if the user provide a customized one? I think this might break other behaviors.