### PR TITLE
Remove the unexpected tag

### DIFF
--- a/doc/fzf-lua.txt
+++ b/doc/fzf-lua.txt
@@ -695,7 +695,7 @@ open an issue and I'll be more than happy to help.**
           -- can be used to add custom fzf-lua mappings, e.g:
           --   vim.keymap.set("t", "<C-j>", "<Down>", { silent = true, buffer = true })
         end,
-        -- called once *after* the fzf interface is closed
+        -- called once _after_ the fzf interface is closed
         -- on_close = function() ... end
       },
       keymap = {


### PR DESCRIPTION
Some day I wanted to look up docs for after-directories so I typed `:h after`, and it led me here.