### PR TITLE
chore: remove redundant bufname checks

### DIFF
--- a/lua/fzf-lua/actions.lua
+++ b/lua/fzf-lua/actions.lua
@@ -241,7 +241,7 @@ M.file_switch = function(selected, opts)
   end
   for _, b in ipairs(vim.api.nvim_list_bufs()) do
     local bname = vim.api.nvim_buf_get_name(b)
-    if bname and bname == fullpath then
+    if bname == fullpath then
       bufnr = b
       break
     end

--- a/lua/fzf-lua/previewer/builtin.lua
+++ b/lua/fzf-lua/previewer/builtin.lua
@@ -999,7 +999,7 @@ function Previewer.marks:parse_entry(entry_str)
     bufnr = self.win.src_bufnr
     filepath = api.nvim_buf_get_name(bufnr)
   end
-  if filepath and #filepath > 0 then
+  if #filepath > 0 then
     local ok, res = pcall(vim.fn.expand, filepath)
     if not ok then
       filepath = ""

--- a/lua/fzf-lua/providers/files.lua
+++ b/lua/fzf-lua/providers/files.lua
@@ -43,7 +43,7 @@ M.files = function(opts)
   if not opts then return end
   if opts.ignore_current_file then
     local curbuf = vim.api.nvim_buf_get_name(0)
-    if type(curbuf) and #curbuf > 0 then
+    if #curbuf > 0 then
       curbuf = path.relative(curbuf, opts.cwd or vim.loop.cwd())
       opts.file_ignore_patterns = opts.file_ignore_patterns or {}
       table.insert(opts.file_ignore_patterns, "^" .. curbuf .. "$")

--- a/lua/fzf-lua/providers/git.lua
+++ b/lua/fzf-lua/providers/git.lua
@@ -140,7 +140,7 @@ M.bcommits = function(opts)
   opts = config.normalize_opts(opts, config.globals.git.bcommits)
   if not opts then return end
   local bufname = vim.api.nvim_buf_get_name(0)
-  if not bufname or #bufname == 0 then
+  if #bufname == 0 then
     utils.info("'bcommits' is not available for unnamed buffers.")
     return
   end

--- a/lua/fzf-lua/providers/tags.lua
+++ b/lua/fzf-lua/providers/tags.lua
@@ -164,7 +164,7 @@ M.btags = function(opts)
   opts = config.normalize_opts(opts, config.globals.btags)
   if not opts then return end
   opts.filename = vim.api.nvim_buf_get_name(0)
-  if not opts.filename or #opts.filename == 0 then
+  if #opts.filename == 0 then
     utils.info("'btags' is not available for unnamed buffers.")
     return
   end

--- a/lua/fzf-lua/utils.lua
+++ b/lua/fzf-lua/utils.lua
@@ -694,7 +694,7 @@ function M.nvim_buf_get_name(bufnr, bufinfo)
     return bufinfo.name
   end
   local bufname = vim.api.nvim_buf_get_name(bufnr)
-  if not bufname or #bufname == 0 then
+  if #bufname == 0 then
     local is_qf = M.buf_is_qf(bufnr, bufinfo)
     if is_qf then
       bufname = is_qf == 1 and "[Quickfix List]" or "[Location List]"


### PR DESCRIPTION
`nvim_buf_get_name` always returns a string, so checking that the result isn't falsy it's not needed :)