### PR TITLE
fix: use proper annotations for public APIs

### DIFF
--- a/lua/fzf-lua/core.lua
+++ b/lua/fzf-lua/core.lua
@@ -116,12 +116,12 @@ local contents_from_arr = function(cont_arr)
   return contents
 end
 
----@alias content table|function|string|nil
+---@alias content string[]|fun(fzf_cb: fun(entry?: string))|string|nil
 
 -- Main API, see:
 -- https://github.com/ibhagwan/fzf-lua/wiki/Advanced
 ---@param contents content
----@param opts {fn_reload: string|function, fn_transform: function, __fzf_init_cmd: string, _normalized: boolean}
+---@param opts? {fn_reload: string|function, fn_transform: function, __fzf_init_cmd: string, _normalized: boolean}
 M.fzf_exec = function(contents, opts)
   if type(contents) == "table" and type(contents[1]) == "table" then
     contents = contents_from_arr(contents)
@@ -183,6 +183,8 @@ M.fzf_exec = function(contents, opts)
   return M.fzf_wrap(opts, contents)()
 end
 
+---@param contents fun(query: string): string|string[]|function
+---@param opts? table
 M.fzf_live = function(contents, opts)
   assert(contents)
   opts = opts or {}


### PR DESCRIPTION
Hi, Thanks for a great plugin!

I've been customizing it based on [this page](https://github.com/ibhagwan/fzf-lua/wiki/Advanced), but the annotations in `fzf_exec` seem to be wrong and I want to fix it.
I get ls warnings for fields that should be omissible.

![image](https://github.com/ibhagwan/fzf-lua/assets/82267684/b2cc95f1-ab64-47c6-869d-bd5bc2bdc8d9)

Also, `fzf_live` does not have annotation, so I need to add it.

However, I am concerned that opts is inherently a more complex table.
Should I do it this way? I'm willing to do that work, but where is the list of all the fields?

```lua
---@class fzf_exec_opts
---@field cwd? string
---@field prompt? string
...
```
