### PR TITLE
fix: file_switch_or_edit with nill

### DIFF
--- a/lua/fzf-lua/actions.lua
+++ b/lua/fzf-lua/actions.lua
@@ -318,6 +318,7 @@ M.file_edit_or_qf = function(selected, opts)
 end
 
 M.file_switch = function(selected, opts)
+  if not selected[1] then return false end
   -- If called from `:FzfLua tabs` switch to requested tab/win
   local tabh, winid = selected[1]:match("(%d+):(%d+)%)")
   if tabh and winid then


### PR DESCRIPTION
Hi, I noticed when I have a buffer list open with a single buffer, calling file_switch_or_edit buffer results in some error due to the passed arg doesn't have any selected buffer.
I added a line to prevent file_switch function from producing error and instead to simply return false

Thank you,