### PR TITLE
fix(colorschemes): not load colorschemes if passed in.

### DIFF
--- a/lua/fzf-lua/providers/colorschemes.lua
+++ b/lua/fzf-lua/providers/colorschemes.lua
@@ -21,7 +21,7 @@ M.colorschemes = function(opts)
 
   local current_colorscheme = get_current_colorscheme()
   local current_background = vim.o.background
-  local colors = vim.list_extend(opts.colors or {}, vim.fn.getcompletion("", "color"))
+  local colors = opts.colors or vim.fn.getcompletion("", "color")
 
   opts.fzf_opts["--no-multi"] = ""
 


### PR DESCRIPTION
Well, this is a breaking change and I'm not sure if you will like it or not.

What I want to do is to create a custom command to show a subset of colorschemes. It is impossible to do without introducing this breaking change or adding a new parameter.

I think the new behavior is easier to use. If people want to extend the list, they can always use `vim.fn.getcompletion` themselves.