### PR TITLE
fix(win): take border width into account when calculating fractional position

### DIFF
--- a/lua/fzf-lua/win.lua
+++ b/lua/fzf-lua/win.lua
@@ -256,10 +256,10 @@ local normalize_winopts = function(o)
     winopts.relative = nil
   else
     if not winopts.row or winopts.row <= 1 then
-      winopts.row = math.floor((vim.o.lines - winopts.height) * winopts.row)
+      winopts.row = math.floor((vim.o.lines - winopts.height - 2) * winopts.row)
     end
     if not winopts.col or winopts.col <= 1 then
-      winopts.col = math.floor((vim.o.columns - winopts.width) * winopts.col)
+      winopts.col = math.floor((vim.o.columns - winopts.width - 2) * winopts.col)
     end
     winopts.col = math.min(winopts.col, max_width - winopts.width)
     winopts.row = math.min(winopts.row, max_height - winopts.height)


### PR DESCRIPTION
I noticed that the position of the floating window was not completely centered using the config below:

```lua
        winopts = {
          width = 0.8,
          height = 0.8,
          row = 0.5,
          col = 0.5,
        },
```

This PR fixes that.

Initially I thought it was because the border wasn't taken into account, but it isn't.

With the PR the window is now correctly centered with/without borders.