### PR TITLE
fix(manpages): preview and open the correct section for the man page

### DIFF
--- a/lua/fzf-lua/actions.lua
+++ b/lua/fzf-lua/actions.lua
@@ -543,9 +543,7 @@ M.help_tab = function(selected)
 end
 
 local function mantags(s)
-  return vim.tbl_map(function(x)
-    return x:match("[^[,( ]+")
-  end, s)
+  return vim.tbl_map(require'fzf-lua.providers.manpages'.manpage_vim_arg, s)
 end
 
 M.man = function(selected)

--- a/lua/fzf-lua/previewer/builtin.lua
+++ b/lua/fzf-lua/previewer/builtin.lua
@@ -986,8 +986,7 @@ function Previewer.man_pages:new(o, opts, fzf_win)
 end
 
 function Previewer.man_pages:parse_entry(entry_str)
-  return entry_str:match("[^[,( ]+")
-  -- return require'fzf-lua.providers.manpages'.getmanpage(entry_str)
+  return require'fzf-lua.providers.manpages'.manpage_sh_arg(entry_str)
 end
 
 function Previewer.man_pages:populate_preview_buf(entry_str)

--- a/lua/fzf-lua/previewer/fzf.lua
+++ b/lua/fzf-lua/previewer/fzf.lua
@@ -397,9 +397,8 @@ end
 function Previewer.man_pages:cmdline(o)
   o = o or {}
   local act = shell.raw_preview_action_cmd(function(items)
-    -- local manpage = require'fzf-lua.providers.manpages'.getmanpage(items[1])
-    local manpage = items[1]:match("[^[,( ]+")
-    local cmd = self.cmd:format(libuv.shellescape(manpage))
+    local manpage = require'fzf-lua.providers.manpages'.manpage_sh_arg(items[1])
+    local cmd = self.cmd:format(manpage)
     return cmd
   end, "{}", self.opts.debug)
   return act

--- a/lua/fzf-lua/providers/manpages.lua
+++ b/lua/fzf-lua/providers/manpages.lua
@@ -1,8 +1,29 @@
 local core = require "fzf-lua.core"
 local utils = require "fzf-lua.utils"
 local config = require "fzf-lua.config"
+local libuv = require "fzf-lua.libuv"
 
 local M = {}
+
+--- E.g. mandoc: "perlfork(1, 1p)             - Perl's fork() emulation"                 -> "perlfork, 1"
+--- E.g. mandoc: "vsnprintf, vsprintf(3P, 3p) - format output of a stdarg argument list" -> "vsnprintf", "3P"
+--- E.g. man-db: "vsnprintf (3p)              - format output of a stdarg argument list" -> "vsnprintf", "3p"
+--- @param apropos_line string a selected output line from `man -k`
+--- @return string page, string and section
+local function parse_apropos(apropos_line)
+  return apropos_line:match("^([^, (]+)[^(]*%(([^), ]*)")
+end
+--- @param apropos_line string
+--- @return string arg without shellescape
+M.manpage_vim_arg = function(apropos_line)
+  return string.format("%s(%s)", parse_apropos(apropos_line))
+end
+--- @param apropos_line string
+--- @return string arg with shellescape
+M.manpage_sh_arg = function(apropos_line)
+  local page, section = parse_apropos(apropos_line)
+  return libuv.shellescape(section) .. " " .. libuv.shellescape(page)
+end
 
 M.manpages = function(opts)
   opts = config.normalize_opts(opts, "manpages")


### PR DESCRIPTION
The man pages are grouped into different sections and it is common for identically named pages to be found in multiple sections. For instance `printf(1)` documenting the shell command and `printf(3)` documenting the C-function.

Prior to these changes the section name was stripped away from the selected entries, so it only previews and opens that page from the default section even though another section was selected. Now the apropos entry is rewritten to a `:Man` argument with the section name.