### PR TITLE
Escaping HOME folder pattern

### DIFF
--- a/lua/fzf-lua/path.lua
+++ b/lua/fzf-lua/path.lua
@@ -148,7 +148,7 @@ function M.tilde_to_HOME(path)
 end
 
 function M.HOME_to_tilde(path)
-  return path and path:gsub("^" .. M.HOME(), "~") or nil
+  return path and path:gsub("^" .. utils.lua_regex_escape(M.HOME()), "~") or nil
 end
 
 function M.shorten(path, max_len)


### PR DESCRIPTION
After I got a new laptop from my company I noticed that the HOME folder in `tab_cwd` was not shortened to a tilde. What changed? After digging a little a realized that my Unix username changed from a purely alphanumeric one to `name-family_name` with a dash ('-'), and that is a magic character in lua patterns.

Using the solution from https://stackoverflow.com/a/34953646, every non-alphanumeric character is escaped before composing the HOME folder pattern.