### PR TITLE
fix: make `opts` optional in `fzf-lua.utils.fzf_version`

### DIFF
--- a/lua/fzf-lua/utils.lua
+++ b/lua/fzf-lua/utils.lua
@@ -952,6 +952,7 @@ function M.neovim_bind_to_fzf(key)
 end
 
 function M.fzf_version(opts)
+  opts = opts or {}
   -- temp unset "FZF_DEFAULT_OPTS" as it might fail `--version`
   -- if it contains options aren't compatible with fzf's version
   local FZF_DEFAULT_OPTS = vim.env.FZF_DEFAULT_OPTS


### PR DESCRIPTION
... so that `require("fzf-lua.utils").fzf_version()` can work, no need
to call like `require("fzf-lua.utils").fzf_version({})`.
