### PR TITLE
fix: no need to exit visual mode

### DIFF
--- a/lua/fzf-lua/utils.lua
+++ b/lua/fzf-lua/utils.lua
@@ -213,10 +213,6 @@ function M.get_visual_selection()
         -- visual line doesn't provide columns
         cscol, cecol = 0, 999
       end
-      -- exit visual mode
-      vim.api.nvim_feedkeys(
-        vim.api.nvim_replace_termcodes("<Esc>",
-          true, false, true), 'n', true)
     else
       -- otherwise, use the last known visual position
       _, csrow, cscol, _ = unpack(vim.fn.getpos("'<"))


### PR DESCRIPTION
no need to exit visual mode for `grep_visual`.
I normally use `grep` like this:

```vim
xnoremap <silent><expr> <leader>d ":\<C-U>lua require('fzf-lua').live_grep({ continue_last_search = false })\<cr>" . luaeval('require("fzf-lua.utils").get_visual_selection()')
```
so I can continue editing the grep words, no need to set to fixed value for search.

but the line for exiting visual mode will make the float window disappear. This PR will fix that 
