### PR TITLE
feat(input): Use asynchronous vim.ui.input with coroutine

### DIFF
--- a/lua/fzf-lua/providers/grep.lua
+++ b/lua/fzf-lua/providers/grep.lua
@@ -110,7 +110,7 @@ local get_grep_cmd = function(opts, search_query, no_esc)
   return command
 end
 
-M.grep = function(opts)
+M.grep = utils.wrap_coroutine(function(opts)
   opts = config.normalize_opts(opts, config.globals.grep)
   if not opts then return end
 
@@ -174,7 +174,7 @@ M.grep = function(opts)
   opts = core.set_header(opts, opts.headers or { "actions", "cwd", "search" })
   opts = core.set_fzf_field_index(opts)
   core.fzf_exec(contents, opts)
-end
+end)
 
 -- single threaded version
 M.live_grep_st = function(opts)

--- a/lua/fzf-lua/providers/tags.lua
+++ b/lua/fzf-lua/providers/tags.lua
@@ -182,7 +182,7 @@ M.btags = function(opts)
   return tags(opts)
 end
 
-M.grep = function(opts)
+M.grep = utils.wrap_coroutine(function(opts)
   opts = opts or {}
 
   if not opts.search and opts.resume then
@@ -191,7 +191,7 @@ M.grep = function(opts)
   end
 
   if not opts.search then
-    local search = utils.input(opts.input_prompt or "Grep For> ")
+    local search = utils.input(opts.input_prompt or "(Tags) Grep For> ")
     if search then
       opts.search = search
     else
@@ -200,7 +200,7 @@ M.grep = function(opts)
   end
 
   return M.tags(opts)
-end
+end)
 
 M.live_grep = function(opts)
   opts = config.normalize_opts(opts, config.globals.tags)


### PR DESCRIPTION
This is an attempt continued from 6ee73fd, trying to use `vim.ui.input`
for asking user inputs via `fzf-lua.utils.input()`.

Previously in commit 6ee73fd (later reverted in 5d8dd50), the use of
`vim.ui.input` was incorrect, because it's an asynchronous function
but `utils.input()` is meant to be a synchronous function.
When dressing.nvim is used for `vim.ui.input`, `utils.input()` will
immediately return with `nil` before user enters text in the prompt;
it would result in the grep command being cancelled.

A possible fix to this would be to use a coroutine, which can "wrap"
an asynchronous function so that it can be used like a synchronous
function. To make it possible, command functions (e.g., FzfLua grep)
that uses `utils.input()` inside should be wrapped with coroutines.
Note that `utils.input()` will fall back to the default behavior
with the synchronous `vim.fn.input()` when coroutine is unavailable.

We enable the use of `vim.ui.input()` for prompting an user input
in neovim 0.9.0+ or higher, because the behavior of `vim.ui.input()`
on aborting the input by 'Ctrl-C' has been changed since neovim 0.9.0.
