### PR TITLE
fix(lsp_code_actions): typo in preview message

### DIFF
--- a/lua/fzf-lua/previewer/codeaction.lua
+++ b/lua/fzf-lua/previewer/codeaction.lua
@@ -125,7 +125,7 @@ local function diff_tuple(tuple, diff_opts)
     local command = type(action.command) == "table" and action.command or action
     return {
       string.format(
-        "Code action preview is only available for document/worksapce edits (%s).",
+        "Code action preview is only available for document/workspace edits (%s).",
         command and type(command.command) == "string"
         and string.format("command:%s", command.command)
         or string.format("kind:%s", action.kind))


### PR DESCRIPTION
Super nit, but given that this message is displayed in the preview window of non-previewable code actions I couldn't resist :D