### PR TITLE
fix(preview): set flex threshold from window columns in split mode

### DIFF
--- a/lua/fzf-lua/core.lua
+++ b/lua/fzf-lua/core.lua
@@ -421,16 +421,10 @@ end
 ---@param o table
 ---@return string
 M.preview_window = function(o)
-  local preview_args = ("%s:%s:%s:"):format(
-    o.winopts.preview.hidden, o.winopts.preview.border, o.winopts.preview.wrap)
-  if o.winopts.preview.layout == "horizontal" or
-      o.winopts.preview.layout == "flex" and
-      vim.o.columns > o.winopts.preview.flip_columns then
-    preview_args = preview_args .. o.winopts.preview.horizontal
-  else
-    preview_args = preview_args .. o.winopts.preview.vertical
-  end
-  return preview_args
+  local hsplit = win:preview_splits_horizontally(o.winopts, 0)
+  local split = hsplit and o.winopts.preview.horizontal or o.winopts.preview.vertical
+  return ("%s:%s:%s:%s"):format(
+    o.winopts.preview.hidden, o.winopts.preview.border, o.winopts.preview.wrap, split)
 end
 
 -- Create fzf --color arguments from a table of vim highlight groups.


### PR DESCRIPTION
The split mode opens the fzf selection in a split from the current window, so the number of available columns can be less than the width of the full terminal, which should be taken into the account when calculating whether the width exceeds the flex threshold or not.



As discussed in #1040, fzf-tmux also have a split mode, in which case the split is relative to the full-width of the terminal window, so maybe the `fzf_bin` should also be taken into account here. Or maybe it should not because fzf-tmux only takes effect if the terminal is a tmux session (or maybe also check e.g. `vim.env.TMUX` to determine if fzf-tmux would have an effect). However, whilst testing that it turns out that having split mode set with fzf-tmux in a tmux session has a lot more serious issues. The behavior on my end (and with `mini.sh`) in that scenario is that the split pane works fine (have not tested these changes with it), but the selections gets lost. Considering this along with the default in fzf-tmux is to not actually use flex mode, so the likelihood that this breaks user configuration any further is pretty low, and it is probably safe to not take that into account for now.