### PR TITLE
feat(lsp): add `unique_line_items` options

### DIFF
--- a/lua/fzf-lua/providers/lsp.lua
+++ b/lua/fzf-lua/providers/lsp.lua
@@ -120,6 +120,19 @@ local function location_handler(opts, cb, _, result, ctx, _)
       end
     end
   end
+  if opts.unique_line_items then
+    local lines = {}
+    local _result = {}
+    for _, loc in ipairs(result) do
+      local uri = loc.uri or loc.targetUri
+      local range = loc.range or loc.targetSelectionRange
+      if not lines[uri .. range.start.line] then
+        _result[#_result + 1] = loc
+        lines[uri .. range.start.line] = true
+      end
+    end
+    result = _result
+  end
   if opts.ignore_current_line then
     local uri = vim.uri_from_bufnr(core.CTX().bufnr)
     local cursor_line = core.CTX().cursor[1] - 1


### PR DESCRIPTION
For example, use `require("fzf-lua").lsp_references`
with `opts.unique_line_items = true`:
![image](https://github.com/user-attachments/assets/e511678e-42bb-4f22-84e9-84a2425c78c4)

with `opts.unique_line_items = false`:
![image](https://github.com/user-attachments/assets/b8f86d0b-a6ca-4bc6-9c33-f48ae432b556)

> This can also be a workaround for https://github.com/LuaLS/lua-language-server/issues/2451.