### PR TITLE
fix: lazy loading of fzf_wrap

### DIFF
--- a/lua/fzf-lua/init.lua
+++ b/lua/fzf-lua/init.lua
@@ -217,7 +217,7 @@ do
     M[k] = function(...)
       -- override self so this function is only called once
       M[k] = require(v[1])[v[2]]
-      M[k](...)
+      return M[k](...)
     end
   end
 end


### PR DESCRIPTION
Got a report here about fzf-lua: https://github.com/stevearc/dressing.nvim/issues/64

The lazy loading was forwarding the function arguments, but not the return value. For `find_files` this is fine, but for `fzf_wrap` we expect it to return a function.