### PR TITLE
fix(previewer): set initial layout for FZF previewer

### DIFF
--- a/lua/fzf-lua/previewer/fzf.lua
+++ b/lua/fzf-lua/previewer/fzf.lua
@@ -1,3 +1,4 @@
+local core = require "fzf-lua.core"
 local path = require "fzf-lua.path"
 local shell = require "fzf-lua.shell"
 local utils = require "fzf-lua.utils"
@@ -23,7 +24,7 @@ function Previewer.base:new(o, opts)
 end
 
 function Previewer.base:preview_window(_)
-  return nil
+  return core.preview_window(self.opts)
 end
 
 function Previewer.base:_preview_offset()


### PR DESCRIPTION
### Summary

The FZF previewer now supports flex layout too and reacts to resize events, but we also need to set the initial layout according to the configuration.

### How to reproduce

1. Use the `bat` previewer and a custom layout, e.g.:

    ```lua
        preview = {
          default = 'bat',
          hidden = 'hidden',
          vertical = 'up:60%',
          horizontal = 'right:50%',
        },
    ```

1. Run `:FzfLua files`
1. The preview should be hidden, but is shown by default. When resizing the window the layout corrects itself.

This can also be seen when using the builtin previewer by default, and a provider that still uses the FZF previewer such as `git_status`.