### PR TITLE
Fix "-.*" and "--.*" queries for st and mt versions of live_grep

### DIFF
--- a/lua/fzf-lua/make_entry.lua
+++ b/lua/fzf-lua/make_entry.lua
@@ -287,7 +287,7 @@ M.preprocess = function(opts)
       search_query = search_query:gsub("%%", "%%%%")
       -- reset argvz so it doesn't get replaced again below
       opts.cmd = opts.cmd:gsub(argvz,
-        glob_args .. vim.fn.shellescape(search_query))
+        glob_args .. "-e " .. vim.fn.shellescape(search_query))
     end
   end
 
@@ -297,7 +297,7 @@ M.preprocess = function(opts)
     opts.cmd = opts.cmd:gsub("{argv.*}",
       function(x)
         local idx = x:match("{argv(.*)}")
-        return vim.fn.shellescape(argv(idx))
+        return "-e " .. vim.fn.shellescape(argv(idx))
       end)
   end
 

--- a/lua/fzf-lua/providers/grep.lua
+++ b/lua/fzf-lua/providers/grep.lua
@@ -100,7 +100,13 @@ local get_grep_cmd = function(opts, search_query, no_esc)
   end
 
   -- construct the final command
-  command = ("%s %s %s"):format(command, search_query, search_path)
+  -- "-e" flag will be added during make_entry.preprocess
+  -- for multiprocess case
+  if opts.multiprocess then
+    command = ("%s %s %s"):format(command, search_query, search_path)
+  else
+    command = ("%s -e %s %s"):format(command, search_query, search_path)
+  end
 
   -- piped command filter, used for filtering ctags
   if opts.filter and #opts.filter > 0 then
@@ -299,7 +305,7 @@ M.live_grep_mt = function(opts)
     -- NOTE: since we cannot guarantee the positional index
     -- of arguments (#291), we use the last argument instead
     command = command:gsub(core.fzf_query_placeholder, "{argvz}")
-        .. " " .. core.fzf_query_placeholder
+        .. " -- " .. core.fzf_query_placeholder
   end
 
   -- signal 'fzf_exec' to set 'change:reload' parameters


### PR DESCRIPTION
Hi!

Thank you for this awesome plugin!
I've read some of the past issues and I can't help but note your thoroughness and kindness with which you maintain this repository!

I stumbled upon a bug with `live_grep` command. It doesn't work for queries like `-info`, `--help` and other things that can be interpreted as command line option.

I saw that you use `utils.rg_escape()` to avoid these issues but unfortunately it doesn't work when user (like me) adds `--fixed-strings` options for `rg` and wants to find only exact matches.

I've fixed it using `rg's` `-e` flag for both single-thread and multi-thread cases of `live_grep`.

It still doesn't work for `grep` command, because I couldn't fix it without changing code too much.

Is there any reason you chose to use `utils.rg_escape()` instead of `-e` flag?