### PR TITLE
fix(oldfiles): properly process opened buffers

### DIFF
--- a/lua/fzf-lua/providers/oldfiles.lua
+++ b/lua/fzf-lua/providers/oldfiles.lua
@@ -1,37 +1,98 @@
-local core = require "fzf-lua.core"
-local utils = require "fzf-lua.utils"
-local config = require "fzf-lua.config"
-local make_entry = require "fzf-lua.make_entry"
+local core = require("fzf-lua.core")
+local config = require("fzf-lua.config")
+local make_entry = require("fzf-lua.make_entry")
 
 local M = {}
 
+M._recent_buffers = {}
+M._recent_counter = 0
+
+vim.api.nvim_create_autocmd("BufEnter", {
+  pattern = "*",
+  callback = function()
+    local buffer = vim.api.nvim_get_current_buf()
+    local file = vim.api.nvim_buf_get_name(buffer)
+    if file ~= "" then
+      M._recent_buffers[file] = M._recent_counter
+      M._recent_counter = M._recent_counter + 1
+    end
+  end,
+})
+
 M.oldfiles = function(opts)
   opts = config.normalize_opts(opts, "oldfiles")
-  if not opts then return end
+  if not opts then
+    return
+  end
 
   local current_buffer = vim.api.nvim_get_current_buf()
   local current_file = vim.api.nvim_buf_get_name(current_buffer)
-  local sess_tbl = {}
-  local sess_map = {}
+
+  local result_list = {}
+  local result_map = {}
+  local old_files_map = {}
+
+  local function add_recent_file(file)
+    if not file or #file == 0 or result_map[file] then
+      return
+    end
+
+    local fs_stat = not opts.stat_file and true or vim.loop.fs_stat(file)
+    if not fs_stat then
+      return
+    end
+
+    table.insert(result_list, file)
+    result_map[file] = true
+  end
+
+  for i, file in ipairs(vim.v.oldfiles) do
+    if opts.show_current_file or file ~= current_file then
+      add_recent_file(file)
+      old_files_map[file] = i
+    end
+  end
 
   if opts.include_current_session then
-    for _, buffer in ipairs(vim.split(vim.fn.execute(":buffers t"), "\n")) do
-      local bufnr = tonumber(buffer:match("%s*(%d+)"))
-      if bufnr then
-        local file = vim.api.nvim_buf_get_name(bufnr)
-        local fs_stat = not opts.stat_file and true or vim.loop.fs_stat(file)
-        if #file > 0 and fs_stat and bufnr ~= current_buffer then
-          sess_map[file] = true
-          table.insert(sess_tbl, file)
-        end
+    for buffer_file in pairs(M._recent_buffers) do
+      if opts.show_current_file or buffer_file ~= current_file then
+        add_recent_file(buffer_file)
       end
     end
   end
 
+  table.sort(result_list, function(a, b)
+    local a_recency = M._recent_buffers[a]
+    local b_recency = M._recent_buffers[b]
+    if a_recency == nil and b_recency == nil then
+      local a_old = old_files_map[a]
+      local b_old = old_files_map[b]
+      if a_old == nil and b_old == nil then
+        return a < b
+      end
+      if a_old == nil then
+        return false
+      end
+      if b_old == nil then
+        return true
+      end
+      return a_old < b_old
+    end
+    if a_recency == nil then
+      return false
+    end
+    if b_recency == nil then
+      return true
+    end
+    return b_recency < a_recency
+  end)
+
   local contents = function(cb)
     local function add_entry(x, co)
       x = make_entry.file(x, opts)
-      if not x then return end
+      if not x then
+        return
+      end
       cb(x, function(err)
         coroutine.resume(co)
         if err then
@@ -47,20 +108,9 @@ M.oldfiles = function(opts)
     coroutine.wrap(function()
       local co = coroutine.running()
 
-      for _, file in ipairs(sess_tbl) do
+      for _, file in ipairs(result_list) do
         add_entry(file, co)
       end
-
-      -- local start = os.time(); for _ = 1,10000,1 do
-      for _, file in ipairs(vim.v.oldfiles) do
-        local fs_stat = not opts.stat_file and true
-            -- FIFO blocks `fs_open` indefinitely (#908)
-            or (not utils.file_is_fifo(file) and utils.file_is_readable(file))
-        if fs_stat and file ~= current_file and not sess_map[file] then
-          add_entry(file, co)
-        end
-      end
-      -- end; print("took", os.time()-start, "seconds.")
 
       -- done
       cb(nil)


### PR DESCRIPTION
In PR #987, I created a new bug by fixing the old one. Now, when the buffer is deleted, the file stops being shown in oldfiles. To fix this error, we had to slightly change the logic of getting opened buffers. Now all buffers that the user opens are saved in a table, which is then used in the picker.

The idea and part of the implementation was taken from [`telescope-recent-files`](https://github.com/smartpde/telescope-recent-files).