### PR TITLE
fix(oldfiles): exclude unlisted buffers

### DIFF
--- a/lua/fzf-lua/providers/oldfiles.lua
+++ b/lua/fzf-lua/providers/oldfiles.lua
@@ -15,7 +15,7 @@ M.oldfiles = function(opts)
   local sess_map = {}
 
   if opts.include_current_session then
-    for _, buffer in ipairs(vim.split(vim.fn.execute(":buffers! t"), "\n")) do
+    for _, buffer in ipairs(vim.split(vim.fn.execute(":buffers t"), "\n")) do
       local bufnr = tonumber(buffer:match("%s*(%d+)"))
       if bufnr then
         local file = vim.api.nvim_buf_get_name(bufnr)


### PR DESCRIPTION
At the moment, when the `include_current_session` option is enabled, extra files get into the oldfiles list (for example, files that got into the preview, but were not opened). It seems that only those files that were actually opened by the user should be added to oldfiles.