### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,12 +224,13 @@ which can be easily mapped to:
 nnoremap <c-P> <cmd>lua require('fzf-lua').files()<CR>
 ```
 
-or if using `init.lua`:
+or if using `init.lua` on nvim version 0.7.0 or above (older nvim versions can use `vim.api.nvim_set_keymap` instead):
 ```lua
 vim.keymap.set("n", "<c-P>", require('fzf-lua').files, { desc = "Fzf Files" })
 -- Or, with args
 vim.keymap.set("n", "<c-P>", function() require('fzf-lua').files({ ... }) end, { desc = "Fzf Files" })
 ```
+
 
 ### Resume
 


### PR DESCRIPTION
Example keymapping uses vim.keymap.set, which isn't available until nvim 0.7.0, and requirements state fzf-lua supports nvim >= 0.5, so added a note about possible replacement