### PR TITLE
fix: check if version is HEAD

### DIFF
--- a/lua/fzf-lua/utils.lua
+++ b/lua/fzf-lua/utils.lua
@@ -808,6 +808,7 @@ end
 
 function M.fzf_version(opts)
   local out = M.io_system({ opts.fzf_bin or "fzf", "--version" })
+  if out:match("HEAD") then return 4 end
   return tonumber(out:match("(%d+.%d+)."))
 end
 


### PR DESCRIPTION
If using the `HEAD` version of fzf, this error is thrown when trying to use the `buffers` function

```
E5108: Error executing lua: ...ng/.local/share/neovim/lazy/fzf-lua/lua/fzf-lua/core.lua:755: attempt to compare nil with number
stack traceback:
	...ng/.local/share/neovim/lazy/fzf-lua/lua/fzf-lua/core.lua:755: in function 'convert_reload_actions'
	...re/neovim/lazy/fzf-lua/lua/fzf-lua/providers/buffers.lua:234: in function 'buffers'

```

```sh
$ fzf --version
HEAD-e619b7c (brew)
```

```
NVIM v0.10.0-dev-1617+g143a17833-Homebrew
Build type: Release
LuaJIT 2.1.0-beta3

```
