### PR TITLE
fix!: Always shellescape fzf_opts["--header"] and don't override for history providers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,11 +3,11 @@ PLENARY-REPO=https://github.com/nvim-lua/plenary.nvim.git
 
 .PHONY: test
 test:
-	nvim --headless --noplugin -u tests/minimal_init.vim -c "lua require('plenary.test_harness').test_directory('tests/', { minimal_init = 'tests/minimal_init.vim', sequential = true, timeout = 120000 })"
+	nvim --headless --clean --noplugin -u tests/minimal_init.vim -c "lua require('plenary.test_harness').test_directory('tests/', { minimal_init = 'tests/minimal_init.vim', sequential = true, timeout = 120000 })"
 
 .PHONY: test-file
 test-file:
-	nvim --headless --noplugin -u tests/minimal_init.vim -c "lua require('plenary.busted').run(vim.loop.cwd()..'/'..[[$(FILE)]])"
+	nvim --headless --clean --noplugin -u tests/minimal_init.vim -c "lua require('plenary.busted').run(vim.loop.cwd()..'/'..[[$(FILE)]])"
 
 
 .PHONY: plenary

--- a/lua/fzf-lua/core.lua
+++ b/lua/fzf-lua/core.lua
@@ -438,6 +438,10 @@ M.build_fzf_cli = function(opts)
       opts.fzf_opts[flag] = opts.fzf_opts[flag]
     end
   end
+  -- shell escape the header. Note: '--header=', '--header', '' are all different!
+  if opts.fzf_opts["--header"] then
+    opts.fzf_opts["--header"] = libuv.shellescape(opts.fzf_opts["--header"])
+  end
   opts.fzf_opts["--bind"] = M.create_fzf_binds(opts.keymap.fzf)
   if opts.fzf_colors then
     opts.fzf_opts["--color"] = M.create_fzf_colors(opts)
@@ -516,8 +520,9 @@ M.build_fzf_cli = function(opts)
     end
     if v then
       v = v:gsub(k .. "=", "")
