### PR TITLE
fix(quickfix): handle multi-line entries more like the quicklist window

### DIFF
--- a/lua/fzf-lua/providers/quickfix.lua
+++ b/lua/fzf-lua/providers/quickfix.lua
@@ -16,6 +16,7 @@ local quickfix_run = function(opts, cfg, locations)
 
   for _, entry in ipairs(locations) do
     if entry.valid == 1 or not opts.only_valid then
+      entry.text = entry.text:gsub("\r?\n", " ")
       table.insert(results, make_entry.lcol(entry, opts))
     end
   end


### PR DESCRIPTION
That means having them displayed without new lines so that they are concatenated into on one long line. Prior to these changes if a quickfix entry included newlines those would become separate entries in the fzf selection list. Quickfix entries are formatted so they start with the file name and location, but only the first line is like that, so if one were to select one of the other lines from an entry the start of this line would be interpreted as a file name and would open a buffer "there"

Here is an example of a multiline error (not really a realistic one as it does not have a filename to begin with though), before:
![quickfix_multiline_before](https://github.com/ibhagwan/fzf-lua/assets/1331670/50395bf0-b0a4-499e-a434-c939c0793399)
After:
![quickfix_multiline_after](https://github.com/ibhagwan/fzf-lua/assets/1331670/a506f1d1-085a-4e82-804c-89d968f87966)
