### PR TITLE
Display Selected Highlight Group In Colorscheme Provider

### DIFF
--- a/lua/fzf-lua/providers/colorschemes.lua
+++ b/lua/fzf-lua/providers/colorschemes.lua
@@ -144,6 +144,11 @@ M.highlights = function(opts)
     end
   end
 
+  opts.fn_selected = function(selected)
+    vim.cmd('hi ' .. selected[2])
+    vim.api.nvim_exec2('hi ' .. selected[2], {})
+  end
+
   core.fzf_exec(contents, opts)
 end
 

--- a/lua/fzf-lua/providers/colorschemes.lua
+++ b/lua/fzf-lua/providers/colorschemes.lua
@@ -145,8 +145,10 @@ M.highlights = function(opts)
   end
 
   opts.fn_selected = function(selected)
-    vim.cmd('hi ' .. selected[2])
-    vim.api.nvim_exec2('hi ' .. selected[2], {})
+    if selected[1] == 'enter' then
+      vim.cmd('hi ' .. selected[2])
+      vim.api.nvim_exec2('hi ' .. selected[2], {})
+    end
   end
 
   core.fzf_exec(contents, opts)


### PR DESCRIPTION
Currently, running `:FzfLua highlights` doesn't actually do *anything* when an entry is selected.

I think it is logical to display the highlighted group in the command line as if `:hi <group>` was run.
