### PR TITLE
fix(previewer): treesitter-context not closed in `live_grep`

### DIFF
--- a/lua/fzf-lua/previewer/builtin.lua
+++ b/lua/fzf-lua/previewer/builtin.lua
@@ -345,7 +345,13 @@ end
 function Previewer.base:display_entry(entry_str)
   -- NOTE: prior to the zero event we may be sent an
   -- empty string in the preview callback (#1567)
-  if not entry_str or #entry_str == 0 then return end
+  if not entry_str or #entry_str == 0 then
+    local winid = self.win.preview_winid
+    if TSContext.is_attached(winid) then
+      TSContext.close(winid)
+    end
+    return
+  end
   -- save last entry even if we don't display
   self.last_entry = entry_str
   if not self.win or not self.win:validate_preview() then return end


### PR DESCRIPTION
## Reproduce
1. Launch live_grep in `fzf-lua` repo, paste/type `vim.api.nvim_win_call, self.border_winid`.
2. Then type: `x`.
Nothing matched, but treesitter context window remain open.
![image](https://github.com/user-attachments/assets/13b91f97-c874-4e47-bb3f-15679893d095)
