### PR TITLE
Fix two bugs (whitespace and multi-line desc) in keymaps

### DIFF
--- a/lua/fzf-lua/actions.lua
+++ b/lua/fzf-lua/actions.lua
@@ -472,7 +472,8 @@ M.goto_jump = function(selected, opts)
 end
 
 M.keymap_apply = function(selected)
-  local key = selected[1]:match("[│]%s+(.*)%s+[│]")
+  -- extract lhs in the keymap. The lhs can't contain a whitespace.
+  local key = selected[1]:match("[│]%s+([^%s]*)%s+[│]")
   vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes(key, true, false, true), "t", true)
 end
 

--- a/lua/fzf-lua/providers/nvim.lua
+++ b/lua/fzf-lua/providers/nvim.lua
@@ -306,6 +306,8 @@ M.keymaps = function(opts)
     if type(keymap.rhs) == "string" and #keymap.rhs == 0 then
       return
     end
+    -- desc can be a multi-line string, normalize it
+    keymap_desc = string.gsub(keymap_desc, "\n%s+", "\r")
     keymap.str = string.format("%s │ %-40s │ %s",
       utils.ansi_codes[modes[keymap.mode] or "blue"](keymap.mode),
       keymap.lhs:gsub("%s", "<Space>"),


### PR DESCRIPTION
> fix(keymaps): Fix keymaps error when desc is a multi-line string

The textual description of a keymap can have more than one lines,
in which case the previewer was emitting errors. An easy fix here would
be to join all the lines (so that 1 keymap entry == 1 line in fzf).

BEFORE:

![image](https://github.com/ibhagwan/fzf-lua/assets/1009873/95424f56-d366-4220-87ab-0dfbde360ae2)

AFTER:

<img width="1200" alt="image" src="https://github.com/ibhagwan/fzf-lua/assets/1009873/abab29b4-1810-4997-aff6-c8862d72a247">


> fix(keymaps): Fix whitespace handling in keymap_apply action
Need to exclude trailing whitespaces to get the lhs keycode.

For example, an entry

    "n │ c                                        │ (desc)"

should be resolved to `c`, not `c                                    `.
