### PR TITLE
Feature: Add action toggle_fixed_strings

### DIFF
--- a/doc/fzf-lua.txt
+++ b/doc/fzf-lua.txt
@@ -1128,6 +1128,8 @@ open an issue and I'll be more than happy to help.**
           ["ctrl-g"]      = { actions.grep_lgrep }
           -- uncomment to enable '.gitignore' toggle for grep
           -- ["ctrl-r"]   = { actions.toggle_ignore }
+          -- uncomment to enable '--fixed-strings' (exact match) toggle for grep
+          -- ["ctrl-x"]   = { actions.toggle_fixed_strings }
         },
         no_header             = false,    -- hide grep|cwd header?
         no_header_i           = false,    -- hide interactive header?

--- a/lua/fzf-lua/actions.lua
+++ b/lua/fzf-lua/actions.lua
@@ -850,6 +850,11 @@ M.toggle_ignore = function(_, opts)
   M.toggle_flag(_, vim.tbl_extend("force", opts, { toggle_flag = flag }))
 end
 
+M.toggle_fixed_strings = function(_, opts)
+  local flag = opts.toggle_ignore_flag or "--fixed-strings"
+  M.toggle_flag(_, vim.tbl_extend("force", opts, { toggle_flag = flag }))
+end
+
 M.toggle_hidden = function(_, opts)
   local flag = opts.toggle_hidden_flag or "--hidden"
   M.toggle_flag(_, vim.tbl_extend("force", opts, { toggle_flag = flag }))

--- a/lua/fzf-lua/config.lua
+++ b/lua/fzf-lua/config.lua
@@ -685,6 +685,7 @@ M._action_to_helpstr = {
   [actions.arg_add]             = "arg-list-add",
   [actions.arg_del]             = "arg-list-delete",
   [actions.toggle_ignore]       = "toggle-ignore",
+  [actions.toggle_fixed_strings] = "toggle-fixed-strings",
   [actions.toggle_hidden]       = "toggle-hidden",
   [actions.grep_lgrep]          = "grep<->lgrep",
   [actions.sym_lsym]            = "sym<->lsym",

--- a/lua/fzf-lua/core.lua
+++ b/lua/fzf-lua/core.lua
@@ -27,6 +27,16 @@ M.ACTION_DEFINITIONS = {
       end
     end,
   },
+  [actions.toggle_fixed_strings] = {
+    function(o)
+      local flag = o.toggle_ignore_flag or "--fixed-strings"
+      if o.cmd and o.cmd:match(utils.lua_regex_escape(flag)) then
+        return "Respect special regex chars"
+      else
+        return "Disable special regex chars"
+      end
+    end,
+  },
   [actions.toggle_hidden]     = {
     function(o)
       local flag = o.toggle_hidden_flag or "--hidden"

--- a/lua/fzf-lua/defaults.lua
+++ b/lua/fzf-lua/defaults.lua
@@ -491,6 +491,7 @@ M.defaults.grep                 = {
       .. "--perl-regexp -e",
   rg_opts        = "--column --line-number --no-heading --color=always --smart-case "
       .. "--max-columns=4096 -e",
+  toggle_fixed_strings = "--fixed-strings",
   _actions       = function() return M.globals.actions.files end,
   actions        = { ["ctrl-g"] = { actions.grep_lgrep } },
   -- live_grep_glob options


### PR DESCRIPTION
### Problem

- I could not find a simple way to toggle between regex and a literal search when using grep.

### Solution

- Implement the action `toggle_fixed_strings` to toggle the flag `--fixed-strings`. This flag is supported by [grep](https://www.gnu.org/software/grep/manual/grep.html#grep-Programs-1), [ripgrep](https://manpages.debian.org/testing/ripgrep/rg.1.en.html#SEARCH_OPTIONS) and [ag](https://man.archlinux.org/man/extra/the_silver_searcher/ag.1.en#OPTIONS). I coded this action following the implementation of `toggle_ignore`; so it was mostly an imitation game. Now toggling between regex and literal search is as simple as adding one line in the actions config of the provider:

```
··
  grep = {
    actions = {
      ["ctrl-g"] = { actions.grep_lgrep },
      ["ctrl-x"] = { actions.toggle_fixed_strings } -- Toggle between regex/literal search with <C-x>.
    },
  }
··
```

---

### Other solutions I considered

- There has already been a discussion about how to use the `--fixed-strings` flag in the grep provider. For the simple use case of just toggling between regex and literal search, I found the [code](https://github.com/ibhagwan/fzf-lua/issues/781#issuecomment-1595831081) provided by [deponian](https://github.com/deponian) to be too complicated. If possible, I would appreciate if fzf-lua provides built-in support for this flag so the user-side configuration is easy.
  - #781  

Thanks.