### PR TITLE
fix(fzf-tmux): disable split mode when using fzf-tmux in a tmux session

### DIFF
--- a/lua/fzf-lua/config.lua
+++ b/lua/fzf-lua/config.lua
@@ -509,6 +509,7 @@ function M.normalize_opts(opts, globals, __resume_key)
   if opts._is_fzf_tmux then
     local out = utils.io_system({ "tmux", "display-message", "-p", "#{window_width}" })
     opts._tmux_columns = tonumber(out:match("%d+"))
+    opts.winopts.split = nil
   end
 
   -- libuv.spawn_nvim_fzf_cmd() pid callback


### PR DESCRIPTION
Because for some reason the selection result does not have any effect when both are configured in and you are in a tmux session.

> I’m failing to imagine how these options work together at all, IMHO if someone is using fzf-tmux and tmux env exists, split should be disabled.

Yes, that seems to solve the problem, so that is probably better than to just leave it as is.