### PR TITLE
fix(tags): Restore searching for tag when line is not in ctags

### DIFF
--- a/lua/fzf-lua/actions.lua
+++ b/lua/fzf-lua/actions.lua
@@ -210,7 +210,7 @@ M.vimcmd_entry = function(_vimcmd, selected, opts, pcall_vimcmd)
         else
           utils.jump_to_location(entry, "utf-16")
         end
-      elseif entry.ctag and not entry.line then
+      elseif entry.ctag and entry.line == 0 then
         vim.api.nvim_win_set_cursor(0, { 1, 0 })
         vim.fn.search(entry.ctag, "W")
       elseif not opts.no_action_set_cursor and entry.line > 0 or entry.col > 0 then


### PR DESCRIPTION
It looks like a Lua gotcha, 0 is truthy. When the line information is absent in the tags file, the search behavior isn’t available.

Using an example file `foo.py`:
```python
def main():
    pass


def foo():
    pass
```

I generate my ctags with:
```
ctags --tag-relative=yes -f"tags" foo.py
```

That gives the following entries (without headers), which do not contains line numbers:
```
foo	toto.py	/^def foo():$/;"	f
main	toto.py	/^def main():$/;"	f
```

When the action runs, the line information is `0`, so the check `if entry.ctags and not entry.line` is not entered.
