### PR TITLE
feat(highlights)!: new hlgroups for paths line|col

### DIFF
--- a/README.md
+++ b/README.md
@@ -1345,9 +1345,10 @@ temporarily overridden by its corresponding `winopts` option:
 |FzfLuaHelpBorder       |FzfLuaBorder |`hls.help_border`   |Help win border|
 |FzfLuaHeaderBind  |*BlanchedAlmond   |`hls.header_bind`   |Header keybind|
 |FzfLuaHeaderText  |*Brown1           |`hls.header_text`   |Header text|
+|FzfLuaPathColNr   |*CadetBlue3       |`hls.path_colnr`    |Path col nr (`lines|qf|lsp|diag`)|
+|FzfLuaPathLineNr  |*MediumSpringGreen|`hls.path_linenr`   |Path line nr (`lines|qf|lsp|diag`)|
 |FzfLuaBufName     |*LightMagenta     |`hls.buf_name`      |Buffer name (`lines`)|
 |FzfLuaBufNr       |*BlanchedAlmond   |`hls.buf_nr`        |Buffer number (all buffers)|
-|FzfLuaBufLineNr   |*MediumSpringGreen|`hls.buf_linenr`    |Buffer line (`lines`)|
 |FzfLuaBufFlagCur  |*Brown1           |`hls.buf_flag_cur`  |Buffer line (`buffers`)|
 |FzfLuaBufFlagAlt  |*CadetBlue1       |`hls.buf_flag_alt`  |Buffer line (`buffers`)|
 |FzfLuaTabTitle    |*LightSkyBlue1    |`hls.tab_title`     |Tab title (`tabs`)|

