### PR TITLE
fix: when jumplist or changelist is nil

### DIFF
--- a/lua/fzf-lua/providers/nvim.lua
+++ b/lua/fzf-lua/providers/nvim.lua
@@ -152,6 +152,11 @@ M.jumps = function(opts)
       text))
   end
 
+  if utils.tbl_isempty(entries) then
+    utils.info(("%s list is empty."):format(opts.h1 or "jump"))
+    return
+  end
+
   table.insert(entries, 1,
     string.format("%6s %s  %s %s", opts.h1 or "jump", "line", "col", "file/text"))
 


### PR DESCRIPTION
## bug reproduction

`:cle<cr>`, `:FzfLua jumps<cr>`

(or: `:delm!<cr>`, `:FzfLua changes<cr>`)

```
Error executing vim.schedule lua callback: ...hare/nvim/lazy/fzf-lua/lua/fzf-lua/previewer/builtin.lua:1118: attempt to perform arithmetic on a nil value
stack traceback:
        ...hare/nvim/lazy/fzf-lua/lua/fzf-lua/previewer/builtin.lua:1118: in function 'parse_entry'
        ...hare/nvim/lazy/fzf-lua/lua/fzf-lua/previewer/builtin.lua:605: in function 'populate_preview_buf'
        ...hare/nvim/lazy/fzf-lua/lua/fzf-lua/previewer/builtin.lua:263: in function 'populate_preview_buf'
        ...hare/nvim/lazy/fzf-lua/lua/fzf-lua/previewer/builtin.lua:280: in function ''
        vim/_editor.lua: in function ''
        vim/_editor.lua: in function <vim/_editor.lua:0>
```
