### PR TITLE
fix: offset_encoding is required now in `make_position_params` and `make_range_params`

### DIFF
--- a/lua/fzf-lua/providers/lsp.lua
+++ b/lua/fzf-lua/providers/lsp.lua
@@ -472,19 +472,18 @@ local function gen_lsp_contents(opts)
   -- build positional params for the LSP query
   -- from the context buffer and cursor position
   if not lsp_params then
-    if not utils.__HAS_NVIM_011 then
-      lsp_params = vim.lsp.util.make_position_params(core.CTX().winid)
-      lsp_params.context = {
+    lsp_params = function(client)
+      local params = vim.lsp.util.make_position_params(core.CTX().winid,
+        -- nvim 0.11 requires offset_encoding param, `client` is first arg of called func
+        -- https://github.com/neovim/neovim/commit/629483e24eed3f2c07e55e0540c553361e0345a2
+        client and client.offset_encoding or nil)
+      params.context = {
         includeDeclaration = opts.includeDeclaration == nil and true or opts.includeDeclaration
       }
-    else
-      lsp_params = function(client)
-        local params = vim.lsp.util.make_position_params(core.CTX().winid, client.offset_encoding)
-        params.context = {
-          includeDeclaration = opts.includeDeclaration == nil and true or opts.includeDeclaration
-        }
-        return params
-      end
+      return params
+    end
+    if not utils.__HAS_NVIM_011 and type(lsp_params) == "function" then
+      lsp_params = lsp_params()
     end
   end
 
@@ -612,11 +611,10 @@ end
 -- see $VIMRUNTIME/lua/vim/buf.lua:pick_call_hierarchy_item()
 local function gen_lsp_contents_call_hierarchy(opts)
   local lsp_params = opts.lsp_params
-  if not lsp_params then
-    lsp_params = utils.__HAS_NVIM_011 and function(client)
-      return vim.lsp.util.make_position_params(core.CTX().winid, client.offset_encoding)
-    end or vim.lsp.util.make_position_params(core.CTX().winid)
-  end
+      or not utils.__HAS_NVIM_011 and vim.lsp.util.make_position_params(core.CTX().winid)
+      or function(client)
+        return vim.lsp.util.make_position_params(core.CTX().winid, client.offset_encoding)
+      end
   local method = "textDocument/prepareCallHierarchy"
   local res, err = vim.lsp.buf_request_sync(0, method, lsp_params, 2000)
   if err then
@@ -951,23 +949,21 @@ M.code_actions = function(opts)
     -- irrelevant for code actions and can cause
     -- single results to be skipped with 'async = false'
     opts.jump_to_single_result = false
-    if not utils.__HAS_NVIM_011 then
-      opts.lsp_params = vim.lsp.util.make_range_params(0)
-      opts.lsp_params.context = opts.context or {
+    opts.lsp_params = function(client)
+      local params = vim.lsp.util.make_range_params(core.CTX().winid,
+        -- nvim 0.11 requires offset_encoding param, `client` is first arg of called func
+        -- https://github.com/neovim/neovim/commit/629483e24eed3f2c07e55e0540c553361e0345a2
+        client and client.offset_encoding or nil)
+      params.context = opts.context or {
         -- Neovim still uses `vim.lsp.diagnostic` API in "nvim/runtime/lua/vim/lsp/buf.lua"
         -- continue to use it until proven otherwise, this also fixes #707 as diagnostics
         -- must not be nil or some LSP servers will fail (e.g. ruff_lsp, rust_analyzer)
         diagnostics = vim.lsp.diagnostic.get_line_diagnostics(core.CTX().bufnr) or {}
       }
-    else
-      local win = vim.api.nvim_get_current_win()
-      opts.lsp_params = function(client)
-        local params = vim.lsp.util.make_range_params(win, client.offset_encoding)
-        params.context = opts.context or {
-          diagnostics = vim.lsp.diagnostic.get_line_diagnostics(core.CTX().bufnr) or {}
-        }
-        return params
-      end
+      return params
+    end
+    if not utils.__HAS_NVIM_011 and type(opts.lsp_params) == "function" then
+      opts.lsp_params = opts.lsp_params()
     end
 
     -- make sure 'gen_lsp_contents' is run synchronously


### PR DESCRIPTION
Adapt to the upstream change https://github.com/neovim/neovim/commit/629483e24eed3f2c07e55e0540c553361e0345a2 to get rid of the warning message "warning: offset_encoding is required, using the offset_encoding from the first client".