### PR TITLE
fix(): update default preview config to `'border'` from `'float'`.

### DIFF
--- a/lua/fzf-lua/config.lua
+++ b/lua/fzf-lua/config.lua
@@ -43,7 +43,7 @@ M.globals = {
     },
     preview = {
       default             = "builtin",
-      border              = 'float',
+      border              = 'border',
       wrap                = 'nowrap',
       hidden              = 'nohidden',
       vertical            = 'down:45%',


### PR DESCRIPTION
Was throwing the following:
`[Fzf-lua] fzf error 2: invalid preview window option: float`

Now matches the docs.