### PR TITLE
fix(lsp): vim.lsp.util.jump_to_location is now deprecated

### DIFF
--- a/lua/fzf-lua/actions.lua
+++ b/lua/fzf-lua/actions.lua
@@ -129,7 +129,7 @@ M.vimcmd_entry = function(_vimcmd, selected, opts, pcall_vimcmd)
       -- Adjust "<auto>" edits based on entry being buffer or filename
       local vimcmd = _vimcmd:gsub("<auto>", entry.bufnr and entry.bufname and "b" or "e")
       -- Do not execute "edit" commands if we already have the same buffer/file open
-      -- or if we are dealing with a URI as it's open with `vim.lsp.util.jump_to_location`
+      -- or if we are dealing with a URI as it's open with `vim.lsp.util.show_document`
       -- opts.__CTX isn't guaranteed by API users (#1414)
       local CTX = opts.__CTX or utils.CTX()
       if vimcmd == "e" and (entry.uri or path.equals(fullpath, CTX.bname))
@@ -198,9 +198,9 @@ M.vimcmd_entry = function(_vimcmd, selected, opts, pcall_vimcmd)
       if entry.uri then
         if utils.is_term_bufname(entry.uri) then
           -- nvim_exec2(): Vim(normal):Can't re-enter normal mode from terminal mode
-          pcall(vim.lsp.util.jump_to_location, entry, "utf-16")
+          pcall(vim.lsp.util.show_document, entry, "utf-16", { focus = true })
         else
-          vim.lsp.util.jump_to_location(entry, "utf-16")
+          vim.lsp.util.show_document(entry, "utf-16", { focus = true })
         end
       elseif entry.ctag then
         vim.api.nvim_win_set_cursor(0, { 1, 0 })

--- a/lua/fzf-lua/defaults.lua
+++ b/lua/fzf-lua/defaults.lua
@@ -797,7 +797,7 @@ M.defaults.lsp                  = {
   fzf_opts         = { ["--multi"] = true },
   _actions         = function() return M.globals.actions.files end,
   _cached_hls      = { "path_colnr", "path_linenr" },
-  -- Signals actions to use uri triggering the use of `lsp.util.jump_to_location`
+  -- Signals actions to use uri triggering the use of `lsp.util.show_document`
   _uri             = true,
 }
 

--- a/lua/fzf-lua/path.lua
+++ b/lua/fzf-lua/path.lua
@@ -423,7 +423,7 @@ function M.entry_to_file(entry, opts, force_uri)
   if cwd and #cwd > 0 and not isURI and not M.is_absolute(stripped) then
     stripped = M.join({ cwd, stripped })
   end
-  -- #336: force LSP jumps using 'vim.lsp.util.jump_to_location'
+  -- #336: force LSP jumps using 'vim.lsp.util.show_document'
   -- so that LSP entries are added to the tag stack
   if not isURI and force_uri then
     isURI = true
@@ -437,7 +437,7 @@ function M.entry_to_file(entry, opts, force_uri)
     -- https://github.com/mfussenegger/nvim-jdtls
     -- LSP entries inside .jar files appear as URIs
     -- 'jdt://' which can then be opened with
-    -- 'vim.lsp.util.jump_to_location' or
+    -- 'vim.lsp.util.show_document' or
     -- 'lua require('jdtls').open_jdt_link(vim.fn.expand('jdt://...'))'
     -- Convert to location item so we can use 'jump_to_location'
     -- This can also work with any 'file://' prefixes

--- a/lua/fzf-lua/previewer/builtin.lua
+++ b/lua/fzf-lua/previewer/builtin.lua
@@ -64,8 +64,8 @@ function Previewer.base:new(o, opts, fzf_win)
   self.cached_bufnrs = {}
   self.cached_buffers = {}
   -- store currently listed buffers, this helps us determine which buffers
-  -- navigated with 'vim.lsp.util.jump_to_location' we can safely unload
-  -- since jump_to_location reuses buffers and I couldn't find a better way
+  -- navigated with 'vim.lsp.util.show_document' we can safely unload
+  -- since show_document reuses buffers and I couldn't find a better way
   -- to determine if the destination buffer was listed prior to the jump
   self.listed_buffers = (function()
     local map = {}
@@ -221,7 +221,7 @@ function Previewer.base:clear_preview_buf(newbuf)
   -- will return false
   -- one case where the buffer may remain valid after detaching
   -- from the preview window is with URI type entries after calling
-  -- 'vim.lsp.util.jump_to_location' which can reuse existing buffers,
+  -- 'vim.lsp.util.show_document' which can reuse existing buffers,
   -- so technically this should never be executed unless the
   -- user wrote an fzf-lua extension and set the preview buffer to
   -- a random buffer without the 'bufhidden' property
@@ -643,14 +643,14 @@ function Previewer.buffer_or_file:populate_preview_buf(entry_str)
     -- LSP 'jdt://' entries, see issue #195
     -- https://github.com/ibhagwan/fzf-lua/issues/195
     vim.api.nvim_win_call(self.win.preview_winid, function()
-      local ok, res = pcall(vim.lsp.util.jump_to_location, entry, "utf-16", false)
+      local ok, res = pcall(vim.lsp.util.show_document, entry, "utf-16", { reuse_win = false, focus = true })
       if ok then
         self.preview_bufnr = vim.api.nvim_get_current_buf()
       else
         -- in case of an error display the stacktrace in the preview buffer
         local lines = vim.split(res, "\n") or { "null" }
         table.insert(lines, 1,
-          string.format("lsp.util.jump_to_location failed for '%s':", entry.uri))
+          string.format("lsp.util.show_document failed for '%s':", entry.uri))
         table.insert(lines, 2, "")
         local tmpbuf = self:get_tmp_buffer()
         vim.api.nvim_buf_set_lines(tmpbuf, 0, -1, false, lines)

--- a/lua/fzf-lua/providers/lsp.lua
+++ b/lua/fzf-lua/providers/lsp.lua
@@ -85,7 +85,7 @@ local jump_to_location = function(opts, result, enc)
     return opts.jump_to_single_result_action({ entry }, opts)
   end
 
-  return vim.lsp.util.jump_to_location(result, enc)
+  return vim.lsp.util.show_document(result, enc, { focus = true })
 end
 
 local regex_filter_fn = function(regex_filter)


### PR DESCRIPTION
`vim.lsp.util.jump_to_location` was deprecated in https://github.com/neovim/neovim/pull/30877.

This PR replaces its uses by `vim.lsp.show_document` (which `jump_to_location` uses in its implementation).