### PR TITLE
chore(lua): use $VIMRUNTIME

### DIFF
--- a/.luarc.json
+++ b/.luarc.json
@@ -21,7 +21,7 @@
     },
     "workspace": {
         "library": [
-            "runtime/lua",
+            "$VIMRUNTIME/lua",
         ],
         "checkThirdParty": false,
         "maxPreload": 2000,


### PR DESCRIPTION
When working on a previous PR, I had to set this in order to get the right completions.