### PR TITLE
fix: when bind is nil

### DIFF
--- a/lua/fzf-lua/core.lua
+++ b/lua/fzf-lua/core.lua
@@ -653,7 +653,7 @@ M.build_fzf_cli = function(opts)
     if expect_binds and #expect_binds > 0 then
       local bind = opts.fzf_opts["--bind"]
       opts.fzf_opts["--bind"] = string.format("%s%s%s",
-        bind, bind and "," or "", table.concat(expect_binds, ","))
+        bind or "", bind and "," or "", table.concat(expect_binds, ","))
     end
   end
   if opts.fzf_opts["--preview-window"] == nil then


### PR DESCRIPTION
To reproduce the bug:
```lua
require("fzf-lua").setup { keymap = { fzf = {} } }
```
then `:FzfLua builtin<cr>` cannot open the float windows.
