### PR TITLE
fix(diagnostic): buffer might have become invalid

### DIFF
--- a/lua/fzf-lua/providers/diagnostic.lua
+++ b/lua/fzf-lua/providers/diagnostic.lua
@@ -192,6 +192,7 @@ M.diagnostics = function(opts)
               local diag_entry = preprocess_diag(diag, bufnr)
               if diag_entry == nil then
                 coroutine.resume(co)
+                return
               end
               local entry = make_entry.lcol(diag_entry, opts)
               entry = make_entry.file(entry, opts)


### PR DESCRIPTION
04d5a528a4159901607c11d46a398f45db2ed43f (#722) attempted to fix this issue, but it was not actually fixed due to the lack of `return`.


Unfortunately, I still don't have a stable reproducer to the original problem.