### PR TITLE
fix: use uri as filename for quickfix list

### DIFF
--- a/lua/fzf-lua/actions.lua
+++ b/lua/fzf-lua/actions.lua
@@ -196,7 +196,7 @@ local sel_to_qf = function(selected, opts, is_loclist)
     local file = path.entry_to_file(selected[i], opts)
     local text = selected[i]:match(":%d+:%d?%d?%d?%d?:?(.*)$")
     table.insert(qf_list, {
-      filename = file.bufname or file.path,
+      filename = file.bufname or file.path or file.uri,
       lnum = file.line,
       col = file.col,
       text = text,


### PR DESCRIPTION
I think I might have found a bug here. Basically if you pass in or transform (with `opts._fmt.from`) a quickfix entry into a uri you can end up getting a broken quickfix list entry that won't open the buffer you want when selected.

## How I found this bug and how to reproduce

1. Trigger [sel_to_qf](https://github.com/milogert/fzf-lua/blob/e5380beb412b6024364544de3e64bd7af107e48f/lua/fzf-lua/actions.lua#L193-L193) with an entry list that looks like `{ "octo://ibhagwan/fzf-lua/issues/1098" }`
2. That calls [path.entry_to_file](https://github.com/milogert/fzf-lua/blob/e5380beb412b6024364544de3e64bd7af107e48f/lua/fzf-lua/path.lua#L372-L372)
3. On https://github.com/milogert/fzf-lua/blob/e5380beb412b6024364544de3e64bd7af107e48f/lua/fzf-lua/path.lua#L396-L396 it will determine that it _is_ a URI and also doesn't not have a `bufnr`.
4. [path.entry_to_location](https://github.com/milogert/fzf-lua/blob/e5380beb412b6024364544de3e64bd7af107e48f/lua/fzf-lua/path.lua#L351-L351) gets called and returns a table with neither `filename` nor `path` in it.
5. `path.entry_to_file` returns that table.
6. Back up the stack fzf-lua checks for _just_ `filename` or `path` here https://github.com/milogert/fzf-lua/blob/main/lua/fzf-lua/actions.lua#L199-L199.
7. See bug. Your quickfix list will show an entry that looks something like `|1 col 1|` instead of `octo://ibhagwan/fzf-lua/issues/1098|1 col 1|`