### PR TITLE
Encode tab_cwd in base64 (*NIX file names are permissive)

### DIFF
--- a/lua/fzf-lua/providers/buffers.lua
+++ b/lua/fzf-lua/providers/buffers.lua
@@ -384,8 +384,9 @@ M.tabs = function(opts)
           function(s) return s end,
           utils.ansi_codes[opts.hls.tab_marker])
 
+        local tab_cwd_tilde_base64 = vim.base64.encode(tab_cwd_tilde)
         if not opts.current_tab_only then
-          cb(string.format("%d)%s:%s%s\t%s", t, tab_cwd_tilde, utils.nbsp,
+          cb(string.format("%d)%s:%s%s\t%s", t, tab_cwd_tilde_base64, utils.nbsp,
             fn_title_hl(title),
             (t == core.CTX().tabnr) and fn_marker_hl(marker) or ""))
         end
@@ -397,7 +398,7 @@ M.tabs = function(opts)
 
         opts.sort_lastused = false
         opts._prefix = string.format("%d)%s:%s%s%s",
-          t, tab_cwd_tilde, utils.nbsp, utils.nbsp, utils.nbsp)
+          t, tab_cwd_tilde_base64, utils.nbsp, utils.nbsp, utils.nbsp)
         local tabh = vim.api.nvim_list_tabpages()[t]
         local buffers = populate_buffer_entries(opts, bufnrs_flat, tabh)
         for _, bufinfo in pairs(buffers) do


### PR DESCRIPTION
See discussion in #1000.

Since *NIX file names allow any character, using them as is in an entry can break tabs functionality. The solution is to encode them in base64 and use a separator that is not in the base64 table, such as colon.

To decode the directory name, Neovim itself can be used:

```lua
fzf.tabs({
  fzf_opts = {
    ["--preview"] = [['echo -n "Tab #"{1}": "; nvim -u NONE -es +":verbose lua print(vim.base64.decode({2}))"']],
    ["--preview-window"] = "up,1",
  }
})
```

Or one can use `base64`:

```lua
fzf.tabs({
  fzf_opts = {
    ["--preview"] = [['echo "Tab #"{1}": $(echo {2} | base64 -d -)"']],
    ["--preview-window"] = "up,1",
  }
})
```