### PR TITLE
fix(changes): add defaults values for changes

### DIFF
--- a/lua/fzf-lua/defaults.lua
+++ b/lua/fzf-lua/defaults.lua
@@ -759,6 +759,12 @@ M.defaults.marks = {
   },
 }
 
+M.defaults.changes = {
+  cmd = "changes",
+  prompt = "Changes> ",
+  h1 = "change",
+}
+
 M.defaults.jumps = {
   prompt    = "Jumps> ",
   cmd       = "jumps",

--- a/lua/fzf-lua/providers/nvim.lua
+++ b/lua/fzf-lua/providers/nvim.lua
@@ -109,10 +109,7 @@ M.search_history = function(opts)
 end
 
 M.changes = function(opts)
-  opts = opts or {}
-  opts.cmd = "changes"
-  opts.prompt = opts.prompt or "Changes> "
-  opts.h1 = opts.h1 or "change"
+  opts = config.normalize_opts(opts, "changes")
   return M.jumps(opts)
 end
 


### PR DESCRIPTION
I noticed that the default values weren't set and calling `normalize_opts` was missing for the `changes` builtin. This was causing issues when I was trying to override the prompt in my configuration. I've updated the defaults, please let me know if any other changes are needed. 