### PR TITLE
fix: marks should go to line and column

### DIFF
--- a/lua/fzf-lua/actions.lua
+++ b/lua/fzf-lua/actions.lua
@@ -447,7 +447,7 @@ M.goto_mark = function(selected)
   local mark = selected[1]
   mark = mark:match("[^ ]+")
   vim.cmd("stopinsert")
-  vim.cmd("normal! '" .. mark)
+  vim.cmd("normal! `" .. mark)
   -- vim.fn.feedkeys(string.format("'%s", mark))
 end
 


### PR DESCRIPTION
Now "marks" will take you to the line and column of the mark, not just the start of the line.