### PR TITLE
fix(windows): fully qualify "cmd.exe" (closes #1396)

### DIFF
--- a/lua/fzf-lua/fzf.lua
+++ b/lua/fzf-lua/fzf.lua
@@ -260,7 +260,8 @@ function M.raw_fzf(contents, fzf_cli_args, opts)
   local co = coroutine.running()
   local jobstart = opts.is_fzf_tmux and vim.fn.jobstart or vim.fn.termopen
   local shell_cmd = utils.__IS_WINDOWS
-      and { "cmd", "/d", "/e:off", "/f:off", "/v:off", "/c" }
+      -- MSYS2 comes with "/usr/bin/cmd" that precedes "cmd.exe" (#1396)
+      and { "cmd.exe", "/d", "/e:off", "/f:off", "/v:off", "/c" }
       or { "sh", "-c" }
   if utils.__IS_WINDOWS then
     utils.tbl_join(shell_cmd, cmd)

--- a/lua/fzf-lua/libuv.lua
+++ b/lua/fzf-lua/libuv.lua
@@ -144,7 +144,7 @@ M.spawn = function(opts, fn_transform, fn_done)
 
   -- https://github.com/luvit/luv/blob/master/docs.md
   -- uv.spawn returns tuple: handle, pid
-  local shell = _is_win and "cmd" or "sh"
+  local shell = _is_win and "cmd.exe" or "sh"
   local args = _is_win and { "/d", "/e:off", "/f:off", "/v:on", "/c" } or { "-c" }
   if type(opts.cmd) == "table" then
     if _is_win then


### PR DESCRIPTION
MSYS2 comes with "/usr/bin/cmd", to avoid conflicts we specifically use "cmd.exe".