### PR TITLE
fix devicon size in kitty using file_icon_padding

### DIFF
--- a/lua/fzf-lua/make_entry.lua
+++ b/lua/fzf-lua/make_entry.lua
@@ -147,7 +147,7 @@ M.get_devicon = function(file, ext)
 
   if config.globals.file_icon_padding and
     #config.globals.file_icon_padding>0 then
-    icon = icon .. config.globals.file_icon_padding:gsub(" ", utils.nbsp)
+    icon = icon .. config.globals.file_icon_padding
   end
 
   return icon, hl


### PR DESCRIPTION
This fix removes the nbsp. Kitty needs a normal space to extend the icon size.