### PR TITLE
fix(lsp): do not prepend `file://` for URIs

### DIFF
--- a/lua/fzf-lua/providers/lsp.lua
+++ b/lua/fzf-lua/providers/lsp.lua
@@ -115,7 +115,7 @@ local function location_handler(opts, cb, _, result, ctx, _)
   -- HACK: make sure target URI is valid for buggy LSPs (#1317)
   for i, x in ipairs(result) do
     for _, k in ipairs({ "uri", "targetUri" }) do
-      if type(x[k]) == "string" and not x[k]:match("file://") then
+      if type(x[k]) == "string" and not x[k]:match("://") then
         result[i][k] = "file://" .. result[i][k]
       end
     end


### PR DESCRIPTION
`gd` on java class files results in error (as shown below) after the recent addition of the workaround for #1317. This is because when jumping to, for example, `java.lang.String` class, jdtls would use a URI in this format: `jdt://contents/java.base/java.lang/String.class...`

The workaround would add `file://` unless the URI matches `file://` and therefore would change the `jdt://...` into `file://jdt://...`. This PR is to make the workaround to prepend `file://` only if the string is not a URI.

Error message before PR change:
```
Error executing Lua callback: .../share/nvim/lazy/lazy.nvim/lua/lazy/core/handler/cmd.lua:48: Vim:Error executing Lua callback: /usr/share/nvim/runtime/lua/vim/lsp/util.lua:1914: index out of range
stack traceback:
	[C]: in function '_str_byteindex_enc'
	/usr/share/nvim/runtime/lua/vim/lsp/util.lua:1914: in function 'locations_to_items'
	...al/share/nvim/lazy/fzf-lua/lua/fzf-lua/providers/lsp.lua:147: in function <...al/share/nvim/lazy/fzf-lua/lua/fzf-lua/providers/lsp.lua:146>
	vim/shared.lua: in function 'tbl_filter'
	...al/share/nvim/lazy/fzf-lua/lua/fzf-lua/providers/lsp.lua:146: in function 'handler'
	...al/share/nvim/lazy/fzf-lua/lua/fzf-lua/providers/lsp.lua:478: in function 'fn_contents'
	...al/share/nvim/lazy/fzf-lua/lua/fzf-lua/providers/lsp.lua:631: in function 'fn'
	...al/share/nvim/lazy/fzf-lua/lua/fzf-lua/providers/lsp.lua:974: in function <...al/share/nvim/lazy/fzf-lua/lua/fzf-lua/providers/lsp.lua:963>
	.../.local/share/nvim/lazy/fzf-lua/lua/fzf-lua/cmd.lua:35: in function 'run_command'
	.../.local/share/nvim/lazy/fzf-lua/plugin/fzf-lua.lua:12: in function <.../.local/share/nvim/lazy/fzf-lua/plugin/fzf-lua.lua:11>
	[C]: in function 'cmd'
	.../share/nvim/lazy/lazy.nvim/lua/lazy/core/handler/cmd.lua:48: in function <.../share/nvim/lazy/lazy.nvim/lua/lazy/core/handler/cmd.lua:16>
stack traceback:
	[C]: in function 'cmd'
	.../share/nvim/lazy/lazy.nvim/lua/lazy/core/handler/cmd.lua:48: in function <.../share/nvim/lazy/lazy.nvim/lua/lazy/core/handler/cmd.lua:16>
```