### PR TITLE
feat(winopts): pass current opts to `winopts_fn`

### DIFF
--- a/lua/fzf-lua/config.lua
+++ b/lua/fzf-lua/config.lua
@@ -262,7 +262,7 @@ function M.normalize_opts(opts, globals, __resume_key)
   -- Merge `winopts` with outputs from `winopts_fn`
   local winopts_fn = opts.winopts_fn or M.globals.winopts_fn
   if type(winopts_fn) == "function" then
-    opts.winopts = vim.tbl_deep_extend("force", opts.winopts, winopts_fn() or {})
+    opts.winopts = vim.tbl_deep_extend("force", opts.winopts, winopts_fn(opts) or {})
   end
 
   -- Merge arrays from globals|defaults, can't use 'vim.tbl_xxx'


### PR DESCRIPTION
I'm trying to attach [`dropbar.nvim`](https://github.com/Bekaboo/dropbar.nvim/) to the preview buffer. And I want to attach only on pickers like `grep/lsp_definitions` but not `files`, so with this pr it can be done by:
```lua
require('fzf-lua').setup {
  winopts_fn = function(opts)
    return {
      preview = {
        winopts = {
          winbar = opts.winopts.preview.winopts.cursorline
              and '%{%v:lua.dropbar.get_dropbar_str()%}'
            or nil,
        },
      },
    }
  end,
}
```

BTW, actually before that I also try to use `autocmds` on the preview win/buf open, or use `after/ftplugins` to detect it, but both didn't work. I found the root cause is `eventignore` from this commit: https://github.com/ibhagwan/fzf-lua/commit/6be3ba4620ed44b29abc1562ecf67e4fdfb48d20. And it can be noted that `w:fzf_lua_preview` here may never be used, since all event are just never fired.
https://github.com/ibhagwan/fzf-lua/blob/260cf55f66adabc4f21a5c2b118e57617de0b635/lua/fzf-lua/win.lua#L631-L632.

Or if in future someone really need autocmds: then it can be replaced by approaches like https://github.com/nvim-telescope/telescope.nvim/pull/2005.