### PR TITLE
fix(git_status): untracked files should be displayed correctly

### DIFF
--- a/lua/fzf-lua/defaults.lua
+++ b/lua/fzf-lua/defaults.lua
@@ -207,7 +207,7 @@ M.defaults.files = {
   cwd_prompt_shorten_len = 32,
   cwd_prompt_shorten_val = 1,
   fzf_opts               = { ["--info"] = "default", },
-  git_status_cmd         = { "git", "-c", "color.status=false", "status", "-s" },
+  git_status_cmd         = { "git", "status", "--porcelain=v1" },
   find_opts              = [[-type f -not -path '*/\.git/*' -printf '%P\n']],
   rg_opts                = "--color=never --files --hidden --follow -g '!.git'",
   fd_opts                = "--color=never --type f --hidden --follow --exclude .git",
@@ -231,9 +231,7 @@ M.defaults.git = {
   },
   status = {
     prompt      = "GitStatus> ",
-    -- override `color.status=always`, techincally not required
-    -- since we now also call `utils.strip_ansi_coloring` (#706)
-    cmd         = "git -c color.status=false status -su",
+    cmd         = "git status --porcelain -u",
     previewer   = "git_diff",
     file_icons  = true and M._has_devicons,
     color_icons = true,


### PR DESCRIPTION
Problem: The git status of untracked files in an (untracked)
directory were not correctly recognized as '?'.

Consider a scenario where
```
$ git status --porcelain=v1     # comment
A  TODO                         # staged
?? foo/                         # untracked
```

```
$ git status --porcelain=v1 -u
A  TODO
?? foo/1.md
?? foo/2.md
```

In this case, foo/1.md and foo/2.md were not recognized correctly as "?"
when included/listed in any normal `Files`-like command, or even in `GitFiles`
with a custom option is used to include untracked files as well, e.g.:

```
fzf_lua.git_files {
  cmd = "git ls-files --exclude-standard --cached --modified --others --deduplicate"
}
```

Solution: Use `-u` (`--untracked-files`) option for git status.

Note:
- Use git status --porcelain command, this is always a preferred
way to generate machine-readable git status.
- Also, the logic for git status parsing has been improved.

Refs: https://git-scm.com/docs/git-status
