### PR TITLE
feat: adopt upstream treesitter breaking change

### DIFF
--- a/lua/fzf-lua/previewer/builtin.lua
+++ b/lua/fzf-lua/previewer/builtin.lua
@@ -755,7 +755,7 @@ end
 -- Attach ts highlighter, neovim >= v0.9
 local ts_attach = function(bufnr, ft)
   local lang = vim.treesitter.language.get_lang(ft)
-  local loaded = pcall(vim.treesitter.language.add, lang)
+  local loaded = utils.has_ts_parser(lang)
   if lang and loaded then
     local ok, err = pcall(vim.treesitter.start, bufnr, lang)
     if not ok then

--- a/lua/fzf-lua/utils.lua
+++ b/lua/fzf-lua/utils.lua
@@ -1238,4 +1238,14 @@ function M.create_user_command_callback(provider, arg, altmap)
   end
 end
 
+--- Checks if treesitter parser for language is installed
+---@param lang string
+function M.has_ts_parser(lang)
+  if M.__HAS_NVIM_011 then
+    return vim.treesitter.language.add(lang)
+  else
+    return pcall(vim.treesitter.language.add, lang)
+  end
+end
+
 return M


### PR DESCRIPTION
Due to a recent treesitter breaking change on neovim.
`vim.treesitter.language.add` returns `true` or `nil, error` now. thus can use it directly without `pcall`.

see https://github.com/neovim/neovim/pull/30379