### PR TITLE
feat: Filter marks with regex string

### DIFF
--- a/README.md
+++ b/README.md
@@ -1280,6 +1280,12 @@ require'fzf-lua'.setup {
     -- severity_limit:  keep any equal or more severe (lower)
     -- severity_bound:  keep any equal or less severe (higher)
   },
+  marks = {
+    marks = "", -- filter vim marks with a lua pattern
+    -- for example if you want to only show user defined marks
+    -- you would set this option as %a this would match characters from [A-Za-z]
+    -- or if you want to show only numbers you would set the pattern to %d (0-9).
+  },
   complete_path = {
     cmd          = nil, -- default: auto detect fd|rg|find
     complete     = { ["default"] = actions.complete },

--- a/lua/fzf-lua/providers/nvim.lua
+++ b/lua/fzf-lua/providers/nvim.lua
@@ -192,19 +192,18 @@ M.marks = function(opts)
   opts = config.normalize_opts(opts, "marks")
   if not opts then return end
 
-  local marks = vim.fn.execute(
-    string.format("marks %s", opts.marks and opts.marks or ""))
+  local marks = vim.fn.execute("marks")
   marks = vim.split(marks, "\n")
 
   local entries = {}
-  local filter = opts.marks and vim.split(opts.marks, "")
+  local pattern = opts.marks and opts.marks or ""
   for i = #marks, 3, -1 do
     local mark, line, col, text = marks[i]:match("(.)%s+(%d+)%s+(%d+)%s+(.*)")
     col = tostring(tonumber(col) + 1)
     if path.is_absolute(text) then
       text = path.HOME_to_tilde(text)
     end
-    if not filter or vim.tbl_contains(filter, mark) then
+    if not pattern or string.match(mark, pattern) then
       table.insert(entries, string.format(" %-15s %15s %15s %s",
         utils.ansi_codes.yellow(mark),
         utils.ansi_codes.blue(line),


### PR DESCRIPTION
# Better mark filter
This PR, addresses two things one is a bug, where if you defined a mark inside your config file and it was not present in nvim at the moment of the search it would throw an error, the second one is the usage of lua patterns to match the marks and make it more user friendly to filter unwanted marks:

## The bug
```lua
-- the culprit is this call:
vim.fn.execute("marks %s")
```

![image](https://github.com/ibhagwan/fzf-lua/assets/29936954/34c09add-1f17-406a-823c-fcfd91dd0e04)
![image](https://github.com/ibhagwan/fzf-lua/assets/29936954/ad486031-f307-4005-b8ba-f735fb771b2b)
![example_bug](https://github.com/ibhagwan/fzf-lua/assets/29936954/0abf62ff-eda1-41b0-8155-e8713cec20da)

## Mark filtering
As of now the logic for filtering is to put a string of individual characters, to match only the marks you wan't, this works, but if you need a more complex solution your config file may end up like this:
![image](https://github.com/ibhagwan/fzf-lua/assets/29936954/be197dcb-e7cf-4614-be37-d9f56be6dfb7)

When instead it could look like this:
![image](https://github.com/ibhagwan/fzf-lua/assets/29936954/1a4d0f37-75b3-4f5e-b3ff-5e2dc02a3f2c)

And finally here's an example of the feature in action:

![Screenshot 2024-04-14 161536](https://github.com/ibhagwan/fzf-lua/assets/29936954/e1da99ee-8ff9-4dbc-9ecd-dd7a13dbf782)

