### PR TITLE
fix: allow setting help str for action tables and/or action.fn

### DIFF
--- a/lua/fzf-lua/win.lua
+++ b/lua/fzf-lua/win.lua
@@ -1371,7 +1371,7 @@ function FzfWin.toggle_help()
     for k, v in pairs(self.actions) do
       if k == "default" then k = "enter" end
       if type(v) == "table" then
-        v = config.get_action_helpstr(v[1]) or v
+        v = v.desc or config.get_action_helpstr(v[1]) or config.get_action_helpstr(v.fn) or v
       elseif v then
         v = config.get_action_helpstr(v) or v
       end


### PR DESCRIPTION
Currently, it's not possible to set a proper description for an action of the form `{ fn = function()end, prefix = ""}`
This PR adds support for getting the action description from the `fn` or if set fom `action.desc`

To be clear, this is for keymap help from something like:

```lua
config.defaults.actions.files["ctrl-t"] = require("trouble.sources.fzf").actions.open -- this is an action table
```