### PR TITLE
ref(oldfiles): simpler+faster file-check alternative

### DIFF
--- a/README.md
+++ b/README.md
@@ -1006,7 +1006,9 @@ require'fzf-lua'.setup {
   oldfiles = {
     prompt            = 'History❯ ',
     cwd_only          = false,
-    stat_file         = true,         -- verify files exist on disk
+    -- "stat": verify files exist on disk and are usable files
+    -- true: just check file can be opened
+    check_file        = "stat",
     include_current_session = false,  -- include bufs from current session
   },
   buffers = {

--- a/README.md
+++ b/README.md
@@ -1006,9 +1006,7 @@ require'fzf-lua'.setup {
   oldfiles = {
     prompt            = 'History❯ ',
     cwd_only          = false,
-    -- "stat": verify files exist on disk and are usable files
-    -- true: just check file can be opened
-    check_file        = "stat",
+    stat_file         = true,         -- verify files exist on disk (or fun() for custom check)
     include_current_session = false,  -- include bufs from current session
   },
   buffers = {

--- a/lua/fzf-lua/defaults.lua
+++ b/lua/fzf-lua/defaults.lua
@@ -435,7 +435,7 @@ M.defaults.oldfiles             = {
   file_icons        = true and M._has_devicons,
   color_icons       = true,
   git_icons         = false,
-  check_file        = "stat",
+  stat_file         = true,
   fzf_opts          = { ["--tiebreak"] = "index", ["--multi"] = true },
   _fzf_nth_devicons = true,
   _actions          = function() return M.globals.actions.files end,

--- a/lua/fzf-lua/defaults.lua
+++ b/lua/fzf-lua/defaults.lua
@@ -435,7 +435,7 @@ M.defaults.oldfiles             = {
   file_icons        = true and M._has_devicons,
   color_icons       = true,
   git_icons         = false,
-  stat_file         = true,
+  check_file        = "stat",
   fzf_opts          = { ["--tiebreak"] = "index", ["--multi"] = true },
   _fzf_nth_devicons = true,
   _actions          = function() return M.globals.actions.files end,

--- a/lua/fzf-lua/providers/oldfiles.lua
+++ b/lua/fzf-lua/providers/oldfiles.lua
@@ -14,19 +14,34 @@ M.oldfiles = function(opts)
   if opts.cwd and opts.cwd_only == nil then
     opts.cwd_only = true
   end
+  if opts.stat_file then -- bw-compat
+    opts.check_file = "stat"
+  end
 
   local current_buffer = vim.api.nvim_get_current_buf()
   local current_file = vim.api.nvim_buf_get_name(current_buffer)
   local sess_tbl = {}
   local sess_map = {}
 
+  local is_valid = not opts.check_file or
+      (opts.check_file == "stat" and function(file)
+        local stat = uv.fs_stat(file)
+        return not utils.path_is_directory(file, stat)
+            and not utils.file_is_fifo(file, stat) -- FIFO blocks `fs_open` indefinitely (#908)
+            and utils.file_is_readable(file)
+      end) or (opts.check_file and function(file)
+        local handle = io.open(file, "r")
+        if handle then handle:close() end
+        return handle ~= nil
+      end)
+
   if opts.include_current_session then
     for _, buffer in ipairs(vim.split(vim.fn.execute(":buffers t"), "\n")) do
       local bufnr = tonumber(buffer:match("%s*(%d+)"))
       if bufnr then
         local file = vim.api.nvim_buf_get_name(bufnr)
-        local fs_stat = not opts.stat_file and true or uv.fs_stat(file)
-        if #file > 0 and fs_stat and bufnr ~= current_buffer then
+        local valid = is_valid == true or is_valid(file)
+        if #file > 0 and valid and bufnr ~= current_buffer then
           sess_map[file] = true
           table.insert(sess_tbl, file)
         end
@@ -59,15 +74,8 @@ M.oldfiles = function(opts)
 
       -- local start = os.time(); for _ = 1,10000,1 do
       for _, file in ipairs(vim.v.oldfiles) do
-        local fs_stat = not opts.stat_file and true
-            or (function()
-              local stat = uv.fs_stat(file)
-              return (not utils.path_is_directory(file, stat)
-                -- FIFO blocks `fs_open` indefinitely (#908)
-                and not utils.file_is_fifo(file, stat)
-                and utils.file_is_readable(file))
-            end)()
-        if fs_stat and file ~= current_file and not sess_map[file] then
+        local valid = is_valid == true or is_valid(file)
+        if valid and file ~= current_file and not sess_map[file] then
           add_entry(file, co)
         end
       end


### PR DESCRIPTION
`vim.loop.fs_stat` is many times slower than just trying to open a file. So I added a backward-compatible `check_file` option to `oldfiles` to do just that. But since I'm not sure if the extra `fs_stat` checks have some extra benefits, I kept it as the default.

Also I have no idea how to format the files, so I had to do everything manually, since stylua would change half of the things because the files don't follow the `.stylua.toml` rules.