### PR TITLE
feat: nvim-cmp source for `:FzfLua` completion (+docs)

### DIFF
--- a/.luarc.jsonc
+++ b/.luarc.jsonc
@@ -15,7 +15,10 @@
       "$VIMRUNTIME/lua",
       "${3rd}/luv/library",
       "$XDG_DATA_HOME/nvim/lazy/plenary.nvim/lua",
-      "$LOCALAPPDATA/nvim-data/lazy/plenary.nvim/lua"
+      "$LOCALAPPDATA/nvim-data/lazy/plenary.nvim/lua",
+      // For "cmp_src.lua" type resolving
+      "$XDG_DATA_HOME/nvim/lazy/nvim-cmp/lua",
+      "$LOCALAPPDATA/nvim-data/lazy/nvim-cmp/lua"
     ],
     "checkThirdParty": false,
     "maxPreload": 2000,

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ yours too, if you allow it.
 - [Installation](#installation)
 - [Usage](#usage)
   + [Resume](#resume)
+  + [Options](#options)
 - [Commands](#commands)
   + [Buffers and Files](#buffers-and-files)
   + [Search](#search)
@@ -239,6 +240,11 @@ Alternatively, resuming work on a specific provider:
 -- or
 :FzfLua files resume=true
 ```
+
+### Options
+
+**Refer to [OPTIONS](https://github.com/ibhagwan/fzf-lua/blob/main/OPTIONS.md)
+to see detailed usage notes and a comprehensive list of all available options.**
 
 ## Commands
 

--- a/doc/fzf-lua-opts.txt
+++ b/doc/fzf-lua-opts.txt
@@ -1,0 +1,1401 @@
+*fzf-lua-opts.txt*        For Neovim >= 0.8.0       Last change: 2024 April 29
+
+==============================================================================
+Table of Contents                             *fzf-lua-opts-table-of-contents*
+
+General Usage ................................... |fzf-lua-opts-general-usage|
+Setup Options ................................... |fzf-lua-opts-setup-options|
+Global Options ................................. |fzf-lua-opts-global-options|
+Commands ............................................. |fzf-lua-opts-commands|
+Buffers and Files ........................... |fzf-lua-opts-buffers-and-files|
+Search ................................................. |fzf-lua-opts-search|
+Tags ..................................................... |fzf-lua-opts-tags|
+Git ....................................................... |fzf-lua-opts-git|
+LSP/Diagnostics ............................... |fzf-lua-opts-lsp/diagnostics|
+Misc ..................................................... |fzf-lua-opts-misc|
+Neovim API ......................................... |fzf-lua-opts-neovim-api|
+nvim-dap ............................................. |fzf-lua-opts-nvim-dap|
+tmux ..................................................... |fzf-lua-opts-tmux|
+Completion Functions ..................... |fzf-lua-opts-completion-functions|
+
+==============================================================================
+NOTE: THIS DOCUMENT IS CURRENTLY WIP*fzf-lua-opts-note:-this-document-is-currently-wip*
+
+
+**This document does not yet contain all of fzf-lua's options, there are a lot
+of esoteric and undocumented options which can be found in issues/discussions
+which I will slowly but surely add to this document.**
+
+
+==============================================================================
+FZF-LUA COMMANDS AND OPTIONS       *fzf-lua-opts-fzf-lua-commands-and-options*
+
+
+- General Usage <#general-usage>
+- Setup Options <#setup-options>
+- Global Options <#global-options>
+- Commands <#commands> + Buffers and Files <#buffers-and-files> + Search
+  <#search> + Tags <#tags> + Git <#git> + LSP | Diagnostics <#lspdiagnostics>
+  + Misc <#misc> + Neovim API <#neovim-api> + `nvim-dap` <#nvim-dap> + `tmux`
+  <#tmux> + Completion Functions <#completion-functions>
+
+------------------------------------------------------------------------------
+GENERAL USAGE                                     *fzf-lua-opts-general-usage*
+
+
+Options in fzf-lua can be specified in a few different ways:
+
+- Global setup options
+- Provider-defaults setup options
+- Provider-specific setup options
+- Command call options
+Most of fzf-lua's options are applicable in all of the above, a few examples
+below:
+
+Global setup, applies to all fzf-lua interfaces:
+
+>lua
+    -- Places the floating window at the bottom left corner
+    require("fzf-lua").setup({ winopts = { row = 1, col = 0 } })
+<
+Disable `file_icons` globally (files, grep, etc) via provider defaults setup
+options:
+
+>lua
+    require("fzf-lua").setup({ defaults = { file_icons = false } })
+<
+Disable `file_icons` in `files` only via provider specific setup options:
+
+>lua
+    require("fzf-lua").setup({ files = { file_icons = false } })
+<
+Disable `file_icons` in `files`, applies to this call only:
+
+>lua
+    :lua require("fzf-lua").files({ file_icons = false  })
+    -- Or
+    :FzfLua files file_icons=false
+<
+Fzf-lua conviniently enables setting lua tables recursively using dotted keys,
+for exmaple, if we wanted to call `files` in "split" mode (instead of the
+default floating window), we would normally call:
+
+>lua
+    :lua require("fzf-lua").files({ winopts = { split = "belowright new" } })
+<
+But we can also use the dotted key format (unique to fzf-lua):
+
+>lua
+    :lua require("fzf-lua").files({ ["winopts.split"] = "belowright new" })
+<
+This makes it possible to send nested lua values via the `:FzfLua` user
+command:
+
+>lua
+    -- Escape spaces with \
+    :FzfLua files winopts.split=belowright\ new
+<
+Lua string serialization is also possible:
+
+>lua
+    -- Places the floating window at the top left corner
+    :FzfLua files winopts={row=0,col=0}
+<
+
+------------------------------------------------------------------------------
+SETUP OPTIONS                                     *fzf-lua-opts-setup-options*
+
+
+Most of fzf-lua's options are global, meaning they can be specified in any of
+the different ways explained in General Usage <#general-usage> and are
+described in detail in the Global Options <#global-options> section below.
+
+There are however a few options that can be specified only during the call to
+`setup`, these are described below.
+
+
+                                                                              
+setup.nbsp                                           *fzf-lua-opts-setup.nbsp*
+
+Type: `string`, Default: `nil`
+
+Fzf-lua uses a special invisible unicode character `EN SPACE` (U+2002) as text
+delimiter.
+
+It is not recommended to modify this value as this can have uninteded
+consequnces when entries contain the character designated as `nbsp`, but if
+your terminal/font does not support `EN_SPACE` you can use `NBSP` (U+00A0)
+instead:
+
+>lua
+    require("fzf-lua").setup({ nbsp = "\xc2\xa0" })
+<
+
+                                                                              
+setup.winopts.preview.default     *fzf-lua-opts-setup.winopts.preview.default*
+
+Type: `string|function|object`, Default: `builtin`
+
+Default previewer for file pickers, possible values `builtin|bat|cat|head`,
+for example:
+
+>lua
+    require("fzf-lua").setup({ winopts = { preview = { default = "bat" } } })
+<
+If set to a `function` the return value will be used (`string|object`).
+
+If set to an `object`, fzf-lua expects a previewer class that will be
+initlaized with `object:new(...)`, see the advanced Wiki "Neovim builtin
+previewer" section for more info.
+
+
+------------------------------------------------------------------------------
+GLOBAL OPTIONS                                   *fzf-lua-opts-global-options*
+
+
+Globals are options that aren't picker-specific and can be used with all
+fzf-lua commands, for example, positioning the floating window at the bottom
+line using `globals.winopts.row`:
+
+  The `globals` prefix denotates the scope of the option and is therefore
+  omitted
+
+Using `FzfLua` user command:
+
+>lua
+    :FzfLua files winopts.row=1
+<
+Using Lua:
+
+>lua
+    :lua require("fzf-lua").files({ winopts = { row = 1 } })
+    -- Using the recursive option format
+    :lua require("fzf-lua").files({ ["winopts.row"] = 1 })
+<
+
+                                                                              
+globals.cwd                                         *fzf-lua-opts-globals.cwd*
+
+Type: `string`, Default: `nil`
+
+Sets the current working directory.
+
+
+                                                                              
+globals.query                                     *fzf-lua-opts-globals.query*
+
+Type: `string`, Default: `nil`
+
+Initial query (prompt text), passed to fzf as `--query` flag.
+
+
+                                                                              
+globals.prompt                                   *fzf-lua-opts-globals.prompt*
+
+Type: `string`, Default: `nil`
+
+Fzf prompt, passed to fzf as `--prompt` flag.
+
+
+                                                                              
+globals.header                                   *fzf-lua-opts-globals.header*
+
+Type: `string|false`, Default: `nil`
+
+Header line, set to any string to display a header line, set to `false` to
+disable fzf-lua interactive headers (e.g. "ctrl-g to disable .gitignore",
+etc), passed to fzf as `--header` flag.
+
+
+                                                                              
+globals.previewer                             *fzf-lua-opts-globals.previewer*
+
+Type: `string`, Default: `nil`
+
+Previewer override, set to `false` to disable the previewer.
+
+By default files pickers use the "builtin" previewer, possible values for file
+pickers `bat|cat|head`.
+
+Other overrides include:
+
+>lua
+    :FzfLua helptags previewer=help_native
+    :FzfLua manpages previewer=man_native
+<
+
+                                                                              
+globals.file_icons                           *fzf-lua-opts-globals.file_icons*
+
+Type: `boolean`, Default: `true`
+
+If available, add devicons to files.
+
+
+                                                                              
+globals.git_icons                             *fzf-lua-opts-globals.git_icons*
+
+Type: `boolean`, Default: `true`
+
+If inside a git-repo add git status indicator icons e.g. `M` for modified
+files.
+
+
+                                                                              
+globals.color_icons                         *fzf-lua-opts-globals.color_icons*
+
+Type: `boolean`, Default: `true`
+
+Add coloring of file|git icons.
+
+
+                                                                              
+globals.winopts.split                     *fzf-lua-opts-globals.winopts.split*
+
+Type: `string`, Default: `nil`
+
+Neovim split command to use for fzf-lua interface, e.g `belowright new`.
+
+
+                                                                              
+globals.winopts.col                         *fzf-lua-opts-globals.winopts.col*
+
+Type: `number`, Default: `0.55`
+
+Screen column where to place the fzf-lua float window, between 0-1 will
+represent precentage of `vim.o.columns` (0: leftmost, 1: rightmost), if >= 1
+will attempt to place the float in the exact screen column.
+
+
+                                                                              
+globals.winopts.row                         *fzf-lua-opts-globals.winopts.row*
+
+Type: `number`, Default: `0.35`
+
+Screen row where to place the fzf-lua float window, between 0-1 will represent
+precentage of `vim.o.lines` (0: top, 1: bottom), if >= 1 will attempt to place
+the float in the exact screen line.
+
+
+                                                                              
+globals.winopts.width                     *fzf-lua-opts-globals.winopts.width*
+
+Type: `number`, Default: `0.80`
+
+Width of the fzf-lua float, between 0-1 will represent precentage of
+`vim.o.columns` (1: max width), if >= 1 will use fixed number of columns.
+
+
+                                                                              
+globals.winopts.height                   *fzf-lua-opts-globals.winopts.height*
+
+Type: `number`, Default: `0.85`
+
+Height of the fzf-lua float, between 0-1 will represent precentage of
+`vim.o.lines` (1: max height), if >= 1 will use fixed number of lines.
+
+
+                                                                              
+globals.winopts.border                   *fzf-lua-opts-globals.winopts.border*
+
+Type: `string|table`, Default: `rounded`
+
+Border of the fzf-lua float, possible values are
+`none|single|double|rounded|thicc|thiccc|thicccc` or a custom border character
+array passed as is to `nvim_open_win`.
+
+
+                                                                              
+globals.winopts.fullscreen           *fzf-lua-opts-globals.winopts.fullscreen*
+
+Type: `fullscreen`, Default: `false`
+
+Use fullscreen for the fzf-load floating window.
+
+
+                                                                              
+globals.winopts.on_create             *fzf-lua-opts-globals.winopts.on_create*
+
+Type: `function`, Default: `nil`
+
+Callback after the creation of the fzf-lua main terminal window.
+
+
+                                                                              
+globals.winopts.preview.delay     *fzf-lua-opts-globals.winopts.preview.delay*
+
+Type: `number`, Default: `100`
+
+Debounce time (miliseconds) for displaying the preview buffer in the builtin
+previewer.
+
+
+                                                                              
+globals.winopts.preview.wrap       *fzf-lua-opts-globals.winopts.preview.wrap*
+
+Type: `string`, Default: `nowrap`
+
+Line wrap in both native fzf and the builtin previewer, mapped to fzf's
+`--preview-window:[no]wrap` flag.
+
+
+                                                                              
+globals.winopts.preview.hidden   *fzf-lua-opts-globals.winopts.preview.hidden*
+
+Type: `string`, Default: `nohidden`
+
+Preview startup visibility in both native fzf and the builtin previewer,
+mapped to fzf's `--preview-window:[no]hidden` flag.
+
+  **NOTE**: this is different than setting `previewer=false` which disables the
+  previewer altogether with no toggle ability.
+
+
+                                                                              
+globals.winopts.preview.border   *fzf-lua-opts-globals.winopts.preview.border*
+
+Type: `string`, Default: `border`
+
+Preview border for native fzf previewers (i.e. `bat`, `git_status`), set to
+`noborder` to hide the preview border, consult `man fzf` for all vailable
+options.
+
+
+                                                                              
+globals.winopts.preview.layout   *fzf-lua-opts-globals.winopts.preview.layout*
+
+Type: `string`, Default: `flex`
+
+Preview layout, possible values are `horizontal|vertical|flex`, when set to
+`flex` neovim width is tested against `winopts.preview.flip_columns`, when <=
+`vertical` is used, otherwise `horizontal`.
+
+
+                                                                              
+globals.winopts.preview.flip_columns*fzf-lua-opts-globals.winopts.preview.flip_columns*
+
+Type: `number`, Default: `120`
+
+Auto-detect the preview layout based on available widht, see above note in
+`winopts.preview.layout`.
+
+
+                                                                              
+globals.winopts.preview.horizontal*fzf-lua-opts-globals.winopts.preview.horizontal*
+
+Type: `string`, Default: `right:60%`
+
+Horizontal preview layout, mapped to fzf's `--preview-window:...` flag.
+
+<sub><sup>*Requires `winopts.preview.layout={horizontal|flex}`</sup></sub>
+
+
+                                                                              
+globals.winopts.preview.vertical*fzf-lua-opts-globals.winopts.preview.vertical*
+
+Type: `string`, Default: `down:45%`
+
+Vertical preview layout, mapped to fzf's `--preview-window:...` flag.
+
+<sub><sup>*Requires `winopts.preview.layout={vertical|flex}`</sup></sub>
+
+
+                                                                              
+globals.winopts.preview.title     *fzf-lua-opts-globals.winopts.preview.title*
+
+Type: `boolean`, Default: `true`
+
+Controls title display in the builtin previewer.
+
+
+                                                                              
+globals.winopts.preview.title_pos*fzf-lua-opts-globals.winopts.preview.title_pos*
+
+Type: `string`, Default: `center`
+
+Controls title display in the builtin previewer, possible values are
+`left|right|center`.
+
+
+                                                                              
+globals.winopts.preview.scrollbar*fzf-lua-opts-globals.winopts.preview.scrollbar*
+
+Type: `string|boolean`, Default: `float`
+
+Scrollbar style in the builtin previewer, set to `false` to disable, possible
+values are `float|border`.
+
+
+                                                                              
+globals.winopts.preview.scrolloff*fzf-lua-opts-globals.winopts.preview.scrolloff*
+
+Type: `number`, Default: `-2`
+
+Float style scrollbar offset from the right edge of the preview window.
+
+<sub><sup>*Requires `winopts.preview.scrollbar=float`</sup></sub>
+
+
+                                                                              
+globals.winopts.preview.scrollchars*fzf-lua-opts-globals.winopts.preview.scrollchars*
+
+Type: `table`, Default: `{'█', '' }`
+
+Border style scrollbar characters `{ <full>, <empty> }`.
+
+<sub><sup>*Requires `winopts.preview.scrollbar=border`</sup></sub>
+
+
+                                                                              
+globals.winopts.preview.winopts.number*fzf-lua-opts-globals.winopts.preview.winopts.number*
+
+Type: `boolean`, Default: `true`
+
+Builtin previewer buffer local option, see `:help 'number'`.
+
+
+                                                                              
+globals.winopts.preview.winopts.relativenumber*fzf-lua-opts-globals.winopts.preview.winopts.relativenumber*
+
+Type: `boolean`, Default: `false`
+
+Builtin previewer buffer local option, see `:help 'relativenumber'`.
+
+
+                                                                              
+globals.winopts.preview.winopts.cursorline*fzf-lua-opts-globals.winopts.preview.winopts.cursorline*
+
+Type: `boolean`, Default: `true`
+
+Builtin previewer buffer local option, see `:help 'cursorline'`.
+
+
+                                                                              
+globals.winopts.preview.winopts.cursorcolumn*fzf-lua-opts-globals.winopts.preview.winopts.cursorcolumn*
+
+Type: `boolean`, Default: `false`
+
+Builtin previewer buffer local option, see `:help 'cursorcolumn'`.
+
+
+                                                                              
+globals.winopts.preview.winopts.cursorlineopt*fzf-lua-opts-globals.winopts.preview.winopts.cursorlineopt*
+
+Type: `string`, Default: `both`
+
+Builtin previewer buffer local option, see `:help 'cursorlineopt'`.
+
+
+                                                                              
+globals.winopts.preview.winopts.signcolumn*fzf-lua-opts-globals.winopts.preview.winopts.signcolumn*
+
+Type: `string`, Default: `no`
+
+Builtin previewer buffer local option, see `:help 'signcolumn'`.
+
+
+                                                                              
+globals.winopts.preview.winopts.list*fzf-lua-opts-globals.winopts.preview.winopts.list*
+
+Type: `boolean`, Default: `false`
+
+Builtin previewer buffer local option, see `:help 'list'`.
+
+
+                                                                              
+globals.winopts.preview.winopts.foldenable*fzf-lua-opts-globals.winopts.preview.winopts.foldenable*
+
+Type: `boolean`, Default: `false`
+
+Builtin previewer buffer local option, see `:help 'foldenable'`.
+
+
+                                                                              
+globals.winopts.preview.winopts.foldmethod*fzf-lua-opts-globals.winopts.preview.winopts.foldmethod*
+
+Type: `string`, Default: `manual`
+
+Builtin previewer buffer local option, see `:help 'foldmethod'`.
+
+
+                                                                              
+globals.winopts.preview.winopts.scrolloff*fzf-lua-opts-globals.winopts.preview.winopts.scrolloff*
+
+Type: `number`, Default: `1`
+
+Builtin previewer buffer local option, see `:help 'scrolloff'`.
+
+
+                                                                              
+globals.hls.normal                           *fzf-lua-opts-globals.hls.normal*
+
+Type: `string`, Default: `FzfLuaNormal`
+
+Main fzf (terminal) window normal (text/bg) highlight group.
+
+
+                                                                              
+globals.hls.border                           *fzf-lua-opts-globals.hls.border*
+
+Type: `string`, Default: `FzfLuaBorder`
+
+Main fzf (terminal) window border highlight group.
+
+
+                                                                              
+globals.hls.title                             *fzf-lua-opts-globals.hls.title*
+
+Type: `string`, Default: `FzfLuaTitle`
+
+Main fzf (terminal) window title highlight group.
+
+
+                                                                              
+globals.hls.preview_normal           *fzf-lua-opts-globals.hls.preview_normal*
+
+Type: `string`, Default: `FzfLuaPreviewNormal`
+
+Builtin previewer window normal (text/bg) highlight group.
+
+
+                                                                              
+globals.hls.preview_border           *fzf-lua-opts-globals.hls.preview_border*
+
+Type: `string`, Default: `FzfLuaPreviewBorder`
+
+Builtin previewer window border highlight group.
+
+
+                                                                              
+globals.hls.preview_title             *fzf-lua-opts-globals.hls.preview_title*
+
+Type: `string`, Default: `FzfLuaPreviewTitle`
+
+Builtin previewer window title highlight group.
+
+
+                                                                              
+globals.hls.cursor                           *fzf-lua-opts-globals.hls.cursor*
+
+Type: `string`, Default: `FzfLuaCursor`
+
+Builtin previewer window `Cursor` highlight group.
+
+
+                                                                              
+globals.hls.cursorline                   *fzf-lua-opts-globals.hls.cursorline*
+
+Type: `string`, Default: `FzfLuaCursorLine`
+
+Builtin previewer window `CursorLine` highlight group.
+
+
+                                                                              
+globals.hls.cursorlinenr               *fzf-lua-opts-globals.hls.cursorlinenr*
+
+Type: `string`, Default: `FzfLuaCursorLineNr`
+
+Builtin previewer window `CursorLineNr` highlight group.
+
+
+                                                                              
+globals.hls.search                           *fzf-lua-opts-globals.hls.search*
+
+Type: `string`, Default: `FzfLuaSearch`
+
+Builtin previewer window search matches highlight group.
+
+
+                                                                              
+globals.hls.scrollborder_e           *fzf-lua-opts-globals.hls.scrollborder_e*
+
+Type: `string`, Default: `FzfLuaScrollBorderEmpty`
+
+Builtin previewer window `border` scrollbar empty highlight group.
+
+
+                                                                              
+globals.hls.scrollborder_f           *fzf-lua-opts-globals.hls.scrollborder_f*
+
+Type: `string`, Default: `FzfLuaScrollBorderFull`
+
+Builtin previewer window `border` scrollbar full highlight group.
+
+
+                                                                              
+globals.hls.scrollfloat_e             *fzf-lua-opts-globals.hls.scrollfloat_e*
+
+Type: `string`, Default: `FzfLuaScrollFloatEmpty`
+
+Builtin previewer window `float` scrollbar empty highlight group.
+
+
+                                                                              
+globals.hls.scrollfloat_f             *fzf-lua-opts-globals.hls.scrollfloat_f*
+
+Type: `string`, Default: `FzfLuaScrollFloatFull`
+
+Builtin previewer window `float` scrollbar full highlight group.
+
+
+                                                                              
+globals.hls.help_normal                 *fzf-lua-opts-globals.hls.help_normal*
+
+Type: `string`, Default: `FzfLuaHelpNormal`
+
+Help window (F1) normal (text/bg) highlight group.
+
+
+                                                                              
+globals.hls.help_border                 *fzf-lua-opts-globals.hls.help_border*
+
+Type: `string`, Default: `FzfLuaHelpBorder`
+
+Help window (F1) border highlight group.
+
+
+                                                                              
+globals.hls.header_bind                 *fzf-lua-opts-globals.hls.header_bind*
+
+Type: `string`, Default: `FzfLuaHeaderBind`
+
+Interactive headers keybind highlight group, e.g. `<ctrl-g> to Disable
+.gitignore`.
+
+
+                                                                              
+globals.hls.header_text                 *fzf-lua-opts-globals.hls.header_text*
+
+Type: `string`, Default: `FzfLuaHeaderText`
+
+Interactive headers description highlight group, e.g. `<ctrl-g> to Disable
+.gitignore`.
+
+
+                                                                              
+globals.hls.path_linenr                 *fzf-lua-opts-globals.hls.path_linenr*
+
+Type: `string`, Default: `FzfLuaPathLineNr`
+
+Highlight group for the line part of paths, e.g. `file:<line>:<col>:`, used in
+pickers such as `bufers`, `lines`, `quickfix`, `lsp`, `diagnostics`, etc.
+
+
+                                                                              
+globals.hls.path_colnr                   *fzf-lua-opts-globals.hls.path_colnr*
+
+Type: `string`, Default: `FzfLuaPathColNr`
+
+Highlight group for the column part of paths, e.g. `file:<line>:<col>:`, used
+in pickers such as `bufers`, `lines`, `quickfix`, `lsp`, `diagnostics`, etc.
+
+
+                                                                              
+globals.hls.buf_name                       *fzf-lua-opts-globals.hls.buf_name*
+
+Type: `string`, Default: `FzfLuaBufName`
+
+Highlight group for buffer name in `lines`.
+
+
+                                                                              
+globals.hls.buf_nr                           *fzf-lua-opts-globals.hls.buf_nr*
+
+Type: `string`, Default: `FzfLuaBufNr`
+
+Highlight group for buffer number in buffer type pickers, i.e. `buffers`,
+`tabs`, `lines`.
+
+
+                                                                              
+globals.hls.buf_flag_cur               *fzf-lua-opts-globals.hls.buf_flag_cur*
+
+Type: `string`, Default: `FzfLuaBufFlagCur`
+
+Highlight group for the current buffer flag in `buffers`, `tabs`.
+
+
+                                                                              
+globals.hls.buf_flag_alt               *fzf-lua-opts-globals.hls.buf_flag_alt*
+
+Type: `string`, Default: `FzfLuaBufFlagAlt`
+
+Highlight group for the alternate buffer flag in `buffers`, `tabs`.
+
+
+                                                                              
+globals.hls.tab_title                     *fzf-lua-opts-globals.hls.tab_title*
+
+Type: `string`, Default: `FzfLuaTabTitle`
+
+Highlight group for the tab title in `tabs`.
+
+
+                                                                              
+globals.hls.tab_marker                   *fzf-lua-opts-globals.hls.tab_marker*
+
+Type: `string`, Default: `FzfLuaTabMarker`
+
+Highlight group for the current tab marker in `tabs`.
+
+
+                                                                              
+globals.hls.dir_icon                       *fzf-lua-opts-globals.hls.dir_icon*
+
+Type: `string`, Default: `FzfLuaDirIcon`
+
+Highlight group for the directory icon in paths that end with a separator,
+usually used in path completion, e.g. `complete_path`.
+
+
+                                                                              
+globals.hls.live_sym                       *fzf-lua-opts-globals.hls.live_sym*
+
+Type: `string`, Default: `FzfLuaLiveSym`
+
+Highlight group for the matched characters in `lsp_live_workspace_symbols`.
+
+
+------------------------------------------------------------------------------
+COMMANDS                                               *fzf-lua-opts-commands*
+
+
+
+                                                                              
+BUFFERS AND FILES                             *fzf-lua-opts-buffers-and-files*
+
+
+                                                                              
+buffers                                                 *fzf-lua-opts-buffers*
+
+Open buffers
+
+
+                                                                              
+tabs                                                       *fzf-lua-opts-tabs*
+
+Open buffers in tabs
+
+
+                                                                              
+oldfiles                                               *fzf-lua-opts-oldfiles*
+
+File history (output of `:oldfiles`)
+
+
+                                                                              
+quickfix                                               *fzf-lua-opts-quickfix*
+
+Quickfix list (output of `:copen`)
+
+
+                                                                              
+quickfix_stack                                   *fzf-lua-opts-quickfix_stack*
+
+Quickfix list history (output of `:chistory`)
+
+
+                                                                              
+loclist                                                 *fzf-lua-opts-loclist*
+
+Location list (output of `:lopen`)
+
+
+                                                                              
+loclist_stack                                     *fzf-lua-opts-loclist_stack*
+
+Location list history (output of `:lhistory`)
+
+
+                                                                              
+blines                                                   *fzf-lua-opts-blines*
+
+Current buffer lines
+
+
+                                                                              
+lines                                                     *fzf-lua-opts-lines*
+
+Open buffers lines
+
+
+                                                                              
+args                                                       *fzf-lua-opts-args*
+
+Neovim's argument list (output of `:args`)
+
+
+args.files_only                                 *fzf-lua-opts-args.files_only*
+
+Type: `boolean`, Default: `true`
+
+Exclude non-file entries (directories).
+
+
+                                                                              
+files                                                     *fzf-lua-opts-files*
+
+Files finder, will enumrate the filesystem of the current working directory
+using `fd`, `rg` and `grep` or `dir.exe`.
+
+
+files.cwd_prompt                               *fzf-lua-opts-files.cwd_prompt*
+
+Type: `boolean`, Default: `true`
+
+Display the current working directory in the prompt (`fzf.vim` style).
+
+
+files.cwd_prompt_shorten_len       *fzf-lua-opts-files.cwd_prompt_shorten_len*
+
+Type: `number`, Default: `32`
+
+Prompt over this length will be shortened, e.g. `~/.config/nvim/lua/` will be
+shortened to `~/.c/n/lua/` (for more info see `:help pathshorten`).
+
+<sub><sup>*Requires `cwd_prompt=true`</sup></sub>
+
+
+files.cwd_prompt_shorten_val       *fzf-lua-opts-files.cwd_prompt_shorten_val*
+
+Type: `number`, Default: `1`
+
+Length of shortened prompt path parts, e.g. set to `2`, `~/.config/nvim/lua/`
+will be shortened to `~/.co/nv/lua/` (for more info see `:help pathshorten`).
+
+<sub><sup>*Requires `cwd_prompt=true`</sup></sub>
+
+
+                                                                              
+SEARCH                                                   *fzf-lua-opts-search*
+
+
+                                                                              
+grep                                                       *fzf-lua-opts-grep*
+
+Search for strings/regexes using `rg`, `grep` or any other compatible grep'er
+binary (e.g. `ag`).
+
+Unless `search=...` is specified will prompt for the search string.
+
+
+                                                                              
+live_grep                                             *fzf-lua-opts-live_grep*
+
+Search for strings/regexes using `rg`, `grep` or any other compatible grep'er
+binary (e.g. `ag`).
+
+Unlike `grep` which uses a fixed search string/regex each keypress generates a
+new underlying grep command with the prompt input text, this can be more
+performant on large monorepos to narrow down the result set before switching
+to fuzzy matching with `ctrl-g` for further refinement.
+
+
+                                                                              
+live_grep_native                               *fzf-lua-opts-live_grep_native*
+
+Performant "live" grep variant piping the underlying command directly to fzf
+(without any processing by fzf-lua), disables all the bells and whistles
+(icons, path manipulation, etc).
+
+
+                                                                              
+live_grep_glob                                   *fzf-lua-opts-live_grep_glob*
+
+"Live" grep variant with add support for `rg --iglob` flag, use the default
+separator `--` to specify globs, for exmaple, `pcall -- *.lua !*spec*` will
+search for `pcall` in any lua file that doesn't contain `spec`.
+
+
+                                                                              
+live_grep_resume                               *fzf-lua-opts-live_grep_resume*
+
+Alias to `:FzfLua live_grep resume=true`
+
+
+                                                                              
+grep_project                                       *fzf-lua-opts-grep_project*
+
+Alias to `:FzfLua grep search=""`, feeds all lines of the project into fzf for
+fuzzy matching.
+
+**NOTE**: on large monorepos feeding all lines of the project into fzf isn't
+very efficient, consider using `live_grep` first with a regex to narrow down
+the result set and then switch to fuzzy finding for further refinement by
+pressing `ctrl-g`.
+
+
+                                                                              
+grep_last                                             *fzf-lua-opts-grep_last*
+
+Alias to `:FzfLua grep resume=true`
+
+
+                                                                              
+grep_cword                                           *fzf-lua-opts-grep_cword*
+
+Grep word under cursor
+
+
+                                                                              
+grep_cWORD                                           *fzf-lua-opts-grep_cword*
+
+Grep WORD under cursor
+
+
+                                                                              
+grep_visual                                         *fzf-lua-opts-grep_visual*
+
+Grep visual selection
+
+
+                                                                              
+grep_curbuf                                         *fzf-lua-opts-grep_curbuf*
+
+Grep on current buffer only
+
+
+                                                                              
+lgrep_curbuf                                       *fzf-lua-opts-lgrep_curbuf*
+
+"Live" grep on current buffer only
+
+
+                                                                              
+TAGS                                                       *fzf-lua-opts-tags*
+
+
+                                                                              
+tags                                                       *fzf-lua-opts-tags*
+
+Search project ctags
+
+
+                                                                              
+btags                                                     *fzf-lua-opts-btags*
+
+Search current buffer ctags
+
+
+                                                                              
+tags_grep                                             *fzf-lua-opts-tags_grep*
+
+"Grep" for tags, see `grep` for more info.
+
+
+                                                                              
+tags_live_grep                                   *fzf-lua-opts-tags_live_grep*
+
+"Live-Grep" for tags, see `live_grep` for more info.
+
+
+                                                                              
+tags_grep_cword                                 *fzf-lua-opts-tags_grep_cword*
+
+Tags-Grep word under cursor
+
+
+                                                                              
+tags_grep_cWORD                                 *fzf-lua-opts-tags_grep_cword*
+
+Tags-Grep WORD under cursor
+
+
+                                                                              
+tags_grep_visual                               *fzf-lua-opts-tags_grep_visual*
+
+Tags-Grep visual selection
+
+
+                                                                              
+GIT                                                         *fzf-lua-opts-git*
+
+
+                                                                              
+git_files                                             *fzf-lua-opts-git_files*
+
+Git files
+
+
+                                                                              
+git_status                                           *fzf-lua-opts-git_status*
+
+Git status
+
+
+                                                                              
+git_commits                                         *fzf-lua-opts-git_commits*
+
+Git commits (project)
+
+
+                                                                              
+git_bcommits                                       *fzf-lua-opts-git_bcommits*
+
+Git commits (buffer)
+
+
+                                                                              
+git_branches                                       *fzf-lua-opts-git_branches*
+
+Git branches
+
+
+                                                                              
+git_tags                                               *fzf-lua-opts-git_tags*
+
+Git tags
+
+
+                                                                              
+git_stash                                             *fzf-lua-opts-git_stash*
+
+Git stashes
+
+
+                                                                              
+LSP/DIAGNOSTICS                                 *fzf-lua-opts-lsp/diagnostics*
+
+
+                                                                              
+lsp_references                                   *fzf-lua-opts-lsp_references*
+
+LSP references
+
+
+                                                                              
+lsp_definitions                                 *fzf-lua-opts-lsp_definitions*
+
+LSP Definitions
+
+
+                                                                              
+lsp_declarations                               *fzf-lua-opts-lsp_declarations*
+
+LSP Declarations
+
+
+                                                                              
+lsp_typedefs                                       *fzf-lua-opts-lsp_typedefs*
+
+LSP Type Definitions
+
+
+                                                                              
+lsp_implementations                         *fzf-lua-opts-lsp_implementations*
+
+LSP Implementations
+
+
+                                                                              
+lsp_document_symbols                       *fzf-lua-opts-lsp_document_symbols*
+
+LSP Document Symbols
+
+
+                                                                              
+lsp_workspace_symbols                     *fzf-lua-opts-lsp_workspace_symbols*
+
+LSP Workspace Symbols
+
+
+                                                                              
+lsp_live_workspace_symbols           *fzf-lua-opts-lsp_live_workspace_symbols*
+
+LSP Workspace Symbols "live" query
+
+
+                                                                              
+lsp_incoming_calls                           *fzf-lua-opts-lsp_incoming_calls*
+
+LSP Incoming Calls
+
+
+                                                                              
+lsp_outgoing_calls                           *fzf-lua-opts-lsp_outgoing_calls*
+
+LSP Outgoing Calls
+
+
+                                                                              
+lsp_code_actions                               *fzf-lua-opts-lsp_code_actions*
+
+LSP Code Actions
+
+
+                                                                              
+lsp_finder                                           *fzf-lua-opts-lsp_finder*
+
+All LSP locations, combined view
+
+
+                                                                              
+lsp_document_diagnostics               *fzf-lua-opts-lsp_document_diagnostics*
+
+Document Diagnostics (alias to `diagnostics_document`)
+
+
+                                                                              
+lsp_workspace_diagnostics             *fzf-lua-opts-lsp_workspace_diagnostics*
+
+Workspace Diagnostics (alias to `diagnostics_workspace`)
+
+
+                                                                              
+diagnostics_document                       *fzf-lua-opts-diagnostics_document*
+
+Document Diagnostics
+
+
+                                                                              
+diagnostics_workspace                     *fzf-lua-opts-diagnostics_workspace*
+
+Workspace Diagnostics
+
+
+lsp.async_or_timeout                       *fzf-lua-opts-lsp.async_or_timeout*
+
+Type: `number|boolean`, Default: `5000`
+
+Whether LSP calls are made block, set to `true` for asynchronous, otherwise
+defines the timeout (ms) for the LPS request via `vim.lsp.buf_request_sync`.
+
+
+                                                                              
+MISC                                                       *fzf-lua-opts-misc*
+
+
+                                                                              
+resume                                                   *fzf-lua-opts-resume*
+
+Resume last command/query
+
+
+                                                                              
+builtin                                                 *fzf-lua-opts-builtin*
+
+fzf-lua builtin commands
+
+
+                                                                              
+profiles                                               *fzf-lua-opts-profiles*
+
+Fzf-lua configuration profiles
+
+
+                                                                              
+helptags                                               *fzf-lua-opts-helptags*
+
+Search Helptags
+
+
+                                                                              
+manpages                                               *fzf-lua-opts-manpages*
+
+Search man pages
+
+
+                                                                              
+colorschemes                                       *fzf-lua-opts-colorschemes*
+
+Installed colorschemes
+
+
+                                                                              
+awesome_colorschemes                       *fzf-lua-opts-awesome_colorschemes*
+
+"Awesome Neovim" colorschemes
+
+
+                                                                              
+highlights                                           *fzf-lua-opts-highlights*
+
+Neovim's highlight groups
+
+
+                                                                              
+commands                                               *fzf-lua-opts-commands*
+
+Neovim commands
+
+
+                                                                              
+command_history                                 *fzf-lua-opts-command_history*
+
+Executed command history
+
+
+                                                                              
+search_history                                   *fzf-lua-opts-search_history*
+
+Search history
+
+
+                                                                              
+marks                                                     *fzf-lua-opts-marks*
+
+Search `:marks`
+
+
+                                                                              
+jumps                                                     *fzf-lua-opts-jumps*
+
+Search `:jumps`
+
+
+                                                                              
+changes                                                 *fzf-lua-opts-changes*
+
+Search `:changes`
+
+
+                                                                              
+registers                                             *fzf-lua-opts-registers*
+
+Search `:registers`
+
+
+                                                                              
+tagstack                                               *fzf-lua-opts-tagstack*
+
+Search `:tags`
+
+
+                                                                              
+autocmds                                               *fzf-lua-opts-autocmds*
+
+Neovim's autocmds
+
+
+                                                                              
+keymaps                                                 *fzf-lua-opts-keymaps*
+
+Neovims key mappings
+
+
+                                                                              
+filetypes                                             *fzf-lua-opts-filetypes*
+
+Filetypes
+
+
+                                                                              
+menus                                                     *fzf-lua-opts-menus*
+
+Neovim's menus
+
+
+                                                                              
+spell_suggest                                     *fzf-lua-opts-spell_suggest*
+
+Spelling suggestions
+
+
+                                                                              
+packadd                                                 *fzf-lua-opts-packadd*
+
+`:packadd <package>`
+
+
+                                                                              
+setup_highlights                               *fzf-lua-opts-setup_highlights*
+
+Setup/Reset fzf-lua highlight groups.
+
+
+                                                                              
+setup_fzfvim_cmds                             *fzf-lua-opts-setup_fzfvim_cmds*
+
+Setup `fzf.vim` user commands mapped to their fzf-lua equivalents (e.g.
+`:Files`, `:Rg`, etc).
+
+
+                                                                              
+NEOVIM API                                           *fzf-lua-opts-neovim-api*
+
+
+                                                                              
+register_ui_select                           *fzf-lua-opts-register_ui_select*
+
+Register fzf-lua as the UI interface for `vim.ui.select`
+
+
+                                                                              
+deregister_ui_select                       *fzf-lua-opts-deregister_ui_select*
+
+De-register fzf-lua with `vim.ui.select`
+
+
+                                                                              
+NVIM-DAP                                               *fzf-lua-opts-nvim-dap*
+
+
+                                                                              
+dap_commands                                       *fzf-lua-opts-dap_commands*
+
+DAP builtin commands
+
+
+                                                                              
+dap_configurations                           *fzf-lua-opts-dap_configurations*
+
+DAP configurations
+
+
+                                                                              
+dap_breakpoints                                 *fzf-lua-opts-dap_breakpoints*
+
+DAP breakpoints
+
+
+                                                                              
+dap_variables                                     *fzf-lua-opts-dap_variables*
+
+DAP active session variables
+
+
+                                                                              
+dap_frames                                           *fzf-lua-opts-dap_frames*
+
+DAP active session jump to frame
+
+
+                                                                              
+TMUX                                                       *fzf-lua-opts-tmux*
+
+
+                                                                              
+tmux_buffers                                       *fzf-lua-opts-tmux_buffers*
+
+Tmux paste buffers
+
+
+                                                                              
+COMPLETION FUNCTIONS                       *fzf-lua-opts-completion-functions*
+
+
+                                                                              
+complete_path                                     *fzf-lua-opts-complete_path*
+
+Complete path under cursor (incl dirs)
+
+
+                                                                              
+complete_file                                     *fzf-lua-opts-complete_file*
+
+Complete file under cursor (excl dirs)
+
+
+                                                                              
+complete_line                                     *fzf-lua-opts-complete_line*
+
+Complete line (all open buffers)
+
+
+                                                                              
+complete_bline                                   *fzf-lua-opts-complete_bline*
+
+Complete line (current buffer only)
+
+
+vim:tw=78:ts=8:ft=help:norl:

--- a/lua/fzf-lua/cmp_src.lua
+++ b/lua/fzf-lua/cmp_src.lua
@@ -1,0 +1,102 @@
+local Src = {}
+
+Src.new = function(_)
+  local self = setmetatable({}, {
+    __index = Src,
+  })
+  return self
+end
+
+---Return whether this source is available in the current context or not (optional).
+---@return boolean
+function Src:is_available()
+  local mode = vim.api.nvim_get_mode().mode:sub(1, 1)
+  return mode == "c" and vim.fn.getcmdtype() == ":"
+end
+
+---Return the debug name of this source (optional).
+---@return string
+function Src:get_debug_name()
+  return "fzf-lua"
+end
+
+---Invoke completion (required).
+---@param params cmp.SourceCompletionApiParams
+---@param callback fun(response: lsp.CompletionResponse|nil)
+function Src:complete(params, callback)
+  if not params.context.cursor_before_line:match("FzfLua") then
+    return callback()
+  end
+  return callback(require("fzf-lua.cmd")._candidates(params.context.cursor_before_line, true))
+end
+
+---@param completion_item lsp.CompletionItem
+---@return lsp.MarkupContent?
+function Src:_get_documentation(completion_item)
+  local options_md = require("fzf-lua.cmd").options_md()
+  if not options_md or vim.tbl_isempty(options_md) then return end
+  local markdown = options_md[completion_item.label]
+  if not markdown and completion_item.data then
+    -- didn't find matching the label directly, search globals
+    -- this will match "winopts.row" as "globals.winopts.row"
+    markdown = options_md["globals." .. completion_item.label]
+  end
+  if not markdown and completion_item.data and completion_item.data.cmd then
+    -- didn't find matching the label or globals, search provider specific
+    -- e.g. for "cwd_prompt" option we search the dict for "files.cwd_prompt"
+    markdown = options_md[completion_item.data.cmd .. "." .. completion_item.label]
+  end
+  return markdown and { kind = "markdown", value = markdown } or nil
+end
+
+---Resolve completion item (optional).
+-- This is called right before the completion is about to be displayed.
+---Useful for setting the text shown in the documentation window (`completion_item.documentation`).
+---@param completion_item lsp.CompletionItem
+---@param callback fun(completion_item: lsp.CompletionItem|nil)
+function Src:resolve(completion_item, callback)
+  completion_item.documentation = self:_get_documentation(completion_item)
+  callback(completion_item)
+end
+
+function Src._register_cmdline()
+  local ok, cmp = pcall(require, "cmp")
+  if not ok then return end
+  cmp.register_source("FzfLua", Src)
+  Src._registered = true
+  local cmdline_cfg = require("cmp.config").cmdline
+  local has_fzf_lua = false
+  for _, s in ipairs(cmdline_cfg[":"].sources or {}) do
+    if s.name == "FzfLua" then
+      has_fzf_lua = true
+    end
+  end
+  if not has_fzf_lua then
+    if cmdline_cfg[":"] then
+      table.insert(cmdline_cfg[":"].sources or {}, {
+        -- nvim-cmp doesn't support keyword_length=0
+        -- https://github.com/hrsh7th/nvim-cmp/issues/1197#issuecomment-1264605106
+        keyword_length = 1,
+        group_index = 1,
+        name = "FzfLua",
+        option = {}
+      })
+    end
+  end
+end
+
+function Src._complete()
+  if Src._registered then
+    vim.schedule(function()
+      require("cmp").complete({
+        config = {
+          sources = {
+            { name = "FzfLua" }
+          }
+        }
+      })
+    end)
+  end
+end
+
+return Src

--- a/lua/fzf-lua/config.lua
+++ b/lua/fzf-lua/config.lua
@@ -141,9 +141,17 @@ function M.normalize_opts(opts, globals, __resume_key)
 
   -- expand opts that were specified with a dot
   -- e.g. `:FzfLua files winopts.border=single`
-  for k, v in pairs(opts) do
-    if k:match("%.") then
-      utils.map_set(opts, k, v)
+  do
+    -- convert keys only after full iteration or we will
+    -- miss keys due to messing with map ordering
+    local to_convert = {}
+    for k, _ in pairs(opts) do
+      if k:match("%.") then
+        table.insert(to_convert, k)
+      end
+    end
+    for _, k in ipairs(to_convert) do
+      utils.map_set(opts, k, opts[k])
       opts[k] = nil
     end
   end

--- a/lua/fzf-lua/defaults.lua
+++ b/lua/fzf-lua/defaults.lua
@@ -43,7 +43,6 @@ M.defaults                      = {
       title_pos    = "center",
       scrollbar    = "border",
       scrolloff    = "-2",
-      scrollchar   = "",
       scrollchars  = { "█", "" },
       -- default preview delay 100ms, same as native fzf preview
       -- https://github.com/junegunn/fzf/issues/2417#issuecomment-809886535
@@ -1043,8 +1042,8 @@ M.defaults.__HLS                = {
 
 M.defaults.__WINOPTS            = {
   borderchars    = {
-    ["none"]    = { " ", " ", " ", " ", " ", " ", " ", " " },
-    ["solid"]   = { " ", " ", " ", " ", " ", " ", " ", " " },
+    ["none"]    = { "", "", "", "", "", "", "", "" },
+    ["empty"]   = { " ", " ", " ", " ", " ", " ", " ", " " },
     ["single"]  = { "┌", "─", "┐", "│", "┘", "─", "└", "│" },
     ["double"]  = { "╔", "═", "╗", "║", "╝", "═", "╚", "║" },
     ["rounded"] = { "╭", "─", "╮", "│", "╯", "─", "╰", "│" },
@@ -1053,8 +1052,8 @@ M.defaults.__WINOPTS            = {
     ["thicccc"] = { "█", "█", "█", "█", "█", "█", "█", "█" },
   },
   -- border chars reverse lookup for ambiwidth="double"
-  _border2string = {
-    [" "] = "solid",
+  border2string = {
+    [" "] = "empty",
     ["┌"] = "single",
     ["╔"] = "double",
     ["╭"] = "rounded",

--- a/lua/fzf-lua/init.lua
+++ b/lua/fzf-lua/init.lua
@@ -19,14 +19,14 @@ do
 
   local currFile = debug.getinfo(1, "S").source:gsub("^@", "")
   vim.g.fzf_lua_directory = path.normalize(path.parent(currFile))
-  local fzf_lua_root = path.parent(path.parent(vim.g.fzf_lua_directory))
+  vim.g.fzf_lua_root = path.parent(path.parent(vim.g.fzf_lua_directory))
 
   -- Manually source the vimL script containing ':FzfLua' cmd
   -- does nothing if already loaded due to `vim.g.loaded_fzf_lua`
-  source_vimL({ fzf_lua_root, "plugin", "fzf-lua.vim" })
+  source_vimL({ vim.g.fzf_lua_root, "plugin", "fzf-lua.vim" })
   -- Autoload scipts dynamically loaded on `vim.fn[fzf_lua#...]` call
   -- `vim.fn.exists("*fzf_lua#...")` will return 0 unless we manuall source
-  source_vimL({ fzf_lua_root, "autoload", "fzf_lua.vim" })
+  source_vimL({ vim.g.fzf_lua_root, "autoload", "fzf_lua.vim" })
   -- Set var post source as the top of the file `require` will return 0
   -- due to it potentially being loaded before "autoload/fzf_lua.vim"
   utils.__HAS_AUTOLOAD_FNS = vim.fn.exists("*fzf_lua#getbufinfo") == 1
@@ -357,6 +357,7 @@ M._exported_modules = {
 -- excluded from builtin / auto-complete
 M._excluded_meta = {
   "setup",
+  "redraw",
   "fzf",
   "fzf_raw",
   "fzf_wrap",

--- a/lua/fzf-lua/profiles/borderless.lua
+++ b/lua/fzf-lua/profiles/borderless.lua
@@ -6,9 +6,7 @@ return {
   desc       = "borderless and minimalistic",
   fzf_opts   = {},
   winopts    = {
-    -- border  = "none",
-    -- border  = "thicccc",
-    border  = { " ", " ", " ", " ", " ", " ", " ", " " },
+    border  = "none",
     preview = {
       scrollbar = "float",
       scrolloff = "-2",

--- a/lua/fzf-lua/profiles/borderless_full.lua
+++ b/lua/fzf-lua/profiles/borderless_full.lua
@@ -7,7 +7,7 @@ return {
   { "default-title" }, -- base profile
   desc       = "borderless and not so minimalistic",
   winopts    = {
-    border  = { " ", " ", " ", " ", " ", " ", " ", " " },
+    border  = "empty",
     preview = {
       scrollbar = "float",
       scrolloff = "-2",

--- a/lua/fzf-lua/win.lua
+++ b/lua/fzf-lua/win.lua
@@ -276,15 +276,12 @@ local normalize_winopts = function(o)
   -- with "border chars must be one cell", force string border (#874)
   if vim.o.ambiwidth == "double" and type(winopts.border) == "table" then
     local topleft = winopts.border[1]
-    winopts.border = topleft
-        and config.globals.__WINOPTS.border2string[topleft] or "rounded"
+    winopts.border = topleft and config.globals.__WINOPTS.border2string[topleft] or "rounded"
+    winopts._border = winopts.border
   end
 
-  -- We only allow 'none|single|double|rounded'
+  -- We only allow 'none|empty|single|double|rounded|thicc|thiccc|thiccc'
   if type(winopts.border) == "string" then
-    -- save the original string so we can pass it
-    -- to the main fzf window 'nvim_open_win' (#364)
-    winopts._border = winopts.border
     winopts.border = config.globals.__WINOPTS.borderchars[winopts.border] or
         config.globals.__WINOPTS.borderchars["rounded"]
   end
@@ -713,16 +710,6 @@ function FzfWin:redraw_main()
   win_opts.row = winopts.row or math.floor(((lines - win_opts.height) / 2) - 1)
   win_opts.col = winopts.col or math.floor((columns - win_opts.width) / 2)
 
-  -- prioritize using border string argument in `nvim_open_win`
-  if self.winopts._border then
-    win_opts.border = self.winopts._border
-    -- adjust for borderless main window (#364)
-    if self.winopts._border == "none" then
-      win_opts.width = win_opts.width + 2
-      win_opts.height = win_opts.height + 2
-    end
-  end
-
   -- When border chars are empty strings 'nvim_open_win' adjusts
   -- the layout to take all avialable space, we use these to adjust
   -- our main window height to use all available lines (#364)
@@ -1016,11 +1003,6 @@ function FzfWin:update_scrollbar_border(o)
   local hl_f = self.hls.scrollborder_f
   local hl_e = self.hls.scrollborder_e
 
-  -- backward compatibility before 'scrollchar' was a table
-  if type(self.winopts.preview.scrollchar) == "string" and
-      #self.winopts.preview.scrollchar > 0 then
-    scrollchars[1] = self.winopts.preview.scrollchar
-  end
   for i = 1, 2 do
     if not scrollchars[i] or #scrollchars[i] == 0 then
       scrollchars[i] = borderchars[4]

--- a/plugin/fzf-lua.lua
+++ b/plugin/fzf-lua.lua
@@ -1,6 +1,4 @@
-if vim.g.loaded_fzf_lua == 1 then
-  return
-end
+if vim.g.loaded_fzf_lua == 1 then return end
 vim.g.loaded_fzf_lua = 1
 
 -- Should never be called, below nvim 0.7 "plugin/fzf-lua.vim"
@@ -11,82 +9,25 @@ if vim.fn.has("nvim-0.7") ~= 1 then
 end
 
 vim.api.nvim_create_user_command("FzfLua", function(opts)
-  require("fzf-lua.cmd").load_command(unpack(opts.fargs))
+  require("fzf-lua.cmd").run_command(unpack(opts.fargs))
 end, {
   nargs = "*",
   range = true,
   complete = function(_, line)
-    local metatable = require("fzf-lua")
-    local builtin_list = vim.tbl_filter(function(k)
-      return metatable._excluded_metamap[k] == nil
-    end, vim.tbl_keys(metatable))
-
-    local l = vim.split(line, "%s+")
-    local n = #l - 2
-
-    if n == 0 then
-      local commands = vim.tbl_flatten({ builtin_list })
-      table.sort(commands)
-
-      return vim.tbl_filter(function(val)
-        return vim.startswith(val, l[2])
-      end, commands)
-    end
-
-    -- Not all commands have their opts under the same key
-    local function cmd2key(cmd)
-      local cmd2cfg = {
-        {
-          patterns = { "^git_", "^dap", "^tmux_" },
-          transform = function(c) return c:gsub("_", ".") end
-        },
-        {
-          patterns = { "^lsp_code_actions$" },
-          transform = function(_) return "lsp.code_actions" end
-        },
-        { patterns = { "^lsp_.*_symbols$" }, transform = function(_) return "lsp.symbols" end },
-        { patterns = { "^lsp_" },            transform = function(_) return "lsp" end },
-        { patterns = { "^diagnostics_" },    transform = function(_) return "dianostics" end },
-        { patterns = { "^tags" },            transform = function(_) return "tags" end },
-        { patterns = { "grep" },             transform = function(_) return "grep" end },
-        { patterns = { "^complete_bline$" }, transform = function(_) return "complete_line" end },
-      }
-      for _, v in pairs(cmd2cfg) do
-        for _, p in ipairs(v.patterns) do
-          if cmd:match(p) then return v.transform(cmd) end
-        end
-      end
-      return cmd
-    end
-
-    local utils = require("fzf-lua.utils")
-    local defaults = require("fzf-lua.defaults").defaults
-    local cmd_opts = utils.map_get(defaults, cmd2key(l[2])) or {}
-    local opts = vim.tbl_filter(function(k)
-      return not k:match("^_")
-    end, vim.tbl_keys(utils.map_flatten(cmd_opts)))
-
-    -- Add globals recursively, e.g. `winopts.fullscreen`
-    -- will be later retrieved using `utils.map_get(...)`
-    for k, v in pairs({
-      winopts       = false,
-      keymap        = false,
-      fzf_opts      = false,
-      fzf_tmux_opts = false,
-      __HLS         = "hls", -- rename prefix
-    }) do
-      opts = vim.tbl_flatten({ opts, vim.tbl_keys(utils.map_flatten(defaults[k] or {}, v or k)) })
-    end
-
-    -- Add generic options that apply to all pickers
-    for _, o in ipairs({ "query" }) do
-      table.insert(opts, o)
-    end
-
-    table.sort(opts)
-
-    return vim.tbl_filter(function(val)
-      return vim.startswith(val, l[#l])
-    end, opts)
+    -- Workaround to trigger cmp completion at `keyword_length=0`
+    -- doesn't work properly, causes the 2nd+ completion to not
+    -- get called until an additional space is pressed
+    -- https://github.com/hrsh7th/nvim-cmp/discussions/1885
+    -- print("called", #line, line, line:match("%s+$") ~= nil)
+    -- if require("fzf-lua.cmp_src")._registered then
+    --   require("fzf-lua.cmp_src")._complete()
+    -- end
+    return require("fzf-lua.cmd")._candidates(line)
   end,
 })
+
+-- If available register as nvim-cmp source
+local ok, _ = pcall(require, "cmp")
+if ok then
+  require("fzf-lua.cmp_src")._register_cmdline()
+end

--- a/plugin/fzf-lua.vim
+++ b/plugin/fzf-lua.vim
@@ -15,22 +15,11 @@ let g:loaded_fzf_lua = 1
 
 " FzfLua builtin lists
 function! s:fzflua_complete(arg, line, pos) abort
-  let l:builtin_list = luaeval('vim.tbl_filter(
-    \ function(k)
-    \   if require("fzf-lua")._excluded_metamap[k] then
-    \     return false
-    \   end
-    \   return true
-    \ end,
-    \ vim.tbl_keys(require("fzf-lua")))')
-  call sort(l:builtin_list)
-
-  let list = [l:builtin_list]
-  let l = split(a:line[:a:pos-1], '\%(\%(\%(^\|[^\\]\)\\\)\@<!\s\)\+', 1)
-  let n = len(l) - index(l, 'FzfLua') - 2
-
-  return join(list[0],"\n")
+  " Should we use `a:line[:a:pos-1]`?
+  let l:candidates = luaeval('require("fzf-lua.cmd")._candidates("'.a:line.'")')
+  return join(candidates,"\n")
 endfunction
 
 " FzfLua commands with auto-complete
-command! -nargs=* -complete=custom,s:fzflua_complete FzfLua lua require('fzf-lua.cmd').load_command(<f-args>)
+command! -nargs=* -complete=custom,s:fzflua_complete FzfLua
+  \ lua require("fzf-lua.cmd").run_command(<f-args>)


### PR DESCRIPTION
- Documented most of fzf-lua options in "OPTIONS.md"
- Auto-generate "options.txt" vimdoc help file
- Custom `cmp-cmdline` source for `:FzfLua` user command
- Includes cmp docs for all fzf-lua pickers and options
- Auto-inject cmp source when available