### PR TITLE
fix(actions): file_switch with formatter

### DIFF
--- a/lua/fzf-lua/actions.lua
+++ b/lua/fzf-lua/actions.lua
@@ -337,7 +337,7 @@ M.file_switch = function(selected, opts)
     end
     return true
   end
-  local entry = path.entry_to_file(selected[1])
+  local entry = path.entry_to_file(selected[1], opts)
   if not entry.bufnr then
     -- Search for the current entry's filepath in buffer list
     local fullpath = entry.path


### PR DESCRIPTION
When a custom formatter is used the `file_switch` action along with any other that depend on it are never able to resolve to an existing buffer.

This is because the call that resolves a selected entry to a file does not provide options so the entry resolution does not know a formatter was used.