### PR TITLE
feat(run_command): provide user feedback in case of wrong command

### DIFF
--- a/lua/fzf-lua/cmd.lua
+++ b/lua/fzf-lua/cmd.lua
@@ -77,7 +77,8 @@ local function run_command(args)
 
   if builtin[cmd] then
     builtin[cmd](opts)
-    return
+	else
+    utils.info(string.format("invalid command '%s'", cmd))
   end
 end
 


### PR DESCRIPTION
Won't happen often, but if a user mistypes a command they will be presented with some feedback like `[Fzf-lua] invalid command 'wrong_cmd_test'`