### PR TITLE
put diagnostic.data on get_line_diagnostics

### DIFF
--- a/lua/fzf-lua/providers/lsp.lua
+++ b/lua/fzf-lua/providers/lsp.lua
@@ -590,7 +590,9 @@ local function get_line_diagnostics(_)
         line = diag[1].end_lnum,
         character = diag[1].end_col,
       }
-    }
+    },
+    data = diag[1].user_data and diag[1].user_data.lsp and
+      diag[1].user_data.lsp.data
   }} or nil
 end
 


### PR DESCRIPTION
Hi. I found code_actions of elm-language-server doesn't work with `:FzfLua lsp_code_actions`, while `:lua vim.lsp.buf.code_action()` works.

I investigated the code to find `data` argument was not passed on `get_line_diagnostics` function, and the problem goes away by passing it.

According to [lsp specification about Diagnostic](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#diagnostic), seems like it should be passed.

Thanks.
