### PR TITLE
fix(lsp): preserve backwards compatibility with jump_to_location deprecation

### DIFF
--- a/lua/fzf-lua/actions.lua
+++ b/lua/fzf-lua/actions.lua
@@ -198,9 +198,9 @@ M.vimcmd_entry = function(_vimcmd, selected, opts, pcall_vimcmd)
       if entry.uri then
         if utils.is_term_bufname(entry.uri) then
           -- nvim_exec2(): Vim(normal):Can't re-enter normal mode from terminal mode
-          pcall(vim.lsp.util.show_document, entry, "utf-16", { focus = true })
+          pcall(utils.jump_to_location, entry, "utf-16")
         else
-          vim.lsp.util.show_document(entry, "utf-16", { focus = true })
+          utils.jump_to_location(entry, "utf-16")
         end
       elseif entry.ctag then
         vim.api.nvim_win_set_cursor(0, { 1, 0 })

--- a/lua/fzf-lua/previewer/builtin.lua
+++ b/lua/fzf-lua/previewer/builtin.lua
@@ -643,14 +643,14 @@ function Previewer.buffer_or_file:populate_preview_buf(entry_str)
     -- LSP 'jdt://' entries, see issue #195
     -- https://github.com/ibhagwan/fzf-lua/issues/195
     vim.api.nvim_win_call(self.win.preview_winid, function()
-      local ok, res = pcall(vim.lsp.util.show_document, entry, "utf-16", { reuse_win = false, focus = true })
+      local ok, res = pcall(utils.jump_to_location, entry, "utf-16", false)
       if ok then
         self.preview_bufnr = vim.api.nvim_get_current_buf()
       else
         -- in case of an error display the stacktrace in the preview buffer
         local lines = vim.split(res, "\n") or { "null" }
         table.insert(lines, 1,
-          string.format("lsp.util.show_document failed for '%s':", entry.uri))
+          string.format("lsp.util.%s failed for '%s':", utils.__HAS_NVIM_011 and "show_document" or "jump_to_location", entry.uri))
         table.insert(lines, 2, "")
         local tmpbuf = self:get_tmp_buffer()
         vim.api.nvim_buf_set_lines(tmpbuf, 0, -1, false, lines)

--- a/lua/fzf-lua/providers/lsp.lua
+++ b/lua/fzf-lua/providers/lsp.lua
@@ -85,7 +85,7 @@ local jump_to_location = function(opts, result, enc)
     return opts.jump_to_single_result_action({ entry }, opts)
   end
 
-  return vim.lsp.util.show_document(result, enc, { focus = true })
+  return utils.jump_to_location(result, enc)
 end
 
 local regex_filter_fn = function(regex_filter)

--- a/lua/fzf-lua/utils.lua
+++ b/lua/fzf-lua/utils.lua
@@ -1249,4 +1249,17 @@ function M.has_ts_parser(lang)
   end
 end
 
+--- Wrapper around vim.lsp.jump_to_location which was deprecated in v0.11
+---@param location lsp.Location|lsp.LocationLink
+---@param offset_encoding 'utf-8'|'utf-16'|'utf-32'
+---@param reuse_win boolean?
+---@return boolean
+function M.jump_to_location(location, offset_encoding, reuse_win)
+  if M.__HAS_NVIM_011 then
+    return vim.lsp.util.show_document(location, offset_encoding, { reuse_win = reuse_win, focus = true })
+  else
+    return vim.lsp.util.jump_to_location(location, offset_encoding, reuse_win)
+  end
+end
+
 return M


### PR DESCRIPTION
Follow up of #1503 to preserve backwards compatibility with versions 5-9.