### PR TITLE
fix: remove useless `{un,}hide` from builtin picker

### DIFF
--- a/lua/fzf-lua/init.lua
+++ b/lua/fzf-lua/init.lua
@@ -409,6 +409,8 @@ M._excluded_meta = {
   "get_info",
   "set_info",
   "get_last_query",
+  "hide",
+  "unhide",
   -- Exclude due to rename:
   --   help_tags -> helptags
   --   man_pages -> manpages


### PR DESCRIPTION
Remove `hide/unhide` entry from the builtin picker (I think they are useless here).
