### PR TITLE
(complete-path): fix E5108, add support for "../path"

### DIFF
--- a/lua/fzf-lua/complete.lua
+++ b/lua/fzf-lua/complete.lua
@@ -67,6 +67,20 @@ local function find_file_path(cursor_before_line)
   return nil
 end
 
+-- get search prompt
+local function get_prompt(filepath)
+  local cwd = vim.fn.getcwd()
+  -- if path include "-", replace it
+  local pattern = cwd:gsub("-", "")
+  local input_string = filepath:gsub("-", "")
+  local relative_path = input_string:gsub(pattern, "")
+  local prompt = relative_path:gsub(vim.env.HOME, "~")
+  if prompt:sub(1, 1) == "/" then
+    prompt = "~" .. prompt:sub(1)
+  end
+  return prompt
+end
+
 -- forward and reverse match spaces and single/double quotes
 -- and attepmpt to find the top level existing directory
 -- set the cwd and prompt top the top level directory and
@@ -83,10 +97,11 @@ local set_cmp_opts_path = function(opts)
     after = line:sub(col):match(match) or ""
   end
   opts.cwd = find_file_path(before)
+  opts.prompt = get_prompt(opts.cwd)
   opts.complete = function(selected, o, l, _)
     -- query fuzzy matching is empty
     if #selected == 0 then return end
-    return line:sub(1, col - 1) .. selected[1] .. line:sub(col)
+    return line:sub(1, col - 1) .. selected[1] .. line:sub(col), col + #selected[1]
   end
   return opts
 end

--- a/lua/fzf-lua/complete.lua
+++ b/lua/fzf-lua/complete.lua
@@ -86,9 +86,6 @@ local set_cmp_opts_path = function(opts)
   opts.complete = function(selected, o, l, _)
     -- query fuzzy matching is empty
     if #selected == 0 then return end
-    print(o)
-    print("l: " .. l)
-    print("_: " .. _)
     return line:sub(1, col - 1) .. selected[1] .. line:sub(col)
   end
   return opts

--- a/lua/fzf-lua/complete.lua
+++ b/lua/fzf-lua/complete.lua
@@ -89,13 +89,11 @@ local set_cmp_opts_path = function(opts)
   local match = "[^%s\"'()[]*"
   local line = vim.api.nvim_get_current_line()
   local col = vim.api.nvim_win_get_cursor(0)[2] + 1
-  local before = col > 1 and line:sub(1, col - 1):reverse():match(match):reverse() or ""
-  local after = line:sub(col):match(match) or ""
-  -- special case when the cursor is on the left surrounding char
-  if #before == 0 and #after == 0 and #line > col then
+  -- for normal mode, the col position need include char under cursor
+  if col > 1 and vim.fn.mode() == "n" then
     col = col + 1
-    after = line:sub(col):match(match) or ""
   end
+  local before = col > 1 and line:sub(1, col - 1):reverse():match(match):reverse() or ""
   opts.cwd = find_file_path(before)
   opts.prompt = get_prompt(opts.cwd)
   opts.complete = function(selected, o, l, _)

--- a/lua/fzf-lua/complete.lua
+++ b/lua/fzf-lua/complete.lua
@@ -95,6 +95,11 @@ local set_cmp_opts_path = function(opts)
   end
   local before = col > 1 and line:sub(1, col - 1):reverse():match(match):reverse() or ""
   opts.cwd = find_file_path(before)
+  -- if not valid path, give message to user instead of open dialog
+  print(string.format("Not an valid path"))
+  if opts.cwd == nil then
+    return
+  end
   opts.prompt = get_prompt(opts.cwd)
   opts.complete = function(selected, o, l, _)
     -- query fuzzy matching is empty


### PR DESCRIPTION
For example.
For relative path "../views", it will find for path related with current file. Regardless of whether the file is in the current directory or not。
![84_1701345536_raw](https://github.com/ibhagwan/fzf-lua/assets/23305067/877b65e4-48de-4ece-a795-22a2d9df9452)
