### PR TITLE
fix(help-previewer): don't error if no table is found

### DIFF
--- a/lua/fzf-lua/previewer/builtin.lua
+++ b/lua/fzf-lua/previewer/builtin.lua
@@ -971,6 +971,9 @@ end
 
 function Previewer.help_tags:parse_entry(entry_str)
   local tag = entry_str:match("^[^%s]+")
+  if not tag then
+    return {}
+  end
   local vimdoc = entry_str:match(string.format("[^%s]+$", utils.nbsp))
   return {
     htag = tag,


### PR DESCRIPTION
If no tag is found (e.g. the user typed a prompt that no longer shows any results), the following line throws an error

https://github.com/TheLeoP/fzf-lua/blob/af659d93df1b110967f5a41e86b969fbabf858a7/lua/fzf-lua/previewer/builtin.lua#L980

Instad, this PR returns an empty table early if no tag is found