### PR TITLE
fix: too broad uri regex match - restrict to jdt / file

### DIFF
--- a/lua/fzf-lua/path.lua
+++ b/lua/fzf-lua/path.lua
@@ -146,7 +146,7 @@ function M.entry_to_file(entry, cwd)
   -- entries from 'buffers' contain '[<bufnr>]'
   -- buffer placeholder always comes before the nbsp
   local bufnr = idx>1 and entry:sub(1, idx):match("%[(%d+)") or nil
-  if not bufnr and stripped:match("^[^ ]+://") then
+  if not bufnr and stripped:match("^%a+://") then
     -- Issue #195, when using nvim-jdtls
     -- https://github.com/mfussenegger/nvim-jdtls
     -- LSP entries inside .jar files appear as URIs


### PR DESCRIPTION
found this bug independently of #204 / https://github.com/ibhagwan/fzf-lua/commit/454b0ba48c89f05ca16023cb34b1ae21c30ff8af and wrote this fix.

unfortunately it still occured with https://github.com/ibhagwan/fzf-lua/commit/454b0ba48c89f05ca16023cb34b1ae21c30ff8af  (like grepping and finding a result `[src](https://domain.tld)`).

although it may not be as elegant i figured i'd create a pr with my initial fix.

thanks for the well documented code btw :)