### PR TITLE
feat(quickfix): add an only_valid option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1105,6 +1105,7 @@ require'fzf-lua'.setup {
   quickfix = {
     file_icons        = true,
     git_icons         = true,
+    only_valid        = false, -- select among only the valid quickfix entries
   },
   quickfix_stack = {
     prompt = "Quickfix Stack> ",

--- a/lua/fzf-lua/defaults.lua
+++ b/lua/fzf-lua/defaults.lua
@@ -380,6 +380,7 @@ M.defaults.quickfix = {
   git_icons   = false,
   fzf_opts    = { ["--multi"] = true },
   _actions    = function() return M.globals.actions.files end,
+  only_valid  = false,
 }
 
 M.defaults.quickfix_stack = {
@@ -399,6 +400,7 @@ M.defaults.loclist = {
   git_icons   = false,
   fzf_opts    = { ["--multi"] = true },
   _actions    = function() return M.globals.actions.files end,
+  only_valid  = false,
 }
 
 M.defaults.loclist_stack = {

--- a/lua/fzf-lua/providers/quickfix.lua
+++ b/lua/fzf-lua/providers/quickfix.lua
@@ -15,7 +15,9 @@ local quickfix_run = function(opts, cfg, locations)
   if not opts.cwd then opts.cwd = vim.loop.cwd() end
 
   for _, entry in ipairs(locations) do
-    table.insert(results, make_entry.lcol(entry, opts))
+    if entry.valid == 1 or not opts.only_valid then
+      table.insert(results, make_entry.lcol(entry, opts))
+    end
   end
 
   local contents = function(cb)


### PR DESCRIPTION
So that the quickfix/loclist providers can include less noise to begin with if users prefers that. Much like the `:clist` command that you need to add a bang to for it to include the invalid entries.