### PR TITLE
Feature: Add an empty space at the end of the ui_select prompt to a better formatting when writing the input

### DIFF
--- a/lua/fzf-lua/providers/ui_select.lua
+++ b/lua/fzf-lua/providers/ui_select.lua
@@ -95,7 +95,14 @@ M.ui_select = function(items, ui_opts, on_choice)
   })
 
   -- Force override prompt or it stays cached (#786)
-  local prompt = ui_opts.prompt or "Select one of:"
+  local prompt = ui_opts.prompt
+  if prompt then
+    -- Add a space at the end of the prompt (if not already present) since the prompt and the input are inline
+    prompt = prompt:gsub("%s*$", " ", 1)
+  else
+    prompt = "Select one of :"
+  end
+
   opts.fzf_opts["--prompt"] = prompt:gsub(":%s?$", "> ")
 
   -- save items so we can access them from the action


### PR DESCRIPTION
It's a small feature I think would be nice.

When using [kulala.nvim](https://github.com/mistweaverco/kulala.nvim), I've noticed the search prompt was not ideal since it had no space between the text and the input. For the default prompt, though, I've changed just a bit the result from `"Select one of> "` to `"Select one of > "`.

<img width="1370" alt="Screenshot 2024-11-04 at 11 38 56" src="https://github.com/user-attachments/assets/2494d78d-8ee5-4d69-809b-5111e1651014">
<img width="269" alt="Screenshot 2024-11-04 at 11 39 12" src="https://github.com/user-attachments/assets/edddb57b-0684-4139-aada-0d439b1f99da">


Please let me know if this is not something you'd want the plugin to deal with or if I need to make any changes (but feel free to do them as well) :)