### PR TITLE
Disable Fzf's native border

### DIFF
--- a/lua/fzf-lua/config.lua
+++ b/lua/fzf-lua/config.lua
@@ -135,6 +135,7 @@ M.globals = {
     ['--info']        = 'inline',
     ['--height']      = '100%',
     ['--layout']      = 'reverse',
+    ['--border']      = 'none',
   },
   previewers = {
     cat = {


### PR DESCRIPTION
Fzf may be configured via `$FZF_DEFAULT_OPTS` to show a border, which
takes up unnecessary space in `fzf-lua`.

Setting `config.globals.fzf_opts['--border'] = 'none'` disables Fzf's
border.
