### PR TITLE
📝 added ´search´ into grep options documentation

### DIFF
--- a/doc/fzf-lua.txt
+++ b/doc/fzf-lua.txt
@@ -954,7 +954,7 @@ open an issue and I'll be more than happy to help.**
       grep = {
         prompt            = 'Rg❯ ',
         input_prompt      = 'Grep For❯ ',
-        search            = nil,            -- string to search for
+        search            = nil,            -- default search string
         multiprocess      = true,           -- run command in a separate process
         git_icons         = true,           -- show git icons?
         file_icons        = true,           -- show file icons?

--- a/doc/fzf-lua.txt
+++ b/doc/fzf-lua.txt
@@ -954,6 +954,7 @@ open an issue and I'll be more than happy to help.**
       grep = {
         prompt            = 'Rg❯ ',
         input_prompt      = 'Grep For❯ ',
+        search            = nil,            -- string to search for
         multiprocess      = true,           -- run command in a separate process
         git_icons         = true,           -- show git icons?
         file_icons        = true,           -- show file icons?


### PR DESCRIPTION
### Problem:
Wanting to use Fzf-Lua for another project i needed to search with grep for a predefined string.
However I could find no documentation for how to search directly without needing a prompt.

### Solution:
Added `search` parameter into default configuration table in the documentation.
This allows people like me to discover how to perform instant searches for known patterns. :)

### Notes:
Thanks for this wonderful plugin <3 