### PR TITLE
fix(actions): toggle-ignore not preserving cwd

### DIFF
--- a/lua/fzf-lua/actions.lua
+++ b/lua/fzf-lua/actions.lua
@@ -766,7 +766,7 @@ M.sym_lsym = function(_, opts)
 end
 
 M.toggle_ignore = function(_, opts)
-  local o = { resume = true }
+  local o = { resume = true, cwd = opts.cwd }
   local flag = opts.toggle_ignore_flag or "--no-ignore"
   if not flag:match("^%s") then
     -- flag must be preceded by whitespace


### PR DESCRIPTION
`toggle-ignore` action always resets cwd to the current working directory, this PR fixes the issue.