### PR TITLE
fix(commands): `ex_run_cr` without showing putting the command into Vim cmdline, should close #747

### DIFF
--- a/lua/fzf-lua/actions.lua
+++ b/lua/fzf-lua/actions.lua
@@ -403,8 +403,8 @@ M.ex_run = function(selected)
 end
 
 M.ex_run_cr = function(selected)
-  local cmd = M.ex_run(selected)
-  utils.feed_keys_termcodes("<CR>")
+  local cmd = selected[1]
+  vim.cmd(cmd)
   vim.fn.histadd("cmd", cmd)
 end
 


### PR DESCRIPTION
I also tested that `stopinsert` is not needed by removing it and tried `:Inspect`. It didn't go into insert mode without it.

Preview: (no cmdline in after the selection comparing to the original one.)

https://user-images.githubusercontent.com/24765272/236675075-942e297a-c03d-485a-b0df-9cc1ab2a0692.mov