### PR TITLE
fix(win): extraneous preview window title highlights

### DIFF
--- a/lua/fzf-lua/win.lua
+++ b/lua/fzf-lua/win.lua
@@ -917,19 +917,17 @@ function FzfWin.win_leave()
   _self:close()
 end
 
-function FzfWin:clear_border_highlights()
-  if self.border_winid and vim.api.nvim_win_is_valid(self.border_winid) then
-    vim.fn.clearmatches(self.border_winid)
-  end
-end
-
 function FzfWin:set_title_hl()
-  if self.winopts.__hl.title and self._title_len and self._title_len > 0 then
-    pcall(vim.api.nvim_win_call, self.border_winid, function()
-      fn.matchaddpos(self.winopts.__hl.title, { { 1, self._title_position, self._title_len + 1 } },
-        11)
-    end)
-  end
+  pcall(vim.api.nvim_win_call, self.border_winid, function()
+    -- Clear all highlights before adding new ones.
+    fn.clearmatches()
+    -- Add the title highlight, if needed.
+    if self.winopts.__hl.title and self._title_len and self._title_len > 0 then
+      fn.matchaddpos(self.winopts.__hl.title, {
+        { 1, self._title_position, self._title_len + 1 }
+      }, 11)
+    end
+  end)
 end
 
 function FzfWin:update_scrollbar_border(o)
@@ -1077,7 +1075,6 @@ function FzfWin:update_scrollbar()
   o.bar_offset = math.min(height - o.bar_height, math.floor(height * topline / o.line_count))
 
   -- reset highlights before we move the scrollbar
-  self:clear_border_highlights()
   self:set_title_hl()
 
   if self.winopts.preview.scrollbar == "float" then


### PR DESCRIPTION
When `winopts.preview.scrollbar` is `false`, the highlights of the preview window's title are not cleared, therefore overlapping with each other when navigating up and down the list of results.

This commit moves the code responsible for clearing the highlights into `FzfWin:set_title_hl()` to avoid leftover highlight artifacts.

Fixes https://github.com/ibhagwan/fzf-lua/issues/796.

| Before | <img width="2179" alt="Screenshot 2023-06-25 at 12 32 34 PM" src="https://github.com/ibhagwan/fzf-lua/assets/5804569/59e8c83b-a170-4fde-873e-5ae20b0125aa"> |
| --- | --- |
| After | <img width="2179" alt="Screenshot 2023-06-25 at 12 33 31 PM" src="https://github.com/ibhagwan/fzf-lua/assets/5804569/11781cb0-1231-473c-a8c1-214165b9ebcb"> |
