### PR TITLE
Correct vim-plug install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ at it. That, **and colorful file icons and git indicators!**.
 Using [vim-plug](https://github.com/junegunn/vim-plug)
 
 ```vim
-Plug 'ibhagwan/fzf-lua'
+Plug 'ibhagwan/fzf-lua', {'branch': 'main'}
 " optional for icon support
 Plug 'kyazdani42/nvim-web-devicons'
 ```


### PR DESCRIPTION
Previously defaulted to master branch, this tells it to use main instead