### PR TITLE
feat(git_status) add git_reset action

### DIFF
--- a/lua/fzf-lua/actions.lua
+++ b/lua/fzf-lua/actions.lua
@@ -592,6 +592,7 @@ end
 M.git_reset = function(selected, opts)
   local cmd = path.git_cwd({ "git", "checkout", "HEAD", "--" }, opts)
   git_exec(selected, opts, cmd)
+  vim.cmd("e!")
 end
 
 M.git_stash_drop = function(selected, opts)

--- a/lua/fzf-lua/defaults.lua
+++ b/lua/fzf-lua/defaults.lua
@@ -241,6 +241,7 @@ M.defaults.git = {
     actions     = {
       ["right"] = { actions.git_unstage, actions.resume },
       ["left"]  = { actions.git_stage, actions.resume },
+      ["ctrl-x"] =  actions.git_reset,
     },
   },
   commits = {


### PR DESCRIPTION
I guess it was designed for git_status? Not using `action.resume` to be safe.