### PR TITLE
refactor(actions)!: join `{buf|file}_xxx` actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -660,31 +660,19 @@ require'fzf-lua'.setup {
     -- the defaults, to inherit from the defaults change [1] from `false` to `true`
     files = {
       false,          -- do not inherit from defaults
-      -- providers that inherit these actions:
-      --   files, git_files, git_status, grep, lsp
-      --   oldfiles, quickfix, loclist, tags, btags
-      --   args
-      -- default action opens a single selection
-      -- or sends multiple selection to quickfix
-      -- replace the default action with the below
-      -- to open all files whether single or multiple
-      -- ["default"]     = actions.file_edit,
-      ["default"]     = actions.file_edit_or_qf,
+      -- Pickers inheriting these actions:
+      --   files, git_files, git_status, grep, lsp, oldfiles, quickfix, loclist,
+      --   tags, btags, args, buffers, tabs, lines, blines
+      -- `file_edit_or_qf` opens a single selection or sends multiple selection to quickfix
+      -- replace `enter` with `file_edit` to open all files/bufs whether single or multiple
+      -- replace `enter` with `file_switch_or_edit` to attempt a switch in current tab first
+      ["enter"]       = actions.file_edit_or_qf,
       ["ctrl-s"]      = actions.file_split,
       ["ctrl-v"]      = actions.file_vsplit,
       ["ctrl-t"]      = actions.file_tabedit,
       ["alt-q"]       = actions.file_sel_to_qf,
-      ["alt-l"]       = actions.file_sel_to_ll,
+      ["alt-Q"]       = actions.file_sel_to_ll,
     },
-    buffers = {
-      false,          -- do not inherit from defaults
-      -- providers that inherit these actions:
-      --   buffers, tabs, lines, blines
-      ["default"]     = actions.buf_edit,
-      ["ctrl-s"]      = actions.buf_split,
-      ["ctrl-v"]      = actions.buf_vsplit,
-      ["ctrl-t"]      = actions.buf_tabedit,
-    }
   },
   fzf_opts = {
     -- options are sent as `<left>=<right>`
@@ -863,7 +851,7 @@ require'fzf-lua'.setup {
       -- action to toggle `--no-ignore`, requires fd or rg installed
       ["ctrl-g"]         = { actions.toggle_ignore },
       -- uncomment to override `actions.file_edit_or_qf`
-      --   ["default"]   = actions.file_edit,
+      --   ["enter"]     = actions.file_edit,
       -- custom actions are available too
       --   ["ctrl-y"]    = function(selected) print(selected[1]) end,
     }
@@ -913,7 +901,7 @@ require'fzf-lua'.setup {
       -- git-delta is automatically detected as pager, uncomment to disable
       -- preview_pager = false,
       actions = {
-        ["default"] = actions.git_checkout,
+        ["enter"]   = actions.git_checkout,
         -- remove `exec_silent` or set to `false` to exit after yank
         ["ctrl-y"]  = { fn = actions.git_yank_commit, exec_silent = true },
       },
@@ -931,7 +919,7 @@ require'fzf-lua'.setup {
       -- git-delta is automatically detected as pager, uncomment to disable
       -- preview_pager = false,
       actions = {
-        ["default"] = actions.git_buf_edit,
+        ["enter"]   = actions.git_buf_edit,
         ["ctrl-s"]  = actions.git_buf_split,
         ["ctrl-v"]  = actions.git_buf_vsplit,
         ["ctrl-t"]  = actions.git_buf_tabedit,
@@ -943,7 +931,7 @@ require'fzf-lua'.setup {
       cmd      = "git branch --all --color",
       preview  = "git log --graph --pretty=oneline --abbrev-commit --color {1}",
       actions  = {
-        ["default"] = actions.git_switch,
+        ["enter"]   = actions.git_switch,
         ["ctrl-x"]  = { fn = actions.git_branch_del, reload = true },
         ["ctrl-a"]  = { fn = actions.git_branch_add, field_index = "{q}", reload = true },
       },
@@ -962,14 +950,14 @@ require'fzf-lua'.setup {
           .. [[ %(subject) %(color:blue)%(taggername)%(color:reset)" refs/tags]],
       preview  = [[git log --graph --color --pretty=format:"%C(yellow)%h%Creset ]]
           .. [[%Cgreen(%><(12)%cr%><|(12))%Creset %s %C(blue)<%an>%Creset" {1}]],
-      actions  = { ["default"] = actions.git_checkout },
+      actions  = { ["enter"] = actions.git_checkout },
     },
     stash = {
       prompt          = 'Stash> ',
       cmd             = "git --no-pager stash list",
       preview         = "git --no-pager stash show --patch --color {1}",
       actions = {
-        ["default"]   = actions.git_stash_apply,
+        ["enter"]     = actions.git_stash_apply,
         ["ctrl-x"]    = { fn = actions.git_stash_drop, reload = true },
       },
     },
@@ -1057,7 +1045,7 @@ require'fzf-lua'.setup {
     cwd_only          = false,        -- buffers for the cwd only
     cwd               = nil,          -- buffers list for a given dir
     actions = {
-      -- actions inherit from 'actions.buffers' and merge
+      -- actions inherit from 'actions.files' and merge
       -- by supplying a table of functions we're telling
       -- fzf-lua to not close the fzf window, this way we
       -- can resume the buffers picker on the same window
@@ -1072,8 +1060,8 @@ require'fzf-lua'.setup {
     file_icons        = true,         -- show file icons (true|"devicons"|"mini")?
     color_icons       = true,         -- colorize file|git icons
     actions = {
-      -- actions inherit from 'actions.buffers' and merge
-      ["default"]     = actions.buf_switch,
+      -- actions inherit from 'actions.files' and merge
+      ["enter"]       = actions.buf_switch,
       ["ctrl-x"]      = { fn = actions.buf_del, reload = true },
     },
     fzf_opts = {
@@ -1096,9 +1084,9 @@ require'fzf-lua'.setup {
       ["--tiebreak"]  = 'index',
       ["--tabstop"]   = "1",
     },
-    -- actions inherit from 'actions.buffers' and merge
+    -- actions inherit from 'actions.files' and merge
     actions = {
-      ["default"]     = actions.buf_edit_or_qf,
+      ["enter"]       = actions.buf_edit_or_qf,
       ["alt-q"]       = actions.buf_sel_to_qf,
       ["alt-l"]       = actions.buf_sel_to_ll
     },
@@ -1116,9 +1104,9 @@ require'fzf-lua'.setup {
       ["--tiebreak"]  = 'index',
       ["--tabstop"]   = "1",
     },
-    -- actions inherit from 'actions.buffers' and merge
+    -- actions inherit from 'actions.files' and merge
     actions = {
-      ["default"]     = actions.buf_edit_or_qf,
+      ["enter"]       = actions.buf_edit_or_qf,
       ["alt-q"]       = actions.buf_sel_to_qf,
       ["alt-l"]       = actions.buf_sel_to_ll
     },
@@ -1157,7 +1145,7 @@ require'fzf-lua'.setup {
   colorschemes = {
     prompt            = 'Colorschemes❯ ',
     live_preview      = true,       -- apply the colorscheme on preview?
-    actions           = { ["default"] = actions.colorscheme },
+    actions           = { ["enter"] = actions.colorscheme },
     winopts           = { height = 0.55, width = 0.30, },
     -- uncomment to ignore colorschemes names (lua patterns)
     -- ignore_patterns   = { "^delek$", "^blue$" },
@@ -1178,7 +1166,7 @@ require'fzf-lua'.setup {
       ["--tiebreak"]  = "index",
     },
     actions           = {
-      ["default"] = actions.colorscheme,
+      ["enter"]   = actions.colorscheme,
       ["ctrl-g"]  = { fn = actions.toggle_bg, exec_silent = true },
       ["ctrl-r"]  = { fn = actions.cs_update, reload = true },
       ["ctrl-x"]  = { fn = actions.cs_delete, reload = true },
@@ -1195,7 +1183,7 @@ require'fzf-lua'.setup {
     -- set `ignore_patterns = false` to disable filtering
     ignore_patterns   = { "^<SNR>", "^<Plug>" },
     actions           = {
-      ["default"]     = actions.keymap_apply,
+      ["enter"]       = actions.keymap_apply,
       ["ctrl-s"]      = actions.keymap_split,
       ["ctrl-v"]      = actions.keymap_vsplit,
       ["ctrl-t"]      = actions.keymap_tabedit,
@@ -1338,7 +1326,7 @@ require'fzf-lua'.setup {
   },
   complete_path = {
     cmd          = nil, -- default: auto detect fd|rg|find
-    complete     = { ["default"] = actions.complete },
+    complete     = { ["enter"] = actions.complete },
   },
   complete_file = {
     cmd          = nil, -- default: auto detect rg|fd|find
@@ -1346,7 +1334,7 @@ require'fzf-lua'.setup {
     color_icons  = true,
     git_icons    = false,
     -- actions inherit from 'actions.files' and merge
-    actions      = { ["default"] = actions.complete },
+    actions      = { ["enter"] = actions.complete },
     -- previewer hidden by default
     winopts      = { preview = { hidden = "hidden" } },
   },

--- a/lua/fzf-lua/config.lua
+++ b/lua/fzf-lua/config.lua
@@ -89,8 +89,12 @@ M.globals = setmetatable({}, {
             and vim.tbl_deep_extend("keep", utils.tbl_deep_clone(setup_value[k]),
               setup_value[k][1] == true and fzflua_default[k] or {})
             or utils.tbl_deep_clone(fzflua_default[k])
-        ret[k][1] = nil
-        ret[k] = utils.map_tolower(ret[k], "^alt%-%a$")
+        if ret[k] then
+          -- Remove the [1] indicating inheritance from defaults and
+          -- exclude case-sensitive alt-binds from being lowercased
+          ret[k][1] = nil
+          ret[k] = utils.map_tolower(ret[k], "^alt%-%a$")
+        end
       end
       return ret
     end
@@ -198,10 +202,11 @@ function M.normalize_opts(opts, globals, __resume_key)
       builtin = utils.map_tolower(m.builtin, exclude_patterns),
     } or nil
   end
-  opts.keymap = keymap_tolower(opts.keymap, "^alt%-%a$")
-  opts.actions = utils.map_tolower(opts.actions, "^alt%-%a$")
-  globals.keymap = keymap_tolower(globals.keymap, "^alt%-%a$")
-  globals.actions = utils.map_tolower(globals.actions, "^alt%-%a$")
+  local exclude_case_sensitive_alt = "^alt%-%a$"
+  opts.keymap = keymap_tolower(opts.keymap, exclude_case_sensitive_alt)
+  opts.actions = utils.map_tolower(opts.actions, exclude_case_sensitive_alt)
+  globals.keymap = keymap_tolower(globals.keymap, exclude_case_sensitive_alt)
+  globals.actions = utils.map_tolower(globals.actions, exclude_case_sensitive_alt)
 
   -- inherit from globals.actions?
   if type(globals._actions) == "function" then
@@ -615,16 +620,18 @@ M._action_to_helpstr = {
   [actions.file_sel_to_ll]      = "file-selection-to-loclist",
   [actions.file_switch]         = "file-switch",
   [actions.file_switch_or_edit] = "file-switch-or-edit",
-  [actions.buf_edit]            = "buffer-edit",
-  [actions.buf_edit_or_qf]      = "buffer-edit-or-qf",
-  [actions.buf_sel_to_qf]       = "buffer-selection-to-qf",
-  [actions.buf_sel_to_ll]       = "buffer-selection-to-loclist",
-  [actions.buf_split]           = "buffer-split",
-  [actions.buf_vsplit]          = "buffer-vsplit",
-  [actions.buf_tabedit]         = "buffer-tabedit",
+  -- Since default actions refactor these are just refs to
+  -- their correspondent `file_xxx` equivalents
+  -- [actions.buf_edit]            = "buffer-edit",
+  -- [actions.buf_edit_or_qf]      = "buffer-edit-or-qf",
+  -- [actions.buf_sel_to_qf]       = "buffer-selection-to-qf",
+  -- [actions.buf_sel_to_ll]       = "buffer-selection-to-loclist",
+  -- [actions.buf_split]           = "buffer-split",
+  -- [actions.buf_vsplit]          = "buffer-vsplit",
+  -- [actions.buf_tabedit]         = "buffer-tabedit",
+  -- [actions.buf_switch]          = "buffer-switch",
+  -- [actions.buf_switch_or_edit]  = "buffer-switch-or-edit",
   [actions.buf_del]             = "buffer-delete",
-  [actions.buf_switch]          = "buffer-switch",
-  [actions.buf_switch_or_edit]  = "buffer-switch-or-edit",
   [actions.run_builtin]         = "run-builtin",
   [actions.ex_run]              = "edit-cmd",
   [actions.ex_run_cr]           = "exec-cmd",

--- a/lua/fzf-lua/core.lua
+++ b/lua/fzf-lua/core.lua
@@ -312,9 +312,9 @@ M.fzf = function(contents, opts)
   opts.actions = opts.actions or {}
   opts.keymap = opts.keymap or {}
   opts.keymap.fzf = opts.keymap.fzf or {}
-  for _, k in ipairs({ "ctrl-c", "ctrl-q", "esc" }) do
-    if opts.actions[k] == nil and
-        (opts.keymap.fzf[k] == nil or opts.keymap.fzf[k] == "abort") then
+  for _, k in ipairs({ "ctrl-c", "ctrl-q", "esc", "enter" }) do
+    if opts.actions[k] == nil and (opts.keymap.fzf[k] == nil or opts.keymap.fzf[k] == "abort")
+    then
       opts.actions[k] = actions.dummy_abort
     end
   end

--- a/lua/fzf-lua/defaults.lua
+++ b/lua/fzf-lua/defaults.lua
@@ -121,19 +121,13 @@ M.defaults                      = {
   },
   actions       = {
     files = {
-      ["default"] = actions.file_edit_or_qf,
-      ["ctrl-s"]  = actions.file_split,
-      ["ctrl-v"]  = actions.file_vsplit,
-      ["ctrl-t"]  = actions.file_tabedit,
-      ["alt-q"]   = actions.file_sel_to_qf,
-      ["alt-l"]   = actions.file_sel_to_ll,
+      ["enter"]  = actions.file_edit_or_qf,
+      ["ctrl-s"] = actions.file_split,
+      ["ctrl-v"] = actions.file_vsplit,
+      ["ctrl-t"] = actions.file_tabedit,
+      ["alt-q"]  = actions.file_sel_to_qf,
+      ["alt-Q"]  = actions.file_sel_to_ll,
     },
-    buffers = {
-      ["default"] = actions.buf_edit,
-      ["ctrl-s"]  = actions.buf_split,
-      ["ctrl-v"]  = actions.buf_vsplit,
-      ["ctrl-t"]  = actions.buf_tabedit,
-    }
   },
   fzf_bin       = nil,
   fzf_opts      = {
@@ -389,8 +383,8 @@ M.defaults.git                  = {
     preview       = "git show --color {1}",
     preview_pager = M._preview_pager_fn,
     actions       = {
-      ["default"] = actions.git_checkout,
-      ["ctrl-y"]  = { fn = actions.git_yank_commit, exec_silent = true },
+      ["enter"]  = actions.git_checkout,
+      ["ctrl-y"] = { fn = actions.git_yank_commit, exec_silent = true },
     },
     fzf_opts      = { ["--no-multi"] = true },
     _multiline    = false,
@@ -402,11 +396,11 @@ M.defaults.git                  = {
     preview       = "git show --color {1} -- {file}",
     preview_pager = M._preview_pager_fn,
     actions       = {
-      ["default"] = actions.git_buf_edit,
-      ["ctrl-s"]  = actions.git_buf_split,
-      ["ctrl-v"]  = actions.git_buf_vsplit,
-      ["ctrl-t"]  = actions.git_buf_tabedit,
-      ["ctrl-y"]  = { fn = actions.git_yank_commit, exec_silent = true },
+      ["enter"]  = actions.git_buf_edit,
+      ["ctrl-s"] = actions.git_buf_split,
+      ["ctrl-v"] = actions.git_buf_vsplit,
+      ["ctrl-t"] = actions.git_buf_tabedit,
+      ["ctrl-y"] = { fn = actions.git_yank_commit, exec_silent = true },
     },
     fzf_opts      = { ["--no-multi"] = true },
     _multiline    = false,
@@ -416,9 +410,9 @@ M.defaults.git                  = {
     cmd        = "git branch --all --color",
     preview    = "git log --graph --pretty=oneline --abbrev-commit --color {1}",
     actions    = {
-      ["default"] = actions.git_switch,
-      ["ctrl-x"]  = { fn = actions.git_branch_del, reload = true },
-      ["ctrl-a"]  = { fn = actions.git_branch_add, field_index = "{q}", reload = true },
+      ["enter"]  = actions.git_switch,
+      ["ctrl-x"] = { fn = actions.git_branch_del, reload = true },
+      ["ctrl-a"] = { fn = actions.git_branch_add, field_index = "{q}", reload = true },
     },
     cmd_add    = { "git", "branch" },
     cmd_del    = { "git", "branch", "--delete" },
@@ -433,7 +427,7 @@ M.defaults.git                  = {
         .. [[ %(subject) %(color:blue)%(taggername)%(color:reset)" refs/tags]],
     preview    = [[git log --graph --color --pretty=format:"%C(yellow)%h%Creset ]]
         .. [[%Cgreen(%><(12)%cr%><|(12))%Creset %s %C(blue)<%an>%Creset" {1}]],
-    actions    = { ["default"] = actions.git_checkout },
+    actions    = { ["enter"] = actions.git_checkout },
     fzf_opts   = { ["--no-multi"] = true },
     _multiline = false,
   },
@@ -443,8 +437,8 @@ M.defaults.git                  = {
     preview       = "git --no-pager stash show --patch --color {1}",
     preview_pager = M._preview_pager_fn,
     actions       = {
-      ["default"] = actions.git_stash_apply,
-      ["ctrl-x"]  = { fn = actions.git_stash_drop, reload = true },
+      ["enter"]  = actions.git_stash_apply,
+      ["ctrl-x"] = { fn = actions.git_stash_drop, reload = true },
     },
     fzf_opts      = {
       -- TODO: multiselect requires more work as dropping
@@ -532,7 +526,7 @@ M.defaults.quickfix_stack       = {
   marker    = ">",
   previewer = { _ctor = previewers.builtin.quickfix, },
   fzf_opts  = { ["--no-multi"] = true },
-  actions   = { ["default"] = actions.set_qflist, },
+  actions   = { ["enter"] = actions.set_qflist, },
 }
 
 M.defaults.loclist              = {
@@ -553,7 +547,7 @@ M.defaults.loclist_stack        = {
   marker    = ">",
   previewer = { _ctor = previewers.builtin.quickfix, },
   fzf_opts  = { ["--no-multi"] = true },
-  actions   = { ["default"] = actions.set_qflist, },
+  actions   = { ["enter"] = actions.set_qflist, },
 }
 
 M.defaults.buffers              = {
@@ -568,7 +562,9 @@ M.defaults.buffers              = {
   cwd_only              = false,
   cwd                   = nil,
   fzf_opts              = { ["--tiebreak"] = "index", ["--multi"] = true },
-  _actions              = function() return M.globals.actions.buffers end,
+  _actions              = function()
+    return M.globals.actions.buffers or M.globals.actions.files
+  end,
   actions               = { ["ctrl-x"] = { fn = actions.buf_del, reload = true } },
   _cached_hls           = { "buf_nr", "buf_flag_cur", "buf_flag_alt", "path_linenr" },
 }
@@ -580,10 +576,12 @@ M.defaults.tabs                 = {
   tab_marker  = "<<",
   file_icons  = true and M._has_devicons,
   color_icons = true,
-  _actions    = function() return M.globals.actions.buffers end,
+  _actions    = function()
+    return M.globals.actions.buffers or M.globals.actions.files
+  end,
   actions     = {
-    ["default"] = actions.buf_switch,
-    ["ctrl-x"]  = { fn = actions.buf_del, reload = true },
+    ["enter"]  = actions.buf_switch,
+    ["ctrl-x"] = { fn = actions.buf_del, reload = true },
   },
   fzf_opts    = {
     ["--multi"]     = true,
@@ -608,11 +606,13 @@ M.defaults.lines                = {
     ["--tiebreak"]  = "index",
   },
   line_field_index = "{3}",
-  _actions         = function() return M.globals.actions.buffers end,
+  _actions         = function()
+    return M.globals.actions.buffers or M.globals.actions.files
+  end,
   actions          = {
-    ["default"] = actions.buf_edit_or_qf,
-    ["alt-q"]   = actions.buf_sel_to_qf,
-    ["alt-l"]   = actions.buf_sel_to_ll
+    ["enter"] = actions.buf_edit_or_qf,
+    ["alt-q"] = actions.buf_sel_to_qf,
+    ["alt-l"] = actions.buf_sel_to_ll
   },
   _cached_hls      = { "buf_name", "buf_nr", "path_linenr" },
 }
@@ -631,11 +631,13 @@ M.defaults.blines               = {
     ["--tiebreak"]  = "index",
   },
   line_field_index = "{2}",
-  _actions         = function() return M.globals.actions.buffers end,
+  _actions         = function()
+    return M.globals.actions.buffers or M.globals.actions.files
+  end,
   actions          = {
-    ["default"] = actions.buf_edit_or_qf,
-    ["alt-q"]   = actions.buf_sel_to_qf,
-    ["alt-l"]   = actions.buf_sel_to_ll
+    ["enter"] = actions.buf_edit_or_qf,
+    ["alt-q"] = actions.buf_sel_to_qf,
+    ["alt-l"] = actions.buf_sel_to_ll
   },
   _cached_hls      = { "buf_name", "buf_nr", "path_linenr" },
 }
@@ -688,7 +690,7 @@ M.defaults.colorschemes         = {
   live_preview = true,
   winopts      = { height = 0.55, width = 0.50, backdrop = false },
   fzf_opts     = { ["--no-multi"] = true },
-  actions      = { ["default"] = actions.colorscheme },
+  actions      = { ["enter"] = actions.colorscheme },
 }
 
 M.defaults.highlights           = {
@@ -714,20 +716,20 @@ M.defaults.awesome_colorschemes = {
     return path.join({ vim.fn.stdpath("cache"), "fzf-lua" })
   end,
   actions      = {
-    ["default"] = actions.colorscheme,
-    ["ctrl-g"]  = { fn = actions.toggle_bg, exec_silent = true },
-    ["ctrl-r"]  = { fn = actions.cs_update, reload = true },
-    ["ctrl-x"]  = { fn = actions.cs_delete, reload = true },
+    ["enter"]  = actions.colorscheme,
+    ["ctrl-g"] = { fn = actions.toggle_bg, exec_silent = true },
+    ["ctrl-r"] = { fn = actions.cs_update, reload = true },
+    ["ctrl-x"] = { fn = actions.cs_delete, reload = true },
   }
 }
 
 M.defaults.helptags             = {
   prompt    = "Help> ",
   actions   = {
-    ["default"] = actions.help,
-    ["ctrl-s"]  = actions.help,
-    ["ctrl-v"]  = actions.help_vert,
-    ["ctrl-t"]  = actions.help_tab,
+    ["enter"]  = actions.help,
+    ["ctrl-s"] = actions.help,
+    ["ctrl-v"] = actions.help_vert,
+    ["ctrl-t"] = actions.help_tab,
   },
   fzf_opts  = {
     ["--no-multi"]  = true,
@@ -744,10 +746,10 @@ M.defaults.manpages             = {
   prompt    = "Man> ",
   cmd       = "man -k .",
   actions   = {
-    ["default"] = actions.man,
-    ["ctrl-s"]  = actions.man,
-    ["ctrl-v"]  = actions.man_vert,
-    ["ctrl-t"]  = actions.man_tab,
+    ["enter"]  = actions.man,
+    ["ctrl-s"] = actions.man,
+    ["ctrl-v"] = actions.man_vert,
+    ["ctrl-t"] = actions.man_tab,
   },
   fzf_opts  = { ["--tiebreak"] = "begin", ["--no-multi"] = true },
   previewer = "man",
@@ -763,6 +765,8 @@ M.defaults.lsp                  = {
   fzf_opts         = { ["--multi"] = true },
   _actions         = function() return M.globals.actions.files end,
   _cached_hls      = { "path_colnr", "path_linenr" },
+  -- Signals actions to use uri triggering the use of `lsp.util.jump_to_location`
+  _uri             = true,
 }
 
 M.defaults.lsp.symbols          = {
@@ -833,6 +837,7 @@ M.defaults.lsp.symbols          = {
   _actions         = function() return M.globals.actions.files end,
   actions          = { ["ctrl-g"] = { actions.sym_lsym } },
   _cached_hls      = { "live_sym", "path_colnr", "path_linenr" },
+  _uri             = true,
 }
 
 M.defaults.lsp.finder           = {
@@ -867,6 +872,7 @@ M.defaults.lsp.finder           = {
   },
   fzf_opts    = { ["--multi"] = true },
   _cached_hls = { "path_colnr", "path_linenr" },
+  _uri        = true,
 }
 
 M.defaults.lsp.code_actions     = {
@@ -908,7 +914,7 @@ M.defaults.builtin              = {
     width  = 0.50,
   },
   fzf_opts = { ["--no-multi"] = true },
-  actions  = { ["default"] = actions.run_builtin },
+  actions  = { ["enter"] = actions.run_builtin },
 }
 
 M.defaults.profiles             = {
@@ -919,13 +925,13 @@ M.defaults.profiles             = {
     ["--with-nth"]  = "-1..",
     ["--no-multi"]  = true,
   },
-  actions   = { ["default"] = actions.apply_profile },
+  actions   = { ["enter"] = actions.apply_profile },
 }
 
 M.defaults.marks                = {
   prompt    = "Marks> ",
   fzf_opts  = { ["--no-multi"] = true },
-  actions   = { ["default"] = actions.goto_mark },
+  actions   = { ["enter"] = actions.goto_mark },
   previewer = { _ctor = previewers.builtin.marks },
 }
 
@@ -939,7 +945,7 @@ M.defaults.jumps                = {
   prompt    = "Jumps> ",
   cmd       = "jumps",
   fzf_opts  = { ["--no-multi"] = true },
-  actions   = { ["default"] = actions.goto_jump },
+  actions   = { ["enter"] = actions.goto_jump },
   previewer = { _ctor = previewers.builtin.jumps },
 }
 
@@ -955,7 +961,7 @@ M.defaults.tagstack             = {
 
 M.defaults.commands             = {
   prompt          = "Commands> ",
-  actions         = { ["default"] = actions.ex_run },
+  actions         = { ["enter"] = actions.ex_run },
   include_builtin = true,
 }
 
@@ -974,8 +980,8 @@ M.defaults.command_history      = {
   prompt   = "Command History> ",
   fzf_opts = { ["--tiebreak"] = "index", ["--no-multi"] = true },
   actions  = {
-    ["default"] = actions.ex_run_cr,
-    ["ctrl-e"]  = actions.ex_run,
+    ["enter"]  = actions.ex_run_cr,
+    ["ctrl-e"] = actions.ex_run,
   },
 }
 
@@ -983,8 +989,8 @@ M.defaults.search_history       = {
   prompt   = "Search History> ",
   fzf_opts = { ["--tiebreak"] = "index", ["--no-multi"] = true },
   actions  = {
-    ["default"] = actions.search_cr,
-    ["ctrl-e"]  = actions.search,
+    ["enter"]  = actions.search_cr,
+    ["ctrl-e"] = actions.search,
   },
 }
 
@@ -992,7 +998,7 @@ M.defaults.registers            = {
   prompt       = "Registers> ",
   multiline    = true,
   ignore_empty = true,
-  actions      = { ["default"] = actions.paste_register },
+  actions      = { ["enter"] = actions.paste_register },
   fzf_opts     = { ["--no-multi"] = true },
 }
 
@@ -1003,38 +1009,38 @@ M.defaults.keymaps              = {
   fzf_opts        = { ["--tiebreak"] = "index", ["--no-multi"] = true },
   ignore_patterns = { "^<SNR>", "^<Plug>" },
   actions         = {
-    ["default"] = actions.keymap_apply,
-    ["ctrl-s"]  = actions.keymap_split,
-    ["ctrl-v"]  = actions.keymap_vsplit,
-    ["ctrl-t"]  = actions.keymap_tabedit,
+    ["enter"]  = actions.keymap_apply,
+    ["ctrl-s"] = actions.keymap_split,
+    ["ctrl-v"] = actions.keymap_vsplit,
+    ["ctrl-t"] = actions.keymap_tabedit,
   },
 }
 
 M.defaults.spell_suggest        = {
   prompt  = "Spelling Suggestions> ",
   actions = {
-    ["default"] = actions.spell_apply,
+    ["enter"] = actions.spell_apply,
   },
 }
 
 M.defaults.filetypes            = {
   prompt  = "Filetypes> ",
   actions = {
-    ["default"] = actions.set_filetype,
+    ["enter"] = actions.set_filetype,
   },
 }
 
 M.defaults.packadd              = {
   prompt  = "packadd> ",
   actions = {
-    ["default"] = actions.packadd,
+    ["enter"] = actions.packadd,
   },
 }
 
 M.defaults.menus                = {
   prompt  = "Menu> ",
   actions = {
-    ["default"] = actions.exec_menu,
+    ["enter"] = actions.exec_menu,
   },
 }
 
@@ -1043,7 +1049,7 @@ M.defaults.tmux                 = {
     prompt   = "Tmux Buffers> ",
     cmd      = "tmux list-buffers",
     register = [["]],
-    actions  = { ["default"] = actions.tmux_buf_set_reg },
+    actions  = { ["enter"] = actions.tmux_buf_set_reg },
     fzf_opts = { ["--no-multi"] = true, ["--delimiter"] = "[:]" }
   },
 }
@@ -1089,7 +1095,7 @@ M.defaults.complete_path        = {
   multiprocess      = true,
   fzf_opts          = { ["--no-multi"] = true },
   _fzf_nth_devicons = true,
-  actions           = { ["default"] = actions.complete },
+  actions           = { ["enter"] = actions.complete },
 }
 
 M.defaults.complete_file        = {
@@ -1099,7 +1105,7 @@ M.defaults.complete_file        = {
   color_icons       = true,
   git_icons         = false,
   _actions          = function() return M.globals.actions.files end,
-  actions           = { ["default"] = actions.complete },
+  actions           = { ["enter"] = actions.complete },
   previewer         = M._default_previewer_fn,
   winopts           = { preview = { hidden = "hidden" } },
   fzf_opts          = { ["--no-multi"] = true },

--- a/lua/fzf-lua/path.lua
+++ b/lua/fzf-lua/path.lua
@@ -494,6 +494,7 @@ function M.entry_to_file(entry, opts, force_uri)
     path     = file,
     line     = tonumber(line) or 0,
     col      = tonumber(col) or 0,
+    ctag     = opts._ctag and M.entry_to_ctag(stripped) or nil,
   }
 end
 

--- a/lua/fzf-lua/previewer/builtin.lua
+++ b/lua/fzf-lua/previewer/builtin.lua
@@ -1118,16 +1118,6 @@ function Previewer.tags:new(o, opts, fzf_win)
   return self
 end
 
-function Previewer.tags:parse_entry(entry_str)
-  -- first parse as normal entry
-  -- must use 'super.' and send self as 1st arg
-  -- or the ':' syntactic sugar will send super's
-  -- self which doesn't have self.opts
-  local entry = self.super.parse_entry(self, entry_str)
-  entry.ctag = path.entry_to_ctag(entry_str)
-  return entry
-end
-
 function Previewer.tags:set_cursor_hl(entry)
   -- pcall(vim.fn.clearmatches, self.win.preview_winid)
   pcall(api.nvim_win_call, self.win.preview_winid, function()

--- a/lua/fzf-lua/previewer/fzf.lua
+++ b/lua/fzf-lua/previewer/fzf.lua
@@ -181,6 +181,7 @@ function Previewer.cmd_async:parse_entry_and_verify(entrystr)
   -- make relative for bat's header display
   local filepath = path.relative_to(entry.bufname or entry.path or "", uv.cwd())
   if self.opts._ctag then
+    -- NOTE: override `entry.ctag` with the unescaped version
     entry.ctag = path.entry_to_ctag(entry.stripped, true)
     if not tonumber(entry.line) or tonumber(entry.line) < 1 then
       -- default tags are without line numbers

--- a/lua/fzf-lua/profiles/fzf-vim.lua
+++ b/lua/fzf-lua/profiles/fzf-vim.lua
@@ -98,19 +98,13 @@ return {
   },
   actions = {
     files = {
-      ["default"] = actions.file_edit_or_qf,
+      ["enter"] = actions.file_edit_or_qf,
       ["ctrl-x"] = actions.file_split,
       ["ctrl-v"] = actions.file_vsplit,
       ["ctrl-t"] = actions.file_tabedit,
       ["alt-q"] = actions.file_sel_to_qf,
       ["alt-l"] = actions.file_sel_to_ll,
     },
-    buffers = {
-      ["default"] = actions.buf_edit,
-      ["ctrl-x"] = actions.buf_split,
-      ["ctrl-v"] = actions.buf_vsplit,
-      ["ctrl-t"] = actions.buf_tabedit,
-    }
   },
   files = {
     cmd = os.getenv("FZF_DEFAULT_COMMAND"),

--- a/lua/fzf-lua/profiles/telescope.lua
+++ b/lua/fzf-lua/profiles/telescope.lua
@@ -83,19 +83,12 @@ return {
   },
   actions    = {
     files = {
-      ["default"] = actions.file_edit_or_qf,
+      ["enter"] = actions.file_edit_or_qf,
       ["ctrl-x"]  = actions.file_split,
       ["ctrl-v"]  = actions.file_vsplit,
       ["ctrl-t"]  = actions.file_tabedit,
       ["alt-q"]   = actions.file_sel_to_qf,
-      ["alt-l"]   = actions.file_sel_to_ll,
     },
-    buffers = {
-      ["default"] = actions.buf_edit,
-      ["ctrl-x"]  = actions.buf_split,
-      ["ctrl-v"]  = actions.buf_vsplit,
-      ["ctrl-t"]  = actions.buf_tabedit,
-    }
   },
   buffers    = {
     keymap = { builtin = { ["<C-d>"] = false } },

--- a/lua/fzf-lua/providers/files.lua
+++ b/lua/fzf-lua/providers/files.lua
@@ -94,6 +94,8 @@ M.args = function(opts)
               cb(s, function()
                 coroutine.resume(co)
               end)
+            else
+              coroutine.resume(co)
             end
           end)
           coroutine.yield()

--- a/lua/fzf-lua/providers/lsp.lua
+++ b/lua/fzf-lua/providers/lsp.lua
@@ -639,7 +639,6 @@ end
 local function fzf_lsp_locations(opts, fn_contents)
   opts = normalize_lsp_opts(opts, "lsp")
   if not opts then return end
-  if opts.force_uri == nil then opts.force_uri = true end
   opts = core.set_fzf_field_index(opts)
   opts = fn_contents(opts)
   if not opts.__contents then
@@ -682,7 +681,6 @@ end
 M.finder = function(opts)
   opts = normalize_lsp_opts(opts, "lsp.finder")
   if not opts then return end
-  if opts.force_uri == nil then opts.force_uri = true end
   local contents = {}
   local lsp_params = opts.lsp_params
   for _, p in ipairs(opts.providers) do
@@ -773,7 +771,6 @@ M.document_symbols = function(opts)
   end
   opts = core.set_header(opts, opts.headers or { "regex_filter" })
   opts = core.set_fzf_field_index(opts)
-  if opts.force_uri == nil then opts.force_uri = true end
   if not opts.fzf_opts or opts.fzf_opts["--with-nth"] == nil then
     -- our delims are {nbsp,:} make sure entry has no icons
     -- "{nbsp}file:line:col:" and hide the last 4 fields
@@ -804,7 +801,6 @@ M.workspace_symbols = function(opts)
   opts = core.set_header(opts, opts.headers or
     { "actions", "cwd", "lsp_query", "regex_filter" })
   opts = core.set_fzf_field_index(opts)
-  if opts.force_uri == nil then opts.force_uri = true end
   opts = gen_lsp_contents(opts)
   if not opts.__contents then
     core.__CTX = nil
@@ -873,7 +869,6 @@ M.live_workspace_symbols = function(opts)
 
   opts = core.set_header(opts, opts.headers or { "actions", "cwd", "regex_filter" })
   opts = core.set_fzf_field_index(opts)
-  if opts.force_uri == nil then opts.force_uri = true end
   if opts.symbol_style or opts.symbol_fmt then
     opts.fn_pre_fzf = function() gen_sym2style_map(opts) end
     opts.fn_post_fzf = function() M._sym2style = nil end
@@ -956,7 +951,7 @@ M.code_actions = function(opts)
   end
 
   opts.actions = opts.actions or {}
-  opts.actions.default = nil
+  opts.actions.enter = nil
   -- only dereg if we aren't registered
   if not registered then
     opts.post_action_cb = function()


### PR DESCRIPTION
Not really breaking but requires attention if you care for setup options improvement.

All entries whether file or buffer can now utilize the same actions code, previously buffer actions (e.g. `buf_edit`) are not mapped to file actions (e.g. `file_edit`) and can work on any file-buffer entry.

Setup's `actions.files` is now used for all file-buffer pickers which simplifies setting up default actions.

**NOTE:** For backward compat previously defined `actions.buffers` will still be used and will take precedence over `actions.files` for buffer pickers (buffers, tabs, lines, blines).

Additional changes:
  - Default bind for sending to location list changed from "alt-l" to "alt-Q" ("alt-shift-Q", doesn't work with skim).
  - Default actions changed from `default` to `enter` to match fzf's terminology (shouldn't change anything)