-      cli_args = cli_args ..
-          (" %s%s"):format(k, #v > 0 and "=" .. v or "")
+      -- assumes v are well normalized and shell-escaped
+      local value_repr = (#v > 0 and "=" .. v or "")
+      cli_args = cli_args .. (" %s%s"):format(k, value_repr)
     end
   end
   return cli_args .. extra_args
@@ -769,7 +774,7 @@ M.set_header = function(opts, hdr_tbl)
     end
   end
   if hdr_str and #hdr_str > 0 then
-    opts.fzf_opts["--header"] = libuv.shellescape(hdr_str)
+    opts.fzf_opts["--header"] = hdr_str   -- escape in build_fzf_cli
   end
   return opts
 end

--- a/lua/fzf-lua/providers/dap.lua
+++ b/lua/fzf-lua/providers/dap.lua
@@ -145,7 +145,7 @@ M.breakpoints = function(opts)
   end
 
   if opts.fzf_opts["--header"] == nil then
-    opts.fzf_opts["--header"] = vim.fn.shellescape((":: %s to delete a Breakpoint")
+    opts.fzf_opts["--header"] = ((":: %s to delete a Breakpoint")
       :format(utils.ansi_codes.yellow("<Ctrl-x>")))
   end
 

--- a/lua/fzf-lua/providers/nvim.lua
+++ b/lua/fzf-lua/providers/nvim.lua
@@ -86,8 +86,10 @@ end
 local arg_header = function(sel_key, edit_key, text)
   sel_key = utils.ansi_codes.yellow(sel_key)
   edit_key = utils.ansi_codes.yellow(edit_key)
-  return vim.fn.shellescape((":: %s to %s, %s to edit")
-    :format(sel_key, text, edit_key))
+  local msg = (":: %s to %s, %s to edit"):format(sel_key, text, edit_key)
+  -- Note: fzf_args['--header'] will be ALWAYS shell escaped.
+  -- return vim.fn.shellescape(msg)
+  return msg
 end
 
 M.command_history = function(opts)

--- a/lua/fzf-lua/providers/nvim.lua
+++ b/lua/fzf-lua/providers/nvim.lua
@@ -95,14 +95,18 @@ end
 M.command_history = function(opts)
   opts = config.normalize_opts(opts, config.globals.command_history)
   if not opts then return end
-  opts.fzf_opts["--header"] = arg_header("<CR>", "<Ctrl-e>", "execute")
+  if opts.fzf_opts["--header"] == nil then
+    opts.fzf_opts["--header"] = arg_header("<CR>", "<Ctrl-e>", "execute")
+  end
   history(opts, "cmd")
 end
 
 M.search_history = function(opts)
   opts = config.normalize_opts(opts, config.globals.search_history)
   if not opts then return end
-  opts.fzf_opts["--header"] = arg_header("<CR>", "<Ctrl-e>", "search")
+  if opts.fzf_opts["--header"] == nil then
+    opts.fzf_opts["--header"] = arg_header("<CR>", "<Ctrl-e>", "search")
+  end
   history(opts, "search")
 end
 

--- a/tests/core_spec.lua
+++ b/tests/core_spec.lua
@@ -1,0 +1,52 @@
+-- TODO: We have a lot of missing tests, but will add more soon :)
+
+local config = require("fzf-lua.config")
+local core = require("fzf-lua.core")
+
+
+describe("fzf-lua.core", function()
+  describe("build_fzf_cli", function()
+    it("should generate fzf flag with minimal opts", function()
+      local opts = {}
+      opts = config.normalize_opts(opts, {})
+
+      local cli = core.build_fzf_cli(opts)
+      _G.dump(cli)
+
+      local expected = [[
+        --border=none --height=100% --multi --preview-window=nohidden:border:nowrap:down:45% layout=reverse --ansi --info=inline
+        --bind='ctrl-e:end-of-line,alt-a:toggle-all,f3:toggle-preview-wrap,f4:toggle-preview,shift-down:preview-page-down,ctrl-z:abort,ctrl-u:unix-line-discard,ctrl-f:half-page-down,ctrl-b:half-page-up,shift-up:preview-page-up,ctrl-a:beginning-of-line'
+      ]]
+
+      -- CLI can have a non-deterministic order
+      local cli_t = vim.split(vim.trim(cli), ' ')
+      local expected_t = vim.split(vim.trim(cli), ' ')
+      table.sort(cli_t)
+      table.sort(expected_t)
+      assert.are.same(expected_t, cli_t)
+    end)
+    it("should handle --header flag properly, which requires a rhs", function()
+      -- Note: `fzf --header --multi`  !=  `fzf --header='' --multi`
+
+      ---@return string
+      local function build(raw_opts)
+        local opts = config.normalize_opts(raw_opts, { query = [[<'" "'>]] })
+        local cli = core.build_fzf_cli(opts)
+        print(raw_opts.fzf_opts["--header"], "=>", cli)
+        return cli .. ' '
+      end
+
+      -- easy case
+      assert.has.match("--header='foo' ", build({ fzf_opts = { ["--header"] = "foo" } }))
+      -- falsy values should remove the flag
+      assert.has_no.match("--header", build({ fzf_opts = { ["--header"] = nil } }))
+      assert.has_no.match("--header ", build({ fzf_opts = { ["--header"] = false } }))
+      -- empty header string (tricky)
+      assert.has.match("--header='' ", build({ fzf_opts = { ["--header"] = '' } }))
+      -- shellescape?
+      assert.has.match("--header=''\\''' ", build({ fzf_opts = { ["--header"] = [[']] } }))
+      assert.has.match("--header='\"' ", build({ fzf_opts = { ["--header"] = [["]] } }))
+
+    end)
+  end)
+end)


### PR DESCRIPTION
### fix(core)!: always shellescape fzf_opts["--header"]

It was previously not clearly documented or required whether `fzf_opts["--header"]` must be shell-escaped or may take a form of raw strings.

**BREAKING CHANGE**: Like `fzf_opts["--prompt"]`, `fzf_opts["--header"]` will be automatically shell-escaped (for the sake of consistency) so normal string can be directly fed to `opts.fzf_opts["--header"]`.

Although this may not break any built-in commands, any user-custom opts that have a *shell-escaped* header fzf_opts may result in a wrong double escaping.

This commit also adds an unit test for this behavior on `--header`.


### fix(actions): Do not override header if it's already given in opts

This allows to override header for command_history and search_history.