### PR TITLE
fix(fzf-tmux): get flex layout for split panes from vim width

### DIFF
--- a/lua/fzf-lua/config.lua
+++ b/lua/fzf-lua/config.lua
@@ -285,9 +285,11 @@ function M.normalize_opts(opts, globals, __resume_key)
 
   -- prioritize fzf-tmux split pane flags over the
   -- popup flag `-p` from fzf-lua defaults (#865)
+  opts._is_fzf_tmux_popup = true
   if type(opts.fzf_tmux_opts) == "table" then
     for _, flag in ipairs({ "-u", "-d", "-l", "-r" }) do
       if opts.fzf_tmux_opts[flag] then
+        opts._is_fzf_tmux_popup = false
         opts.fzf_tmux_opts["-p"] = nil
       end
     end

--- a/lua/fzf-lua/win.lua
+++ b/lua/fzf-lua/win.lua
@@ -183,7 +183,7 @@ local strip_borderchars_hl = function(border)
 end
 
 function FzfWin:preview_splits_horizontally(winopts, winid)
-  local columns = self._o._is_fzf_tmux and self._o._tmux_columns
+  local columns = self._o._is_fzf_tmux and self._o._is_fzf_tmux_popup and self._o._tmux_columns
       or winopts.split and vim.api.nvim_win_get_width(winid)
       or vim.o.columns
   return winopts.preview.layout == "horizontal"


### PR DESCRIPTION
In case the tmux terminal is vertically split already, because then the pane will be split from the current pane not the full window width.