### PR TITLE
feat: add new opt `ls_cmd` to buffer provider; small fix to bufnr alignment

### DIFF
--- a/lua/fzf-lua/defaults.lua
+++ b/lua/fzf-lua/defaults.lua
@@ -425,6 +425,7 @@ M.defaults.buffers = {
   ignore_current_buffer = false,
   no_action_set_cursor  = true,
   cwd_only              = false,
+  ls_cmd                = nil,
   cwd                   = nil,
   fzf_opts              = { ["--tiebreak"] = "index", },
   _actions              = function() return M.globals.actions.buffers end,


### PR DESCRIPTION
## What?

This PR adds a new option `ls_cmd` to the buffer provider.

If `ls_cmd` is specified, buffer list will be get from the output of `:ls`
instead of `vim.api.nvim_list_bufs()`, for example:

```lua
require('fzf-lua').buffers({ ls_cmd = 'ls a+' })
```

will get buffer lists from the output of `ls a+` (active buffers with
modification).

Users can use `:ls[!] [flags]` command with arbitrary flags supported by
nvim, e.g.

- `{ ls_cmd = 'ls!' }` -> get list of "unlisted" buffers
- `{ ls_cmd = 'ls F' }` -> get list of terminal buffers with finished job,
  etc.

In addition, if `ls_cmd` is specified, buffer flags will be grepped directly
from the `ls` output. In this way, it can show more information than the current implementation, which only has '%' and '#' flags.

This PR also includes a small fix of the alignment issue of buffer numbers: in the function `gen_buffer_entry()` variable `max_bufnr_w` is set to `26 + #tostring(max_bufnr)`, I don't know where the number 26 comes from but seems like it's the length of the ANSI code in the bufnr. However if the user sets the `FzfLuaBufNr` highlight group to a different color, the ansicode length will be different or not exist at all, and the alignment will look weird:




**Before the fix:**

When `FzfLuaBufNr` is linked to 'Normal' (correct):

![image](https://github.com/ibhagwan/fzf-lua/assets/76579810/faba95db-41d0-4b33-af70-b202d2a119fd)


When `FzfLuaBufNr` is linked to 'Operator' (wider than normal)
![image](https://github.com/ibhagwan/fzf-lua/assets/76579810/3b3a294e-fd55-42b7-a9d5-d04d5e932f2f)


When `FzfLuaBufNr` is cleared (way too wide):
![image](https://github.com/ibhagwan/fzf-lua/assets/76579810/33b06b31-b4c6-472d-be3c-5b6cc5f75eee)


**After fix:**

When `FzfLuaBufNr` is linked to 'Normal':

![image](https://github.com/ibhagwan/fzf-lua/assets/76579810/563c011d-8a6e-4114-9afe-4a91f91c5e04)


When `FzfLuaBufNr` is cleared:

![image](https://github.com/ibhagwan/fzf-lua/assets/76579810/79389844-70c3-47c6-a7bd-e910ebb152cb)


When `FzfLuaBufNr` is linked to 'Operator'

![image](https://github.com/ibhagwan/fzf-lua/assets/76579810/919b8733-e278-4da7-9f1a-49721ee7445a)


## Why?

I want to use the fzf buffers to completely replace nvim's builtin command `:ls`/`:buffers`/`:files`, but found that it does not support some flags of these commands, see `:h :ls`. This PR gives us the ability to use those flags with fzf buffer provider.

Another benefit is that we now have a way to get more buffer flags from `:ls` instead of calculating them on our own to mimic the behavior of `:ls`

`require('fzf-lua').buffers({})` before this PR:

![image](https://github.com/ibhagwan/fzf-lua/assets/76579810/9ea9d81a-657f-4dfd-a444-832d00284165)

`require('fzf-lua').buffers({ ls_cmd = 'ls' })` after this PR:

![image](https://github.com/ibhagwan/fzf-lua/assets/76579810/db790947-f284-4903-ba93-8f434368bfdd)

Actual output of `:ls`:

![image](https://github.com/ibhagwan/fzf-lua/assets/76579810/9606d293-1778-4070-926e-e57f813a2ad9)
