### PR TITLE
fix: annotaion for fzf_exec

### DIFF
--- a/lua/fzf-lua/core.lua
+++ b/lua/fzf-lua/core.lua
@@ -116,7 +116,7 @@ local contents_from_arr = function(cont_arr)
   return contents
 end
 
----@alias content string[]|fun(fzf_cb: fun(entry?: string))|string|nil
+---@alias content (string|number)[]|fun(fzf_cb: fun(entry?: string|number, cb?: function))|string|nil
 
 -- Main API, see:
 -- https://github.com/ibhagwan/fzf-lua/wiki/Advanced


### PR DESCRIPTION
If my perception is wrong, please point it out.

- An entry is string or number (just need to be able to apply `table.concat()`).
- `fzf_cb` can receive a callback function as a second argument (optional).
