### PR TITLE
fix: don't trigger autocmds when closing FZF window

### DIFF
--- a/lua/fzf-lua/win.lua
+++ b/lua/fzf-lua/win.lua
@@ -942,7 +942,7 @@ function FzfWin:close(fzf_bufnr)
     pcall(vim.api.nvim_win_close, self.fzf_winid, true)
   end
   if self.fzf_bufnr and vim.api.nvim_buf_is_valid(self.fzf_bufnr) then
-    vim.api.nvim_buf_delete(self.fzf_bufnr, { force = true })
+    util.nvim_buf_delete(self.fzf_bufnr, { force = true })
   end
   -- when using `split = "belowright new"` closing the fzf
   -- window may not always return to the correct source win


### PR DESCRIPTION
This fixes a small bug when using Airline and showing buffers in the tabline, which listens to `BufUnload` to decide whether to show or hide the tabline.

For example when the tabline is configured to only appear with a minimum of 2 buffers, and exactly 2 buffers are open, the tabline disappears after closing an FZF window, because the code in Airline naively assumes that the count of buffers is reduced by 1 on every `BufUnload` [1].

[1] https://github.com/vim-airline/vim-airline/blob/d9f42cb46710e31962a9609939ddfeb0685dd779/autoload/airline/extensions/tabline/autoshow.vim#L31

### Notes

- Yes, I'll switch to `lualine.nvim` soon :sweat_smile: 
- There are a couple of other direct calls to `vim.api.nvim_buf_delete`, but I haven't run into problems with them yet. Maybe they should all use `util.nvim_buf_delete`?