### PR TITLE
Erroneous `return`

### DIFF
--- a/lua/fzf-lua/win.lua
+++ b/lua/fzf-lua/win.lua
@@ -712,7 +712,6 @@ function FzfWin:create()
     -- fzf will not use all the avialable width until 'redraw' is
     -- called resulting in misaligned native and builtin previews
     vim.cmd("redraw")
-    return
   end
 
   if not self.winopts.split and self.previewer_is_builtin then


### PR DESCRIPTION
I think this method should not return here? my `on_create` function doesn't run after switch from grep to live_grep via action if it does.