--- a/lua/fzf-lua/defaults.lua
+++ b/lua/fzf-lua/defaults.lua
@@ -424,6 +424,7 @@ M.defaults.quickfix             = {
   fzf_opts    = { ["--multi"] = true },
   _actions    = function() return M.globals.actions.files end,
   only_valid  = false,
+  _cached_hls = { "path_colnr", "path_linenr" },
 }
 
 M.defaults.quickfix_stack       = {
@@ -444,6 +445,7 @@ M.defaults.loclist              = {
   fzf_opts    = { ["--multi"] = true },
   _actions    = function() return M.globals.actions.files end,
   only_valid  = false,
+  _cached_hls = { "path_colnr", "path_linenr" },
 }
 
 M.defaults.loclist_stack        = {
@@ -468,7 +470,7 @@ M.defaults.buffers              = {
   fzf_opts              = { ["--tiebreak"] = "index", ["--multi"] = true },
   _actions              = function() return M.globals.actions.buffers end,
   actions               = { ["ctrl-x"] = { fn = actions.buf_del, reload = true } },
-  _cached_hls           = { "buf_nr", "buf_flag_cur", "buf_flag_alt" },
+  _cached_hls           = { "buf_nr", "buf_flag_cur", "buf_flag_alt", "path_linenr" },
 }
 
 M.defaults.tabs                 = {
@@ -513,7 +515,7 @@ M.defaults.lines                = {
     ["alt-q"]   = actions.buf_sel_to_qf,
     ["alt-l"]   = actions.buf_sel_to_ll
   },
-  _cached_hls      = { "buf_name", "buf_nr", "buf_linenr" },
+  _cached_hls      = { "buf_name", "buf_nr", "path_linenr" },
 }
 
 M.defaults.blines               = {
@@ -537,7 +539,7 @@ M.defaults.blines               = {
     ["alt-q"]   = actions.buf_sel_to_qf,
     ["alt-l"]   = actions.buf_sel_to_ll
   },
-  _cached_hls      = { "buf_name", "buf_nr", "buf_linenr" },
+  _cached_hls      = { "buf_name", "buf_nr", "path_linenr" },
 }
 
 M.defaults.tags                 = {
@@ -661,6 +663,7 @@ M.defaults.lsp                  = {
   async_or_timeout = 5000,
   fzf_opts         = { ["--multi"] = true },
   _actions         = function() return M.globals.actions.files end,
+  _cached_hls      = { "path_colnr", "path_linenr" },
 }
 
 M.defaults.lsp.symbols          = {
@@ -729,7 +732,7 @@ M.defaults.lsp.symbols          = {
   },
   _actions         = function() return M.globals.actions.files end,
   actions          = { ["ctrl-g"] = { actions.sym_lsym } },
-  _cached_hls      = { "live_sym" },
+  _cached_hls      = { "live_sym", "path_colnr", "path_linenr" },
 }
 
 M.defaults.lsp.finder           = {
@@ -762,6 +765,7 @@ M.defaults.lsp.finder           = {
     { "incoming_calls",  prefix = utils.ansi_codes.cyan("in  ") },
     { "outgoing_calls",  prefix = utils.ansi_codes.yellow("out ") },
   },
+  _cached_hls = { "path_colnr", "path_linenr" },
 }
 
 M.defaults.lsp.code_actions     = {
@@ -783,6 +787,7 @@ M.defaults.diagnostics          = {
   multiline   = true,
   fzf_opts    = { ["--multi"] = true },
   _actions    = function() return M.globals.actions.files end,
+  _cached_hls = { "path_colnr", "path_linenr" },
   -- signs = {
   --   ["Error"] = { text = "e", texthl = "DiagnosticError" },
   --   ["Warn"]  = { text = "w", texthl = "DiagnosticWarn" },
@@ -967,6 +972,7 @@ M.defaults.dap                  = {
       ["--delimiter"] = "[\\]:]",
       ["--with-nth"]  = "2..",
     },
+    _cached_hls = { "path_colnr", "path_linenr" },
   },
 }
 
@@ -1020,9 +1026,10 @@ M.defaults.__HLS                = {
   scrollfloat_f  = "FzfLuaScrollFloatFull",
   header_bind    = "FzfLuaHeaderBind",
   header_text    = "FzfLuaHeaderText",
+  path_colnr     = "FzfLuaPathColNr",
+  path_linenr    = "FzfLuaPathLineNr",
   buf_name       = "FzfLuaBufName",
   buf_nr         = "FzfLuaBufNr",
-  buf_linenr     = "FzfLuaBufLineNr",
   buf_flag_cur   = "FzfLuaBufFlagCur",
   buf_flag_alt   = "FzfLuaBufFlagAlt",
   tab_title      = "FzfLuaTabTitle",

--- a/lua/fzf-lua/init.lua
+++ b/lua/fzf-lua/init.lua
@@ -72,13 +72,15 @@ function M.setup_highlights(override)
       { default = default, fg = is_light and "MediumSpringGreen" or "BlanchedAlmond" } },
     { "FzfLuaHeaderText", "header_text",
       { default = default, fg = is_light and "Brown4" or "Brown1" } },
+    { "FzfLuaPathColNr", "path_colnr",   -- lines|blines|qf|diag|lsp
+      { default = default, fg = is_light and "CadetBlue4" or "CadetBlue1" } },
+    { "FzfLuaPathLineNr", "path_linenr", -- lines|blines|qf|diag|lsp
+      { default = default, fg = is_light and "MediumSpringGreen" or "LightGreen" } },
     { "FzfLuaLiveSym", "live_sym",
       { default = default, fg = is_light and "Brown4" or "Brown1" } },
     -- Provider specific highlights
     { "FzfLuaBufName", "buf_name",        -- lines|blines (hidden)
       { default = default, fg = is_light and "DarkOrchid3" or "LightMagenta" } },
-    { "FzfLuaBufLineNr", "buf_linenr",    -- lines|blines
-      { default = default, fg = is_light and "MediumSpringGreen" or "MediumSpringGreen" } },
     { "FzfLuaBufNr", "buf_nr",            -- buffers|tabs|lines|blines
       { default = default, fg = is_light and "AquaMarine3" or "BlanchedAlmond" } },
     { "FzfLuaBufFlagCur", "buf_flag_cur", -- buffers|tabs

--- a/lua/fzf-lua/make_entry.lua
+++ b/lua/fzf-lua/make_entry.lua
@@ -246,13 +246,17 @@ end
 
 M.lcol = function(entry, opts)
   if not entry then return nil end
+  local hl_colnr = vim.tbl_contains(opts._cached_hls or {}, "path_colnr")
+      and opts.hls.path_colnr or "blue"
+  local hl_linenr = vim.tbl_contains(opts._cached_hls or {}, "path_linenr")
+      and opts.hls.path_linenr or "green"
   local filename = entry.filename or vim.api.nvim_buf_get_name(entry.bufnr)
   return string.format("%s:%s:%s:%s%s",
     -- uncomment to test URIs
     -- "file://" .. filename,
     filename, --utils.ansi_codes.magenta(filename),
-    utils.ansi_codes.green(tostring(entry.lnum)),
-    utils.ansi_codes.blue(tostring(entry.col)),
+    utils.ansi_codes[hl_linenr](tostring(entry.lnum)),
+    utils.ansi_codes[hl_colnr](tostring(entry.col)),
     entry.text and #entry.text > 0 and " " or "",
     not entry.text and "" or
     (opts and opts.trim_entry and vim.trim(entry.text)) or entry.text)

--- a/lua/fzf-lua/providers/buffers.lua
+++ b/lua/fzf-lua/providers/buffers.lua
@@ -129,7 +129,9 @@ local function gen_buffer_entry(opts, buf, max_bufnr, cwd)
     bufname = path.shorten(bufname, tonumber(opts.path_shorten))
   end
   -- add line number
-  bufname = ("%s:%s"):format(bufname, buf.info.lnum > 0 and buf.info.lnum or "")
+  if buf.info.lnum > 0 and not opts.no_lnum then
+    bufname = bufname .. ":" .. utils.ansi_codes[opts.hls.path_linenr](tostring(buf.info.lnum))
+  end
   if buf.flag == "%" then
     flags = utils.ansi_codes[opts.hls.buf_flag_cur](buf.flag) .. flags
   elseif buf.flag == "#" then
@@ -283,7 +285,7 @@ M.buffer_lines = function(opts)
             buficon or "",
             buficon and utils.nbsp or "",
             utils.ansi_codes[opts.hls.buf_name](bufname),
-            utils.ansi_codes[opts.hls.buf_linenr](tostring(lnum)),
+            utils.ansi_codes[opts.hls.path_linenr](tostring(lnum)),
             data[lnum]), co)
         end
       end


### PR DESCRIPTION
New highlight customization requested in discussion #1153, `FzfLuaPathLineNr` and `FzfLuaPathColNr`.

Used in the below pickers:
- buffers
- tabs
- lines|blines
- lsp
- diagnostics
- quickfix|loclist