### PR TITLE
added option to provide marks to builtin marks-provider

### DIFF
--- a/lua/fzf-lua/providers/nvim.lua
+++ b/lua/fzf-lua/providers/nvim.lua
@@ -62,7 +62,7 @@ local arg_header = function(sel_key, edit_key, text)
   sel_key = utils.ansi_codes.yellow(sel_key)
   edit_key = utils.ansi_codes.yellow(edit_key)
   return vim.fn.shellescape((":: %s to %s, %s to edit")
-    :format(sel_key, text, edit_key))
+  :format(sel_key, text, edit_key))
 end
 
 M.command_history = function(opts)
@@ -171,7 +171,14 @@ M.marks = function(opts)
   opts = config.normalize_opts(opts, config.globals.marks)
   if not opts then return end
 
-  local marks = vim.fn.execute("marks")
+  local marks;
+
+  if opts.marks ~= nil then
+    marks = vim.fn.execute("marks " .. opts.marks)
+  else
+    marks = vim.fn.execute("marks")
+  end
+
   marks = vim.split(marks, "\n")
 
   --[[ local prev_act = shell.action(function (args, fzf_lines, _)
@@ -187,7 +194,6 @@ M.marks = function(opts)
       return "UNLOADED: " .. name
     end
   end) ]]
-
   local entries = {}
   for i = #marks, 3, -1 do
     local mark, line, col, text = marks[i]:match("(.)%s+(%d+)%s+(%d+)%s+(.*)")


### PR DESCRIPTION
I've added logic in order to be able to provide marks to the builtin marks-provider. This way you can filter the marks to what you need.

```
marks = {
    marks = "abcdef"
}
```