### PR TITLE
feat(lsp): add optional filter function

### DIFF
--- a/lua/fzf-lua/providers/lsp.lua
+++ b/lua/fzf-lua/providers/lsp.lua
@@ -105,6 +105,9 @@ local function location_handler(opts, cb, _, result, ctx, _)
     jump_to_location(opts, result[1], encoding)
   end
   local items = vim.lsp.util.locations_to_items(result, encoding)
+  if opts.filter and type(opts.filter) == "function" then
+    items = opts.filter(items)
+  end
   for _, entry in ipairs(items) do
     if not opts.current_buffer_only or __CTX.bufname == entry.filename then
       entry = make_entry.lcol(entry, opts)


### PR DESCRIPTION
This PR provides a optional filter to give user the ability to filter the results of the LSP calls before viewing.

This is helpful in situations the user doesn't want to list some references. Here is an example usage in Go to filter out all the items in mock files:

```lua
local check = "_mock.go"
local filter = function(items)
  local ret = {}
  for _, item in ipairs(items) do
    if item.filename:sub(-#check) ~= check then
      table.insert(ret, item)
    end
    return ret
  end
end
require("fzf-lua").lsp_implementations({
  jump_to_single_result = true,
  filter = filter,
})
```