### PR TITLE
fix(bat): adjust bat default cmd batcat/bat(#800)

### DIFF
--- a/lua/fzf-lua/defaults.lua
+++ b/lua/fzf-lua/defaults.lua
@@ -141,17 +141,17 @@ M.defaults = {
       _ctor = previewers.fzf.cmd,
     },
     bat = {
-      cmd   = "bat",
+      cmd   = vim.fn.executable("batcat") == 1 and "batcat" or "bat",
       args  = "--color=always --style=numbers,changes",
       _ctor = previewers.fzf.bat_async,
     },
     bat_native = {
-      cmd   = "bat",
+      cmd   = vim.fn.executable("batcat") == 1 and "batcat" or "bat",
       args  = "--color=always --style=numbers,changes",
       _ctor = previewers.fzf.bat,
     },
     bat_async = {
-      cmd   = "bat",
+      cmd   = vim.fn.executable("batcat") == 1 and "batcat" or "bat",
       args  = "--color=always --style=numbers,changes",
       _ctor = previewers.fzf.bat_async,
     },


### PR DESCRIPTION
I'm sorry I made a mistake that I forgot to use `vim.fn.executable()==1`,  this commit works well, please re-merge this commit instead.