### PR TITLE
cd: bump luarocks-tag-release to v3

### DIFF
--- a/.github/workflows/luarocks-release.yaml
+++ b/.github/workflows/luarocks-release.yaml
@@ -16,13 +16,10 @@ jobs:
       - name: Get new commit count
         run: echo "NEW_COMMIT_COUNT=$(git log --oneline --since '24 hours ago' | wc -l)" >> $GITHUB_ENV
       - name: LuaRocks Upload
-        uses: nvim-neorocks/luarocks-tag-release@v2.1.0
+        uses: nvim-neorocks/luarocks-tag-release@v3
         if: ${{ env.NEW_COMMIT_COUNT > 0 }}
         env:
           LUAROCKS_API_KEY: ${{ secrets.LUAROCKS_API_KEY }}
         with:
           version: ${{ env.LUAROCKS_VERSION }} 
           license: "AGPL-3.0"
-          copy_directories: |
-            doc
-            plugin


### PR DESCRIPTION
We have released a new version of luarocks-tag-release that automatically detects neovim plugin directories
(based on `:help runtimepath`) and adds them to the rockspec if found.

The `v3` tag is a mutable tag that lets you benefit from improvements and new features without breaking changes.