### PR TITLE
feat: expose core.ACTION_DEFINITIONS to allow custom header sections

### DIFF
--- a/lua/fzf-lua/core.lua
+++ b/lua/fzf-lua/core.lua
@@ -10,7 +10,7 @@ local make_entry = require "fzf-lua.make_entry"
 
 local M = {}
 
-local ACTION_DEFINITIONS = {
+M.ACTION_DEFINITIONS = {
   -- list of supported actions with labels to be displayed in the headers
   -- no pos implies an append to header array
   [actions.toggle_ignore]     = { "Disable .gitignore", fn_reload = "Respect .gitignore" },
@@ -748,7 +748,7 @@ M.set_header = function(opts, hdr_tbl)
       hdr_txt_str = "",
       val = function()
         if opts.no_header_i then return end
-        local defs = ACTION_DEFINITIONS
+        local defs = M.ACTION_DEFINITIONS
         local ret = {}
         for k, v in pairs(opts.actions) do
           local action = type(v) == "function" and v or type(v) == "table" and (v.fn or v[1])
@@ -768,7 +768,7 @@ M.set_header = function(opts, hdr_tbl)
             table.insert(t, i)
           end
           t[1] = (opts.header_prefix or ":: ") .. t[1]
-          return table.concat(t, opts.header_separator or "")
+          return table.concat(t, opts.header_separator or "|")
         end)() or nil
       end,
     },


### PR DESCRIPTION
I want to add two custom actions `switch_provider` and `switch_cwd` and have them shown in the fzf header like what the `live_grep` or the `git_status` provider has:

```lua
---Switch provider while preserving the last query and cwd
---@return nil
local function switch_provider()
  local opts = {
    query = fzf.config.__resume_data.last_query,
    cwd = fzf.config.__resume_data.opts.cwd,
  }
  fzf.builtin({
    actions = {
      ['default'] = function(selected)
        fzf[selected[1]](opts)
      end,
      ['esc'] = function()
        fzf.resume(opts)
      end,
    },
  })
end

---Switch cwd while preserving the last query
---@return nil
local function switch_cwd()
  local opts = fzf.config.__resume_data.opts or {}

    -- Remove old fn_selected, else selected item will be opened
    -- with previous cwd
    opts.fn_selected = nil
    opts.cwd = opts.cwd or vim.uv.cwd()
    opts.query = fzf.config.__resume_data.last_query

    vim.ui.input({
      prompt = 'New cwd: ',
      default = opts.cwd,
      completion = 'dir',
    }, function(input)
      if not input then
        return
      end
      local stat = vim.uv.fs_stat(input)
      if not stat or not stat.type == 'directory' then
        print('\n')
        vim.notify(
          '[Fzf-lua] invalid path: ' .. input .. '\n',
          vim.log.levels.ERROR
        )
        return
      end
      opts.cwd = vim.fs.normalize(input)
    end)

    -- Adapted from fzf-lua `core.set_header()` function
    if opts.cwd_prompt then
      opts.prompt = vim.fn.fnamemodify(opts.cwd, ':~:.')
      local shorten_len = tonumber(opts.cwd_prompt_shorten_len)
      if shorten_len and #opts.prompt >= shorten_len then
        opts.prompt =
          path.shorten(opts.prompt, tonumber(opts.cwd_prompt_shorten_val) or 1)
      end
      if not path.ends_with_separator(opts.prompt) then
        opts.prompt = opts.prompt .. path.separator()
      end
    end

    fzf.resume(opts)
end
```

I searched through the the issue and found [this](https://github.com/ibhagwan/fzf-lua/issues/599) that provides a method to set custom headers, but as it says it does not change the header of some providers that already have their default header, and it is also kind of cumbersome if user wants to add a action header for multiple providers (e.g. the `switch_cwd` actions can be applied to all providers that inherits the `files` actions, including `files`, `git_files`, `git_status`, `grep`, `lsp`, `oldfiles`, `quickfix`, `loclist`, `tags`, `btags`, `args`)

After some searching and reading (using fzf-lua's live_grep :)) I found the default headers are defined in the `ACTION_DEFINITIONS` variable in `core.lua`. It will be much more convenient if we can expose it to users so that they can add custom actions to the table and fzf-lua will automaitcally pick it up.

For example, to add the `switch_cwd` custom action, one only need to


```lua
local fzf = require('fzf-lua')
local actions = require('fzf-lua.actions')
local core = require('fzf-lua.core')
local path = require('fzf-lua.path')

---Switch cwd while preserving the last query
---@return nil
function actions.switch_cwd()
  local opts = fzf.config.__resume_data.opts or {}

    -- Remove old fn_selected, else selected item will be opened
    -- with previous cwd
    opts.fn_selected = nil
    opts.cwd = opts.cwd or vim.uv.cwd()
    opts.query = fzf.config.__resume_data.last_query

    vim.ui.input({
      prompt = 'New cwd: ',
      default = opts.cwd,
      completion = 'dir',
    }, function(input)
      if not input then
        return
      end
      local stat = vim.uv.fs_stat(input)
      if not stat or not stat.type == 'directory' then
        print('\n')
        vim.notify(
          '[Fzf-lua] invalid path: ' .. input .. '\n',
          vim.log.levels.ERROR
        )
        return
      end
      opts.cwd = vim.fs.normalize(input)
    end)

    -- Adapted from fzf-lua `core.set_header()` function
    if opts.cwd_prompt then
      opts.prompt = vim.fn.fnamemodify(opts.cwd, ':~:.')
      local shorten_len = tonumber(opts.cwd_prompt_shorten_len)
      if shorten_len and #opts.prompt >= shorten_len then
        opts.prompt =
          path.shorten(opts.prompt, tonumber(opts.cwd_prompt_shorten_val) or 1)
      end
      if not path.ends_with_separator(opts.prompt) then
        opts.prompt = opts.prompt .. path.separator()
      end
    end

    fzf.resume(opts)
end

core.ACTION_DEFINITIONS[actions.switch_cwd] = { "Switch CWD" }

fzf.setup({
  actions = {
    files = {
      ['alt-c'] = actions.switch_cwd,
    },
  },
})
```

to have the custom header shown in all providers that inherits from `files`:

![image](https://github.com/ibhagwan/fzf-lua/assets/76579810/8a5fc8b6-b400-4e57-9141-b32d4b8a5064)

`files` provider

![image](https://github.com/ibhagwan/fzf-lua/assets/76579810/004551bb-5cd0-4c98-b0b7-859fe5591d6e)

`git_status` provider

Also changing the default separator to "|" to align with the default separator of `git_status`.