### PR TITLE
fix(ctag): better handle line number for tag entries

### DIFF
--- a/lua/fzf-lua/actions.lua
+++ b/lua/fzf-lua/actions.lua
@@ -210,7 +210,7 @@ M.vimcmd_entry = function(_vimcmd, selected, opts, pcall_vimcmd)
         else
           utils.jump_to_location(entry, "utf-16")
         end
-      elseif entry.ctag then
+      elseif entry.ctag and not entry.line then
         vim.api.nvim_win_set_cursor(0, { 1, 0 })
         vim.fn.search(entry.ctag, "W")
       elseif not opts.no_action_set_cursor and entry.line > 0 or entry.col > 0 then

--- a/lua/fzf-lua/make_entry.lua
+++ b/lua/fzf-lua/make_entry.lua
@@ -439,6 +439,11 @@ M.tag = function(x, opts)
   -- from rg/grep output when using `tags_grep_xxx`
   local align = utils.has_ansi_coloring(name) and 47 or 30
   local line, tag = text:match("(%d-);?(/.*/)")
+  if not tag then
+    -- lines with a tag located solely by line number contain nothing but the
+    -- number at this point
+    line = text:match("%d+")
+  end
   line = line and #line > 0 and tonumber(line)
   return string.format("%-" .. tostring(align) .. "s%s%s%s: %s",
     name,

--- a/lua/fzf-lua/make_entry.lua
+++ b/lua/fzf-lua/make_entry.lua
@@ -441,7 +441,7 @@ M.tag = function(x, opts)
   local line, tag = text:match("(%d-);?(/.*/)")
   if not tag then
     -- lines with a tag located solely by line number contain nothing but the
-    -- number at this point
+    -- number at this point (e.g. using "ctags -R --excmd=number")
     line = text:match("%d+")
   end
   line = line and #line > 0 and tonumber(line)

--- a/lua/fzf-lua/previewer/builtin.lua
+++ b/lua/fzf-lua/previewer/builtin.lua
@@ -1131,11 +1131,17 @@ function Previewer.tags:set_cursor_hl(entry)
   pcall(api.nvim_win_call, self.win.preview_winid, function()
     -- start searching at line 1 in case we
     -- didn't reload the buffer (same file)
-    api.nvim_win_set_cursor(0, { 1, 0 })
-    fn.clearmatches()
-    fn.search(entry.ctag, "W")
-    if self.win.hls.search then
-      fn.matchadd(self.win.hls.search, entry.ctag)
+    if not entry.line or entry.line == 0 then
+      api.nvim_win_set_cursor(0, { 1, 0 })
+      fn.clearmatches()
+      fn.search(entry.ctag, "W")
+      if self.win.hls.search then
+        fn.matchadd(self.win.hls.search, entry.ctag)
+      end
+    else
+      -- the entry's line is assumed to be correct,
+      -- allowing the search to be skipped
+      api.nvim_win_set_cursor(0, { entry.line, 0 })
     end
     self.orig_pos = api.nvim_win_get_cursor(0)
     utils.zz()

--- a/lua/fzf-lua/previewer/builtin.lua
+++ b/lua/fzf-lua/previewer/builtin.lua
@@ -1127,21 +1127,19 @@ function Previewer.tags:new(o, opts, fzf_win)
 end
 
 function Previewer.tags:set_cursor_hl(entry)
+  if tonumber(entry.line) and entry.line > 0 then
+    Previewer.buffer_or_file.set_cursor_hl(self, entry)
+    return
+  end
   -- pcall(vim.fn.clearmatches, self.win.preview_winid)
   pcall(api.nvim_win_call, self.win.preview_winid, function()
     -- start searching at line 1 in case we
     -- didn't reload the buffer (same file)
-    if not entry.line or entry.line == 0 then
-      api.nvim_win_set_cursor(0, { 1, 0 })
-      fn.clearmatches()
-      fn.search(entry.ctag, "W")
-      if self.win.hls.search then
-        fn.matchadd(self.win.hls.search, entry.ctag)
-      end
-    else
-      -- the entry's line is assumed to be correct,
-      -- allowing the search to be skipped
-      api.nvim_win_set_cursor(0, { entry.line, 0 })
+    api.nvim_win_set_cursor(0, { 1, 0 })
+    fn.clearmatches()
+    fn.search(entry.ctag, "W")
+    if self.win.hls.search then
+      fn.matchadd(self.win.hls.search, entry.ctag)
     end
     self.orig_pos = api.nvim_win_get_cursor(0)
     utils.zz()


### PR DESCRIPTION
Attempts to fix the problems highlighted in [this issue](https://github.com/ibhagwan/fzf-lua/issues/1547), notably:
- the line number of tag entries with no regex was not properly extracted, and thus were unusable
- tag entries with both a regex and a line number did not take advantage of the line number, thus were susceptible to collisions on the regex
-   the default previewer for tags could not make use of the line number of an entry