### PR TITLE
fix: don't replace "accept" in normal query

### DIFF
--- a/lua/fzf-lua/core.lua
+++ b/lua/fzf-lua/core.lua
@@ -586,10 +586,10 @@ M.create_fzf_binds = function(opts)
     -- that meant printing an empty string for the default enter key
     if opts.__FZF_VERSION
         and opts.__FZF_VERSION >= 0.53
-        and action:match("accept")
+        and action:match("accept%s-$")
         and not action:match("print(.-)%+accept")
     then
-      action = action:gsub("accept", "print(enter)+accept")
+      action = action:gsub("accept%s-$", "print(enter)+accept")
     end
     table.insert(tbl, string.format("%s:%s", key, action))
   end


### PR DESCRIPTION
## bug reproduce

fzf-lua's config
```lua
require("fzf-lua").setup {
  actions = { files = { ["ctrl-x"] = { fn = function() end, reload = true } } },
}
```

Then run `:FzfLua live_grep query=acceptxx debug=true<cr>` will fail.

## error log
```
[Fzf-lua]: FZF_DEFAULT_COMMAND: VIMRUNTIME='/usr/share/nvim/runtime' '/usr/bin/nvim' -n --headless --clean --cmd 'lua vim.g.did_load_filetypes=1; loadfile([[/tmp/fzf-lua.tmp/nvim/site/pack/vendor/start/fzf-lua/lua/fzf-lua/libuv.lua]])().spawn_stdio([==[e2RlYnVnID0gdHJ1ZSwgY21kID0gInJnIC0tY29sdW1uIC0tbGluZS1udW1iZXIgLS1uby1oZWFkaW5nIC0tY29sb3I9YWx3YXlzIC0tc21hcnQtY2FzZSAtLW1heC1jb2x1bW5zPTQwOTYgLWUge2FyZ3Z6fSAiLCBnaXRfaWNvbnMgPSBmYWxzZSwgY29sb3JfaWNvbnMgPSB0cnVlLCBnID0ge19memZfbHVhX3NlcnZlciA9ICIvcnVuL3VzZXIvMTAwMC9memYtbHVhLjE3MjEwNjE4NjYuMTMyNDM5LjEiLCBfZGV2aWNvbnNfcGF0aCA9ICIvdG1wL2Z6Zi1sdWEudG1wL252aW0vc2l0ZS9wYWNrL3ZlbmRvci9zdGFydC9udmltLXdlYi1kZXZpY29ucy8ifSwgZmlsZV9pY29ucyA9IHRydWUsIGFyZ3ZfZXhwciA9IHRydWV9]==],[==[cmV0dXJuIHJlcXVpcmUoIm1ha2VfZW50cnkiKS5maWxl]==],[==[cmV0dXJuIHJlcXVpcmUoIm1ha2VfZW50cnkiKS5wcmVwcm9jZXNz]==])' -- 'acceptxx' 2>&1 || true  [Fzf-lua]: fzf cmd: fzf --bind 'alt-a:toggle-all,ctrl-x:unbind(ctrl-x)+execute-silent(VIMRUNTIME='\''/usr/share/nvim/runtime'\'' '\''/usr/bin/nvim'\'' -n --headless --clean --cmd '\''lua vim.g.did_load_filetypes=1; loadfile([[/tmp/fzf-lua.tmp/nvim/site/pack/vendor/start/fzf-lua/lua/fzf-lua/shell_helper.lua]])().rpc_nvim_exec_lua({fzf_lua_server=[[/run/user/1000/fzf-lua.1721061866.132439.1]], fnc_id=3 , debug=true})'\'' -- {+})+reload(VIMRUNTIME='\''/usr/share/nvim/runtime'\'' '\''/usr/bin/nvim'\'' -n --headless --clean --cmd '\''lua vim.g.did_load_filetypes=1; loadfile([[/tmp/fzf-lua.tmp/nvim/site/pack/vendor/start/fzf-lua/lua/fzf-lua/libuv.lua]])().spawn_stdio([==[e2RlYnVnID0gdHJ1ZSwgY21kID0gInJnIC0tY29sdW1uIC0tbGluZS1udW1iZXIgLS1uby1oZWFkaW5nIC0tY29sb3I9YWx3YXlzIC0tc21hcnQtY2FzZSAtLW1heC1jb2x1bW5zPTQwOTYgLWUge2FyZ3Z6fSAiLCBnaXRfaWNvbnMgPSBmYWxzZSwgY29sb3JfaWNvbnMgPSB0cnVlLCBnID0ge19memZfbHVhX3NlcnZlciA9ICIvcnVuL3VzZXIvMTAwMC9memYtbHVhLjE3MjEwNjE4NjYuMTMyNDM5LjEiLCBfZGV2aWNvbnNfcGF0aCA9ICIvdG1wL2Z6Zi1sdWEudG1wL252aW0vc2l0ZS9wYWNrL3ZlbmRvci9zdGFydC9udmltLXdlYi1kZXZpY29ucy8ifSwgZmlsZV9pY29ucyA9IHRydWUsIGFyZ3ZfZXhwciA9IHRydWV9]==],[==[cmV0dXJuIHJlcXVpcmUoIm1ha2VfZW50cnkiKS5maWxl]==],[==[cmV0dXJuIHJlcXVpcmUoIm1ha2VfZW50cnkiKS5wcmVwcm9jZXNz]==])'\'' -- '\''print(enter)+acceptxx'\'' 2>&1),f3:toggle-preview-wrap,load:rebind(ctrl-x),f4:toggle-preview,shift-down:preview-page-down,ctrl-z:abort,ctrl-u:unix-line-discard,alt-shift-up:preview-up,ctrl-f:half-page-down,zero:execute-silent(mkdir '\''/tmp/nvim.phan/ifmAVD/0'\'' && VIMRUNTIME='\''/usr/share/nvim/runtime'\'' '\''/usr/bin/nvim'\'' -n --headless --clean --cmd '\''lua vim.g.did_load_filetypes=1; loadfile([[/tmp/fzf-lua.tmp/nvim/site/pack/vendor/start/fzf-lua/lua/fzf-lua/shell_helper.lua]])().rpc_nvim_exec_lua({fzf_lua_server=[[/run/user/1000/fzf-lua.1721061866.132439.1]], fnc_id=2 , debug=true})'\'' -- ),ctrl-b:half-page-up,alt-shift-down:preview-down,ctrl-a:beginning-of-line,shift-up:preview-page-up,ctrl-e:end-of-line,ctrl-q:print(ctrl-q)+accept,esc:print(esc)+accept,ctrl-g:print(ctrl-g)+accept,ctrl-c:print(ctrl-c)+accept' --height '100%' --layout 'reverse' --multi --highlight-line --preview 'VIMRUNTIME='\''/usr/share/nvim/runtime'\'' '\''/usr/bin/nvim'\'' -n --headless --clean --cmd '\''lua vim.g.did_load_filetypes=1; loadfile([[/tmp/fzf-lua.tmp/nvim/site/pack/vendor/start/fzf-lua/lua/fzf-lua/shell_helper.lua]])().rpc_nvim_exec_lua({fzf_lua_server=[[/run/user/1000/fzf-lua.1721061866.132439.1]], fnc_id=1 , debug=true})'\'' -- {}' --query 'acceptxx' --print-query --header ':: <^[[38;2;255;235;205mctrl-g^[[0m> to ^[[38;2;255;64;64mFuzzy Search^[[0m' --border 'none' --disabled --prompt '*Rg> ' --preview-window 'nohidden:right:0' --ansi --info 'inline-right' --bind='change:reload:VIMRUNTIME='\''/usr/share/nvim/runtime'\'' '\''/usr/bin/nvim'\'' -n --headless --clean --cmd '\''lua vim.g.did_load_filetypes=1; loadfile([[/tmp/fzf-lua.tmp/nvim/site/pack/vendor/start/fzf-lua/lua/fzf-lua/libuv.lua]])().spawn_stdio([==[e2RlYnVnID0gdHJ1ZSwgY21kID0gInJnIC0tY29sdW1uIC0tbGluZS1udW1iZXIgLS1uby1oZWFkaW5nIC0tY29sb3I9YWx3YXlzIC0tc21hcnQtY2FzZSAtLW1heC1jb2x1bW5zPTQwOTYgLWUge2FyZ3Z6fSAiLCBnaXRfaWNvbnMgPSBmYWxzZSwgY29sb3JfaWNvbnMgPSB0cnVlLCBnID0ge19memZfbHVhX3NlcnZlciA9ICIvcnVuL3VzZXIvMTAwMC9memYtbHVhLjE3MjEwNjE4NjYuMTMyNDM5LjEiLCBfZGV2aWNvbnNfcGF0aCA9ICIvdG1wL2Z6Zi1sdWEudG1wL252aW0vc2l0ZS9wYWNrL3ZlbmRvci9zdGFydC9udmltLXdlYi1kZXZpY29ucy8ifSwgZmlsZV9pY29ucyA9IHRydWUsIGFyZ3ZfZXhwciA9IHRydWV9]==],[==[cmV0dXJuIHJlcXVpcmUoIm1ha2VfZW50cnkiKS5maWxl]==],[==[cmV0dXJuIHJlcXVpcmUoIm1ha2VfZW50cnkiKS5wcmVwcm9jZXNz]==])'\'' -- {q} 2>&1 || true' > '/tmp/nvim.phan/ifmAVD/2'
[Fzf-lua] fzf error 2: unknown action: acceptxx' 2>&1)
```


## fix
I guess the `accept` as normal text in `reload()` is mistakenly substituted into `print(enter)+accept` (not sure).
This pr suppose `accept` to be the last args in one actions, so it maybe not work in some edge cases.

Here is a untested idea using lua's `%bxy` pattern maybe helpful.
```lua
if opts.__FZF_VERSION
    and opts.__FZF_VERSION >= 0.53
    and action:match("accept")
    and not action:match("print(.-)%+accept")
then
  local i = 1
  for s, e in action:gmatch('()[^+()]+%b()()') do
    local sub, ok = action:sub(i, s - 1):gsub('accept', 'print(enter)+accept')
    if ok then
      action = action:sub(1, i - 1) .. sub .. action:sub(s, -1)
      i = #action
      break
    end
    i = e + 1
  end
  if i < #action then
    action = action:sub(1, i) .. action:sub(i + 1, -1):gsub('accept', 'print(enter)+accept')
  end
end
```
