### PR TITLE
fix(fn_selected): pass down opts to fn_selected in fzf_wrap

### DIFF
--- a/lua/fzf-lua/core.lua
+++ b/lua/fzf-lua/core.lua
@@ -101,7 +101,7 @@ M.fzf_wrap = function(opts, contents, fn_selected)
     opts.fn_selected = opts.fn_selected or fn_selected
     local selected = M.fzf(contents, opts)
     if opts.fn_selected then
-      opts.fn_selected(selected)
+      opts.fn_selected(selected, opts)
     end
   end)
 end


### PR DESCRIPTION
Hey there, love your lua glue to fzf !

Would it be possible to pass down the `opts` to `fn_selected` in fzf_wrap so we can better customize it ?

My use case is to operate multi select on rg grep sending it to the quickfix list like so:

```lua
local function grep_sel_to_qf(selected, opts)
  local qf_list = {}
  for i = 1, #selected do
    local file = fzf_lua.path.entry_to_file(selected[i], opts)
    local text = selected[i]:match(":%d+:%d?%d?%d?%d?:?(.*)$")
    table.insert(qf_list, {
      filename = file.bufname or file.path,
      lnum = file.line,
      col = file.col,
      text = text,
    })
  end
  vim.fn.setqflist(qf_list, "r")
end

local function fn_selected_multi(selected, opts)
  if not selected then
    return
  end
  -- first element of "selected" is the keybind pressed
  if #selected <= 2 then
    fzf_lua.actions.act(opts.actions, selected, opts)
  else -- here we multi-selected
    local _, entries = fzf_lua.actions.normalize_selected(opts.actions, selected)
    grep_sel_to_qf(entries, opts)
    vim.cmd("cfirst")
  end
end

-- using the following fzf keymap:
--      ["ctrl-r"] = "select-all+accept", -- https://github.com/ibhagwan/fzf-lua/issues/324
```