### PR TITLE
fix(highlights): uppercase prompt

### DIFF
--- a/lua/fzf-lua/defaults.lua
+++ b/lua/fzf-lua/defaults.lua
@@ -516,7 +516,7 @@ M.defaults.colorschemes = {
 }
 
 M.defaults.highlights = {
-  prompt    = "highlights> ",
+  prompt    = "Highlights> ",
   previewer = { _ctor = previewers.builtin.highlights, },
 }
 


### PR DESCRIPTION
A bit pedantic, but I think it makes sense to use the same casing as the other defaults :)