### PR TITLE
feat(hl): Add new FzfLuaPreviewBorder highlight

### DIFF
--- a/README.md
+++ b/README.md
@@ -1144,6 +1144,7 @@ FzfLua conviniently creates the below highlights:
   FzfLuaScrollFloatFull   = { 'winopts.hl.scrollfloat_f', "PmenuThumb" },
   FzfLuaHelpNormal = { 'winopts.hl.help_normal', "FzfLuaNormal" },
   FzfLuaHelpBorder = { 'winopts.hl.help_border', "FzfLuaBorder" },
+  FzfLuaPreviewBorder     = { "winopts.hl.preview_border", "Normal" },
 ```
 
 

--- a/lua/fzf-lua/init.lua
+++ b/lua/fzf-lua/init.lua
@@ -46,6 +46,7 @@ function M.setup_highlights()
     FzfLuaScrollFloatFull   = { "winopts.hl.scrollfloat_f", "PmenuThumb" },
     FzfLuaHelpNormal        = { "winopts.hl.help_normal", "FzfLuaNormal" },
     FzfLuaHelpBorder        = { "winopts.hl.help_border", "FzfLuaBorder" },
+    FzfLuaPreviewBorder     = { "winopts.hl.preview_border", "FzfLuaBorder" },
   }
   for hl_name, v in pairs(highlights) do
     -- define a new linked highlight and then override the

--- a/lua/fzf-lua/win.lua
+++ b/lua/fzf-lua/win.lua
@@ -283,7 +283,7 @@ function FzfWin:reset_win_highlights(win, is_border)
   if is_border then
     -- our border is manually drawn so we need
     -- to replace Normal with the border color
-    hl = ("Normal:%s"):format(self.winopts.__hl.border)
+    hl = ("Normal:%s"):format(self.winopts.__hl.preview_border)
   end
   vim.api.nvim_win_set_option(win, "winhighlight", hl)
 end
@@ -851,7 +851,7 @@ function FzfWin:close(fzf_bufnr)
   -- When a window is reused, (e.g. open any fzf-lua interface, press <C-\-n> and run
   -- ":FzfLua") `FzfWin:set_tmp_buffer()` will call `nvim_buf_delete` on the original
   -- fzf terminal buffer which will terminate the fzf process and trigger the call to
-  -- `fzf_win:close()` within `core.fzf()`. We need to avoid the close in this case. 
+  -- `fzf_win:close()` within `core.fzf()`. We need to avoid the close in this case.
   if fzf_bufnr and fzf_bufnr ~= self.fzf_bufnr then
     return
   end


### PR DESCRIPTION
I'd like to add an additional highlight group `FzfLuaPreviewBorder`. I have different background colors for the fzf window and preview window. This allows me to customize the border on each differently to match the corresponding background color.

Without the highlight group:
![fzf-lua-without-hl](https://github.com/ibhagwan/fzf-lua/assets/10135646/9b78d72e-6052-49f1-b0cb-08e347db63bb)

With the highlight group:
![fzf-lua-with-hl](https://github.com/ibhagwan/fzf-lua/assets/10135646/9c69dd23-afb3-4f21-86ac-e47f89dea9af)

Please let me know what you think.