### PR TITLE
fix(fzf-vim): Guard check if fzf_colors is a table

### DIFF
--- a/lua/fzf-lua/profiles/fzf-vim.lua
+++ b/lua/fzf-lua/profiles/fzf-vim.lua
@@ -99,6 +99,10 @@ return {
     ["--layout"] = false,
   },
   fzf_colors = (function()
+    if type(vim.g.fzf_colors) ~= "table" then
+      return vim.g.fzf_colors
+    end
+
     return vim.tbl_map(function(v)
       local new_v = { v[1], { v[2] } }
       for i = 3, #v do


### PR DESCRIPTION
By default, `vim.g.fzf_colors` is not defined and `vim.tbl_map` requires a table.