### PR TITLE
appending exclamation to buffer command when deleting term buffer from buffer selection tool

### DIFF
--- a/lua/fzf-lua/actions.lua
+++ b/lua/fzf-lua/actions.lua
@@ -304,6 +304,11 @@ M.vimcmd_buf = function(vimcmd, selected, opts)
     -- add current location to jumplist
     if not is_term then vim.cmd("normal! m`") end
     if vimcmd ~= "b" or curbuf ~= entry.bufnr then
+      local bufname = vim.api.nvim_buf_is_valid(entry.bufnr) and
+          vim.api.nvim_buf_get_name(entry.bufnr)
+      if utils.is_term_bufname(bufname) then
+        vimcmd = vimcmd .. "!"
+      end
       local cmd = vimcmd .. " " .. entry.bufnr
       local ok, res = pcall(vim.cmd, cmd)
       if not ok then


### PR DESCRIPTION
I wanted to be able to leverage the built-in `ctrl-x` close buffer behavior on terminals. My workflow, I create a lot of terminal buffers I'd like to be able to easily close.

I verified that this correctly closes the terminal buffer locally on macos for me. Beyond that, no testing of this. I realize that's not great.

I'm open to any and all criticism regarding this PR! I understand if don't want to merge.