### PR TITLE
Generate unique name for RPC server

### DIFF
--- a/lua/fzf-lua/init.lua
+++ b/lua/fzf-lua/init.lua
@@ -25,7 +25,7 @@ do
   -- fixed $NVIM_LISTEN_ADDRESS, different neovim instances will use the same path
   -- as their address and messages won't be received on older instances
   if not vim.g.fzf_lua_server then
-    vim.g.fzf_lua_server = vim.fn.serverstart()
+    vim.g.fzf_lua_server = vim.fn.serverstart("fzf-lua." .. os.time())
   end
 end
 


### PR DESCRIPTION
Using `vim.fn.serverstart()` can cause conflicts when different nvim instances have the same PID. This can happen if nvim runs sandboxed in its own PID namespace, for example when using Flatpak. The two different instances can have the same PID in their own namespace.

As noted in the docs, neovim will use the default path of `stdpath("run").."/{name}.{pid}.{counter}"`, however if the PID is the same, the RPC servers will clash.

To accomodate this use-case, the RPC server will be started with a reasonably unique name by using a timestamp in its name. This avoids name clashes.