### PR TITLE
[previewer/builtin] turn utils.has_ts_parser call into protected call

### DIFF
--- a/lua/fzf-lua/previewer/builtin.lua
+++ b/lua/fzf-lua/previewer/builtin.lua
@@ -755,8 +755,8 @@ end
 -- Attach ts highlighter, neovim >= v0.9
 local ts_attach = function(bufnr, ft)
   local lang = vim.treesitter.language.get_lang(ft)
-  local loaded = utils.has_ts_parser(lang)
-  if lang and loaded then
+  local ok, loaded = pcall(utils.has_ts_parser, lang)
+  if lang and ok and loaded then
     local ok, err = pcall(vim.treesitter.start, bufnr, lang)
     if not ok then
       utils.warn(string.format(


### PR DESCRIPTION
I've experienced that recent changes causes the following error if TreeSitter is not activated. 

I get this error even on `require('fzf-lua').files` call:

```
Error executing vim.schedule lua callback: ...arm64/share/nvim/runtime/lua/vim/treesitter/language.lua:84: lang: expected string, got nil
stack traceback:
        [C]: in function 'error'
        vim/shared.lua: in function 'validate'
        ...arm64/share/nvim/runtime/lua/vim/treesitter/language.lua:84: in function 'has_ts_parser'
        ...e/pack/_/start/fzf-lua/lua/fzf-lua/previewer/builtin.lua:758: in function 'ts_attach'
        ...e/pack/_/start/fzf-lua/lua/fzf-lua/previewer/builtin.lua:825: in function <...e/pack/_/start/fzf-lua/lua/fzf-lua/previewer/builtin.lua:803>
        ...e/pack/_/start/fzf-lua/lua/fzf-lua/previewer/builtin.lua:833: in function 'do_syntax'
        ...e/pack/_/start/fzf-lua/lua/fzf-lua/previewer/builtin.lua:954: in function 'preview_buf_post'
        ...e/pack/_/start/fzf-lua/lua/fzf-lua/previewer/builtin.lua:716: in function ''
        vim/_editor.lua: in function <vim/_editor.lua:0>
```

```sh
$ nvim --version
NVIM v0.11.0-dev-836+g64847fbdc
Build type: RelWithDebInfo
LuaJIT 2.1.1724512491
Run "nvim -V1 -v" for more info
```

```sh
$ fzf --version
0.55 (devel)
```


This PR turns the related call (following stacking trace) into [protected call](https://www.lua.org/pil/8.4.html).

I've tested it with my own config [.config/nvim/init.lua](https://github.com/balazs4/dotfiles/blob/6fedd147f3993fd7b893924cd16fe57086ef9625/.config/nvim/init.lua#L231-L261) on macOS.