### PR TITLE
Do not remap when calling feedkeys (closes #258)

### DIFF
--- a/lua/fzf-lua/actions.lua
+++ b/lua/fzf-lua/actions.lua
@@ -246,7 +246,7 @@ end
 M.ex_run = function(selected)
   local cmd = selected[1]
   vim.cmd("stopinsert")
-  vim.fn.feedkeys(string.format(":%s", cmd))
+  vim.fn.feedkeys(string.format(":%s", cmd), "n")
   return cmd
 end
 
@@ -259,7 +259,7 @@ end
 M.search = function(selected)
   local query = selected[1]
   vim.cmd("stopinsert")
-  vim.fn.feedkeys(string.format("/%s", query))
+  vim.fn.feedkeys(string.format("/%s", query), "n")
   return query
 end
 


### PR DESCRIPTION
When calling vim.fn.feedkeys for commands or searches ,which means it is prefixed by ":" or "/", one of those keys could be remapped to something else. Calling feedkeys with "n" means this mapping would be ignored.