### PR TITLE
fix(run_command): wrong logical condition

### DIFF
--- a/lua/fzf-lua/cmd.lua
+++ b/lua/fzf-lua/cmd.lua
@@ -63,7 +63,7 @@ end
 -- }
 local function run_command(args)
   local user_opts = args or {}
-  if next(user_opts) == nil and not user_opts.cmd then
+  if next(user_opts) == nil or not user_opts.cmd then
     utils.info("missing command args")
     return
   end


### PR DESCRIPTION
Although not directly exposed, the logical condition in run_command is wrong and makes the second part of the `and` pointless. Instead `or` would do the correct evaluation.