### PR TITLE
refactor(utils)!: use vim.system for running process if available

### DIFF
--- a/lua/fzf-lua/init.lua
+++ b/lua/fzf-lua/init.lua
@@ -138,8 +138,6 @@ function M.setup(opts, do_not_reset_defaults)
       opts[gopt] = nil
     end
   end
-  -- set lua_io if caller requested
-  utils.set_lua_io(opts.lua_io)
   -- set custom &nbsp if caller requested
   if opts.nbsp then utils.nbsp = opts.nbsp end
   -- store the setup options


### PR DESCRIPTION
Use the new `vim.system()` API on neovim 0.10 or higher, in place of
`vim.fn.system()`. It's more performant by using libuv (`vim.loop`),
though only slightly and known to have less glitches.
