### PR TITLE
add default action to paste register

### DIFF
--- a/lua/fzf-lua/actions.lua
+++ b/lua/fzf-lua/actions.lua
@@ -692,5 +692,11 @@ M.tmux_buf_set_reg = function(selected, opts)
     end
 end
 
+M.paste_register = function(selected)
+	local lines = vim.split(selected[1], "^%[.] ", false)
+	local text = table.remove(lines)
+	vim.api.nvim_put({text}, "c", true, true)
+end
+
 return M
 

--- a/lua/fzf-lua/actions.lua
+++ b/lua/fzf-lua/actions.lua
@@ -693,10 +693,12 @@ M.tmux_buf_set_reg = function(selected, opts)
 end
 
 M.paste_register = function(selected)
-	local lines = vim.split(selected[1], "^%[.] ", false)
-	local text = table.remove(lines)
-	vim.api.nvim_put({text}, "c", true, true)
+	local reg = selected[1]:match("%[(.-)%]")
+	if reg == '"' then
+		vim.cmd.normal("p")
+	else
+		vim.cmd.normal('"' .. reg .. "p")
+	end
 end
 
 return M
-

--- a/lua/fzf-lua/providers/tmux.lua
+++ b/lua/fzf-lua/providers/tmux.lua
@@ -11,7 +11,7 @@ M.buffers = function(opts)
   if not opts then return end
 
   opts.fn_transform = function(x)
-    local buf, data = x:match('^(.-):.-: "(.-)"')
+    local buf, data = x:match('^(.-):%s+%d+%s+bytes: "(.*)"$')
     return string.format("[%s] %s", utils.ansi_codes.yellow(buf), data)
   end
 


### PR DESCRIPTION
I would like to propose an action for the `register` provider: namely insert selected text at cursor position. Not sure if in scope, but I have had it in my config for a while and I thought it may make a nice default addition: browsing registers means the user more likely than not intends to paste some content.


https://user-images.githubusercontent.com/15387611/195696850-854eda14-06bf-458b-afe5-cce26b9e3e0e.mov

In the demo you can see that it works also for long text containing spaces and tabs, pasting as intended. ~I have not figured out yet how to make new line characters `\n` paste as such, I suspect it is because you parse the registers content literally as `\n` string (thus vim thinks this is just a character rather than a line break)?~

EDIT: I amended and simplified the logic by just fetching the register number and invoking the paste command in normal mode: it works under all circumstances now.

In my configuration I have it bound as
```
...
registers = {
  actions = {
    ["default"] = actions.paste_register,
  },
}
```
I haven't found the place in the code to actually bind it to defaults - if you consider it valid you could make the change.