### PR TITLE
feat(beta): use ts highlights in main fzf win

### DIFF
--- a/OPTIONS.md
+++ b/OPTIONS.md
@@ -265,9 +265,18 @@ Backdrop opacity value, 0 for fully opaque, 100 for fully transparent (i.e. disa
 
 #### globals.winopts.fullscreen
 
-Type: `fullscreen`, Default: `false`
+Type: `boolean`, Default: `false`
 
 Use fullscreen for the fzf-load floating window.
+
+#### globals.winopts.treesitter
+
+Type: `boolean`, Default: `false`
+
+Use treesitter highlighting in fzf's main window.
+
+> **NOTE**: Only works for file-like entires where treesitter parser exists and is loaded
+> for the filetype.
 
 #### globals.winopts.on_create
 

--- a/doc/fzf-lua-opts.txt
+++ b/doc/fzf-lua-opts.txt
@@ -346,9 +346,20 @@ disabled).
                                                                               
 globals.winopts.fullscreen           *fzf-lua-opts-globals.winopts.fullscreen*
 
-Type: `fullscreen`, Default: `false`
+Type: `boolean`, Default: `false`
 
 Use fullscreen for the fzf-load floating window.
+
+
+                                                                              
+globals.winopts.treesitter           *fzf-lua-opts-globals.winopts.treesitter*
+
+Type: `boolean`, Default: `false`
+
+Use treesitter highlighting in fzf's main window.
+
+  **NOTE**: Only works for file-like entires where treesitter parser exists and
+  is loaded for the filetype.
 
 
                                                                               


### PR DESCRIPTION
**Feedback appreciated**: https://github.com/ibhagwan/fzf-lua/issues/1485

Will only work with file-like entries, e.g. grep_xxx, blines, etc:
```
  file:line:col:text   (grep_xxx)
  file:line:text       (grep_project or missing "--column" flag)
  line:col:text        (grep_curbuf)
  line:text            (blines)
```

Enable globally via `setup`:
```lua
require("fzf-lua").setup({ winopts = { treesitter = true } })
```

Or call individually per picker:
```vim
:FzfLua blines winopts.treesitter=true
```
or
```lua
:lua require("fzf-lua").blines({ winopts = { treesitter = true } })
```