### PR TITLE
Allow setting --preview-window to false to not override FZF defaults

### DIFF
--- a/lua/fzf-lua/core.lua
+++ b/lua/fzf-lua/core.lua
@@ -502,7 +502,7 @@ M.build_fzf_cli = function(opts)
   if opts.fzf_opts["--preview-window"] == nil then
     opts.fzf_opts["--preview-window"] = M.preview_window(opts)
   end
-  if opts.preview_offset and #opts.preview_offset > 0 then
+  if opts.fzf_opts["--preview-window"] and opts.preview_offset and #opts.preview_offset > 0 then
     opts.fzf_opts["--preview-window"] =
         opts.fzf_opts["--preview-window"] .. ":" .. opts.preview_offset
   end


### PR DESCRIPTION
Currently when fzf_opts["--preview-window"] is set to false, it works as long as opts.preview_offset is not set. But this is set for grep by default so it throws error. This checks if --preview-window is set before adding preview offset to it.