### PR TITLE
Encode tab_cwd in bas64 and add it to tabs buffer entry as field 2

### DIFF
--- a/lua/fzf-lua/defaults.lua
+++ b/lua/fzf-lua/defaults.lua
@@ -450,7 +450,7 @@ M.defaults.tabs = {
   },
   fzf_opts    = {
     ["--delimiter"] = "'[\\):]'",
-    ["--with-nth"]  = "2..",
+    ["--with-nth"]  = "3..",
   },
   _cached_hls = { "buf_nr", "buf_flag_cur", "buf_flag_alt", "tab_title", "tab_marker" },
 }

--- a/lua/fzf-lua/providers/buffers.lua
+++ b/lua/fzf-lua/providers/buffers.lua
@@ -371,11 +371,12 @@ M.tabs = function(opts)
           return msg, hl
         end
 
+        local tab_cwd_tilde = path.HOME_to_tilde(tab_cwd)
         local title, fn_title_hl = opt_hl("tab_title",
           function(s)
             return string.format("%s%s#%d%s", s, utils.nbsp, t,
               (vim.loop.cwd() == tab_cwd and ""
-                or string.format(": %s", path.HOME_to_tilde(tab_cwd))))
+                or string.format(": %s", tab_cwd_tilde)))
           end,
           utils.ansi_codes[opts.hls.tab_title])
 
@@ -383,8 +384,9 @@ M.tabs = function(opts)
           function(s) return s end,
           utils.ansi_codes[opts.hls.tab_marker])
 
+        local tab_cwd_tilde_base64 = vim.base64.encode(tab_cwd_tilde)
         if not opts.current_tab_only then
-          cb(string.format("%d)%s%s\t%s", t, utils.nbsp,
+          cb(string.format("%d)%s)%s%s\t%s", t, tab_cwd_tilde_base64, utils.nbsp,
             fn_title_hl(title),
             (t == core.CTX().tabnr) and fn_marker_hl(marker) or ""))
         end
@@ -395,7 +397,7 @@ M.tabs = function(opts)
         end
 
         opts.sort_lastused = false
-        opts._prefix = ("%d)%s%s%s"):format(t, utils.nbsp, utils.nbsp, utils.nbsp)
+        opts._prefix = ("%d)%s)%s%s%s"):format(t, tab_cwd_tilde_base64, utils.nbsp, utils.nbsp, utils.nbsp)
         local tabh = vim.api.nvim_list_tabpages()[t]
         local buffers = populate_buffer_entries(opts, bufnrs_flat, tabh)
         for _, bufinfo in pairs(buffers) do


### PR DESCRIPTION
With `tab_cwd` in entry, one can do something like:

```lua
fzf.tabs({
  fzf_opts = {
    ["--preview"] = [['echo "Tab #"{1}": $(echo {2} | base64 -d -)"']],
    ["--preview-window"] = "down,1",
  }
})
```

And get:

![Screenshot from 2024-01-14 13-11-10](https://github.com/ibhagwan/fzf-lua/assets/5733531/a09dc8ef-6589-4308-96a0-fc2a5663d123)
![Screenshot from 2024-01-14 13-11-20](https://github.com/ibhagwan/fzf-lua/assets/5733531/e0d7c50e-4b65-4d25-b594-2fb916adefea)
![Screenshot from 2024-01-14 13-11-25](https://github.com/ibhagwan/fzf-lua/assets/5733531/607fd107-763c-4088-b255-f5c22bd02877)
