### PR TITLE
fix: fzf-lua exit when there are hlgroups with attr fg/bg=fg/bg

### DIFF
--- a/lua/fzf-lua/utils.lua
+++ b/lua/fzf-lua/utils.lua
@@ -445,6 +445,11 @@ end
 function M.hexcol_from_hl(hlgroup, what)
   if not hlgroup or not what then return end
   local hexcol = synIDattr(hlgroup, what)
+  -- some colorschemes set fg=fg/bg or bg=fg/bg
+  -- which causes hexcol to be "fg" or "bg"
+  if hexcol == "fg" or hexcol == "bg" then
+    return ""
+  end
   if hexcol and not hexcol:match("^#") then
     -- try to acquire the color from the map
     -- some schemes don't capitalize first letter?


### PR DESCRIPTION
Bug:    Some colorschemes (e.g. the builtin colorscheme 'torte') set
        fg/bg=fg/bg for hlgroups. If we pass --color=fg:fg to fzf, it
        will make fzf to exit immediately.

Fix:    Detect this in function `utils.hexcol_from_hl()`


To reproduce the bug, set nvim colorscheme to "torte": `:color torte` then open fzf-lua.