### PR TITLE
feat: support multi-part extensions for file icons

### DIFF
--- a/lua/fzf-lua/make_entry.lua
+++ b/lua/fzf-lua/make_entry.lua
@@ -5,18 +5,36 @@ local utils = require "fzf-lua.utils"
 local libuv = require "fzf-lua.libuv"
 local config = nil
 
+-- These are the supported multi-part extensions from nvim-web-devicons
+-- https://github.com/nvim-tree/nvim-web-devicons/blob/master/lua/nvim-web-devicons/icons-default.lua
+local supported_multi_part_icon_extensions = {
+  ["spec.js"] = true,
+  ["spec.jsx"] = true,
+  ["spec.ts"] = true,
+  ["spec.tsx"] = true,
+  ["test.js"] = true,
+  ["test.jsx"] = true,
+  ["test.ts"] = true,
+  ["test.tsx"] = true,
+}
 -- Supports multi-part extensions
 -- e.g.
 --    "file.js" -> "js"
 --    "file.test.js" -> "test.js"
 --    "file.spec.js" -> "spec.js"
-local function get_extension_from_file_name(file_name)
+local function get_icon_extension_from_file_name(file_name)
   local name, extension = file_name:match("(.+)%.(.+)$")
 
   if name and extension then
     local preExtension = name:match(".+%.(.+)$")
     if preExtension then
-      return (preExtension .. "." .. extension):lower()
+      local combined = (preExtension .. "." .. extension):lower()
+      
+      if supported_multi_part_icon_extensions[combined] then
+        return combined
+      end
+
+      return extension:lower()
     else
       return extension:lower()
     end
@@ -227,7 +245,7 @@ end
 -- by default the extension will be derived from `file`, but you can
 -- override it by passing `extensionOverride`
 M.get_devicon = function(file, extensionOverride)
-  local ext = extensionOverride or get_extension_from_file_name(file)
+  local ext = extensionOverride or get_icon_extension_from_file_name(file)
 
   local icon, hl
   if path.ends_with_separator(file) then

--- a/lua/fzf-lua/providers/buffers.lua
+++ b/lua/fzf-lua/providers/buffers.lua
@@ -146,8 +146,7 @@ local function gen_buffer_entry(opts, buf, max_bufnr, cwd)
       buficon, hl = make_entry.get_devicon(buf.info.name, "sh")
     else
       local filename = path.tail(buf.info.name)
-      local extension = path.extension(filename)
-      buficon, hl = make_entry.get_devicon(filename, extension)
+      buficon, hl = make_entry.get_devicon(filename)
     end
     if opts.color_icons then
       -- fallback to "grey" color (#817)
@@ -259,8 +258,7 @@ M.buffer_lines = function(opts)
           bufname = path.basename(filepath)
           if opts.file_icons then
             local filename = path.tail(bufname)
-            local extension = path.extension(filename)
-            buficon, hl = make_entry.get_devicon(filename, extension)
+            buficon, hl = make_entry.get_devicon(filename)
             if opts.color_icons then
               buficon = utils.ansi_codes[hl](buficon)
             end

--- a/lua/fzf-lua/providers/nvim.lua
+++ b/lua/fzf-lua/providers/nvim.lua
@@ -164,8 +164,7 @@ M.tagstack = function(opts)
     local buficon, hl
     if opts.file_icons then
       local filename = path.tail(bufname)
-      local extension = path.extension(filename)
-      buficon, hl = make_entry.get_devicon(filename, extension)
+      buficon, hl = make_entry.get_devicon(filename)
       if opts.color_icons then
         buficon = utils.ansi_codes[hl](buficon)
       end


### PR DESCRIPTION
`nvim-tree/nvim-web-devicons` supports "mult-part" file extensions. 

E.g. for these 2 files:
- `file1.js`
- `file1.test.js`

`nvim-web-devicons` can return different icons for `"js"` and `"test.js"`. But right now fzf-lua only ever passes "js" as the extension.

This PR parses the filename in order to determine the extension and handles these multi-part extensions.

Before: 
<img width="291" alt="before" src="https://github.com/ibhagwan/fzf-lua/assets/3977781/df1f95fb-3602-4474-a5bc-4b054510b827">

After:
<img width="287" alt="after" src="https://github.com/ibhagwan/fzf-lua/assets/3977781/329a9789-81b3-4143-af10-facbee264028">

P.s. thank you for this plugin!! 🔥