### PR TITLE
tags: only match against tag name per default

### DIFF
--- a/lua/fzf-lua/config.lua
+++ b/lua/fzf-lua/config.lua
@@ -375,6 +375,9 @@ M.globals.tags = {
     git_icons             = true,
     color_icons           = true,
     actions               = M.globals.files.actions,
+    fzf_opts = {
+      ['--nth'] = '2',
+    },
   }
 M.globals.btags = {
     previewer             = { _ctor = previewers.builtin.tags },

--- a/lua/fzf-lua/providers/tags.lua
+++ b/lua/fzf-lua/providers/tags.lua
@@ -153,7 +153,7 @@ M.btags = function(opts)
   opts = config.normalize_opts(opts, config.globals.btags)
   if not opts then return end
   opts.fzf_opts = vim.tbl_extend("keep",
-    opts.fzf_opts or {}, config.globals.blines.fzf_opts)
+    opts.fzf_opts or {}, config.globals.tags.fzf_opts)
   opts.current_buffer_only = true
   return fzf_tags(opts)
 end


### PR DESCRIPTION
ctags have a file, a name and a context (the line of the file where the tag appears). This is useful information, however when fuzzy finding only the name of the tag is relevant. Matching against the file or the context pollutes the results.

This PR changes the default behavior of the tags and btags providers to only match against the tag's name.