### PR TITLE
Tab index also embedded in buffer entry

### DIFF
--- a/lua/fzf-lua/defaults.lua
+++ b/lua/fzf-lua/defaults.lua
@@ -586,7 +586,7 @@ M.defaults.tabs                 = {
   fzf_opts    = {
     ["--multi"]     = true,
     ["--delimiter"] = "[\\):]",
-    ["--with-nth"]  = "4..",
+    ["--with-nth"]  = "5..",
   },
   _cached_hls = { "buf_nr", "buf_flag_cur", "buf_flag_alt", "tab_title", "tab_marker", "path_linenr" },
 }

--- a/lua/fzf-lua/providers/buffers.lua
+++ b/lua/fzf-lua/providers/buffers.lua
@@ -360,8 +360,9 @@ M.tabs = function(opts)
 
           local tab_cwd_tilde_base64 = base64.encode(tab_cwd_tilde)
           if not opts.current_tab_only then
-            cb(string.format("%s:%d:0)%s%s  %s",
+            cb(string.format("%s:%d:%d:0)%s%s  %s",
               tab_cwd_tilde_base64,
+              tabnr,
               tabh,
               utils.nbsp,
               fn_title_hl(title),
@@ -372,8 +373,8 @@ M.tabs = function(opts)
             if tabh ~= core.CTX().tabh or core.CTX().curtab_wins[tostring(w)] then
               local b = filter_buffers(opts, { vim.api.nvim_win_get_buf(w) })[1]
               if b then
-                local prefix = string.format("%s:%d:%d)%s%s%s",
-                  tab_cwd_tilde_base64, tabh, w, utils.nbsp, utils.nbsp, utils.nbsp)
+                local prefix = string.format("%s:%d:%d:%d)%s%s%s",
+                  tab_cwd_tilde_base64, tabnr, tabh, w, utils.nbsp, utils.nbsp, utils.nbsp)
                 local bufinfo = populate_buffer_entries({}, { b }, w)[1]
                 cb(gen_buffer_entry(opts, bufinfo, max_bufnr, tab_cwd, prefix))
               end


### PR DESCRIPTION
Tab indices are used in ex commands (e.g. `:tabn`) and are more human friendly:

```lua
fzf.tabs({
  fzf_opts = {
    ["--preview"] = [['echo "Tab #"{1}": $(echo {2} | base64 -d -)"']],
    ["--preview-window"] = "nohidden:up,1",
  }
})
```