### PR TITLE
fix: restore window layout for splits

### DIFF
--- a/lua/fzf-lua/win.lua
+++ b/lua/fzf-lua/win.lua
@@ -838,6 +838,8 @@ function FzfWin:create()
   -- save sending bufnr/winid
   self.src_bufnr = vim.api.nvim_get_current_buf()
   self.src_winid = vim.api.nvim_get_current_win()
+  -- save current window layout cmd
+  self.winrestcmd = vim.fn.winrestcmd()
 
   if self.winopts.split then
     vim.cmd(self.winopts.split)
@@ -935,6 +937,9 @@ function FzfWin:close(fzf_bufnr)
       and self.src_winid ~= vim.api.nvim_get_current_win()
       and vim.api.nvim_win_is_valid(self.src_winid) then
     vim.api.nvim_set_current_win(self.src_winid)
+  end
+  if self.winopts.split then
+    vim.cmd(self.winrestcmd)
   end
   if self.hls_on_close then
     -- restore search highlighting if we disabled it


### PR DESCRIPTION
If we're using fzf-lua with the split option the default behavior is that after leaving the fzf window the remaining windows will be balanced in size (`CTRL-W_=`). I would argue that the default should be to restore the previous layout which the user might have configured to their liking (the floating window also does not interfere with the window layout).

## Reproduce

> using `sh -c "$(curl -s https://raw.githubusercontent.com/ibhagwan/fzf-lua/main/scripts/mini.sh)"`

- split the window (`:split`)
- adapt the height of the current window (e.g. `CTRL-W_+`)
- configure fzf-lua to use the split option `:lua require'fzf-lua'.setup { winopts = { split = 'botright new' }}`
- open a file via fzf `:FzfLua files`

### Expected Result

The window sizes are restored to their values before invoking fzf-lua

### Actual Result

All windows have been "balanced" (like with `CTRL-W_=`)

## Solution

We can use `winrestcmd()` to easily restore the previous window layout. One could argue that the user can do it themselves, saving the state beforehand, then invoking fzf-lua and in the `on_close` function calling the saved command. By in my opinion minimal interference should always be the default.

If you see a better solution or a better place/variable name etc. please feel free to share :slightly_smiling_face: 