### PR TITLE
feat(file_ignore_globs): maybe a replacement of `file_ignore_patterns` for `rg`/`fd`

### DIFF
--- a/lua/fzf-lua/config.lua
+++ b/lua/fzf-lua/config.lua
@@ -267,14 +267,12 @@ function M.normalize_opts(opts, globals, __resume_key)
 
   -- Merge arrays from globals|defaults, can't use 'vim.tbl_xxx'
   -- for these as they only work for maps, ie. '{ key = value }'
-  for _, k in ipairs({ "file_ignore_patterns" }) do
+  for _, k in ipairs({ "file_ignore_patterns", "file_ignore_globs" }) do
     for _, m in ipairs({ globals, M.globals }) do
-      if m[k] then
-        for _, item in ipairs(m[k]) do
-          if not opts[k] then opts[k] = {} end
-          table.insert(opts[k], item)
-        end
-      end
+      if not m[k] then goto continue end
+      local _opts = type(m[k]) ~= "function" and m[k] or m[k](opts)
+      opts[k] = (_opts and #_opts ~= 0) and vim.deepcopy(_opts)
+      ::continue::
     end
   end
 

--- a/lua/fzf-lua/core.lua
+++ b/lua/fzf-lua/core.lua
@@ -794,6 +794,7 @@ M.mt_cmd_wrapper = function(opts)
       "strip_cwd_prefix",
       "exec_empty_query",
       "file_ignore_patterns",
+      "file_ignore_globs",
       "rg_glob",
       "_base64",
       utils.__IS_WINDOWS and "__FZF_VERSION" or nil,
@@ -839,7 +840,8 @@ M.mt_cmd_wrapper = function(opts)
   if not opts.requires_processing
       and not opts.git_icons
       and not opts.file_icons
-      and not opts.file_ignore_patterns
+      and not opts.file_ignore_patterns -- need transform
+      and not opts.file_ignore_globs -- need preprocess
       and not opts.path_shorten
       and not opts.formatter
       and not opts.multiline

--- a/lua/fzf-lua/make_entry.lua
+++ b/lua/fzf-lua/make_entry.lua
@@ -224,6 +224,13 @@ M.preprocess = function(opts)
       end)
   end
 
+  -- support file_ignore_globs for fd
+  if opts.cmd and opts.cmd:match("^fd") and opts.file_ignore_globs then
+    local globs = vim.tbl_map(libuv.shellescape, opts.file_ignore_globs)
+    local cmd_tbl = utils.tbl_join({ opts.cmd }, globs)
+    opts.cmd = table.concat(cmd_tbl, " -E ")
+  end
+
   if utils.__IS_WINDOWS and opts.cmd:match("!") then
     -- https://ss64.com/nt/syntax-esc.html
     -- This changes slightly if you are running with DelayedExpansion of variables:


### PR DESCRIPTION
* `file_ignore_patterns` use lua patterns and need to be transformed entry by entry, especially when all other transform options(e.g. `file_icons/git_icons`) turn off.
* `file_ignore_globs` will be applied as `rg -iglob "!glob1" -iglob "!glob2" ...` and `fd --exclude "glob1" --exclude "glob2" ...`.
* Both `file_ignore_{patterns,globs}` can be a function now.
