### PR TITLE
feat(keymaps): add the `show_details` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1182,6 +1182,9 @@ require'fzf-lua'.setup {
     -- by default, we ignore <Plug> and <SNR> mappings
     -- set `ignore_patterns = false` to disable filtering
     ignore_patterns   = { "^<SNR>", "^<Plug>" },
+    -- by default, both description and details are shown
+    -- `false` shows details only if the description is missing
+    show_details      = true,
     actions           = {
       ["enter"]       = actions.keymap_apply,
       ["ctrl-s"]      = actions.keymap_split,

--- a/lua/fzf-lua/defaults.lua
+++ b/lua/fzf-lua/defaults.lua
@@ -1008,6 +1008,7 @@ M.defaults.keymaps              = {
   winopts         = { preview = { layout = "vertical" } },
   fzf_opts        = { ["--tiebreak"] = "index", ["--no-multi"] = true },
   ignore_patterns = { "^<SNR>", "^<Plug>" },
+  show_details    = true,
   actions         = {
     ["enter"]  = actions.keymap_apply,
     ["ctrl-s"] = actions.keymap_split,


### PR DESCRIPTION
Hi, thanks for this package!

I'm migrating from the telescope (because of slowness on large codebases), and I noticed that the keymaps picker is too restrictive, which is not very useful for those who provide detailed descriptions for all bindings:
![2024-09-22_00-13-34](https://github.com/user-attachments/assets/b79c3873-605f-4c0a-aba1-e7b380719587)

This PR introduces the `show_details` option, which (if `false`) disables the `detail` column completely and shows this info only if `description` is empty.

By default, `show_details = true`, thus it doesn't affect existing users.

Result:
![2024-09-22_00-13-53](https://github.com/user-attachments/assets/b4d8a3a6-5bb2-4203-bdf1-75f79ed23614)
