### PR TITLE
fix(buf_switch): winid_from_tab_buf expects number

### DIFF
--- a/lua/fzf-lua/actions.lua
+++ b/lua/fzf-lua/actions.lua
@@ -277,7 +277,7 @@ M.buf_del = function(selected, opts)
 end
 
 M.buf_switch = function(selected, _)
-  local tabnr = selected[1]:match("(%d+)%)")
+  local tabnr = tonumber(selected[1]:match("(%d+)%)"))
   if tabnr then
     vim.cmd("tabn " .. tabnr)
   else


### PR DESCRIPTION
**Expected behavior**: `action.buf_switch` in combination with `fzf_lua.tabs()` switches to the selected buffer in the selected tab.
**Actual behavior** in `main`: The action switches to the selected tab but the code crashes before selecting the buffer.


Here's the problem:

With `fzf_lua.tabs()`, `tabnr` is a string:
https://github.com/ibhagwan/fzf-lua/blob/786d06bc51de2dba9ccf5b80571ad03c65080f80/lua/fzf-lua/actions.lua#L280

but `tabnr` gets passed to `vim.api.nvim_tabpage_list_wins`, which expects a number:
https://github.com/ibhagwan/fzf-lua/blob/786d06bc51de2dba9ccf5b80571ad03c65080f80/lua/fzf-lua/actions.lua#L288
https://github.com/ibhagwan/fzf-lua/blob/817df87a8ebd2137aa42c2fa370e33b980e313dc/lua/fzf-lua/utils.lua#L469-L470

**Fix**: Convert `tabnr` to a number.