### PR TITLE
fix(oldfiles): include unlisted buffers with `include_current_session`

### DIFF
--- a/lua/fzf-lua/providers/oldfiles.lua
+++ b/lua/fzf-lua/providers/oldfiles.lua
@@ -31,7 +31,7 @@ M.oldfiles = function(opts)
       end
 
   if opts.include_current_session then
-    for _, buffer in ipairs(vim.split(vim.fn.execute(":buffers t"), "\n")) do
+    for _, buffer in ipairs(vim.split(vim.fn.execute(":buffers! t"), "\n")) do
       local bufnr = tonumber(buffer:match("%s*(%d+)"))
       if bufnr then
         local file = vim.api.nvim_buf_get_name(bufnr)


### PR DESCRIPTION
This allows reopening buffers that were first opened in the current session, and then closed again.

Steps to reproduce:

1. Open a buffer which doesn't appear in `oldfiles` yet
2. Close it with `:bd`
3. Run `:FzfLua oldfiles` (with `include_current_session` enabled)
4. Previously the closed buffer wouldn't show up, but now it does! :tada: 