### PR TITLE
feat(treesitter)!: enable treesitter for `lines|blines|git_blame`

### DIFF
--- a/OPTIONS.md
+++ b/OPTIONS.md
@@ -546,25 +546,37 @@ Interactive headers description highlight group, e.g. `<ctrl-g> to Disable .giti
 
 Type: `string`, Default: `FzfLuaPathLineNr`
 
-Highlight group for the line part of paths, e.g. `file:<line>:<col>:`, used in pickers such as `buffers`, `lines`, `quickfix`, `lsp`, `diagnostics`, etc.
+Highlight group for the line part of paths, e.g. `file:<line>:<col>:`, used in pickers such as `buffers`, `quickfix`, `lsp`, `diagnostics`, etc.
 
 #### globals.hls.path_colnr
 
 Type: `string`, Default: `FzfLuaPathColNr`
 
-Highlight group for the column part of paths, e.g. `file:<line>:<col>:`, used in pickers such as `buffers`, `lines`, `quickfix`, `lsp`, `diagnostics`, etc.
+Highlight group for the column part of paths, e.g. `file:<line>:<col>:`, used in pickers such as `buffers`, `quickfix`, `lsp`, `diagnostics`, etc.
 
 #### globals.hls.buf_name
 
 Type: `string`, Default: `FzfLuaBufName`
 
-Highlight group for buffer name in `lines`.
+Highlight group for buffer name (filepath) in `lines`.
+
+#### globals.hls.buf_id
+
+Type: `string`, Default: `FzfLuaBufId`
+
+Highlight group for buffer id (number) in `lines`.
 
 #### globals.hls.buf_nr
 
 Type: `string`, Default: `FzfLuaBufNr`
 
-Highlight group for buffer number in buffer type pickers, i.e. `buffers`, `tabs`, `lines`.
+Highlight group for buffer number in `buffers`, `tabs`.
+
+#### globals.hls.buf_linenr
+
+Type: `string`, Default: `FzfLuaBufLineNr`
+
+Highlight group for buffer line number in `lines`, `blines` and `treesitter`.
 
 #### globals.hls.buf_flag_cur
 

--- a/doc/fzf-lua-opts.txt
+++ b/doc/fzf-lua-opts.txt
@@ -1,4 +1,4 @@
-*fzf-lua-opts.txt*      For Neovim >= 0.8.0      Last change: 2024 December 06
+*fzf-lua-opts.txt*      For Neovim >= 0.8.0      Last change: 2024 December 16
 
 ==============================================================================
 Table of Contents                             *fzf-lua-opts-table-of-contents*
@@ -726,7 +726,7 @@ globals.hls.path_linenr                 *fzf-lua-opts-globals.hls.path_linenr*
 Type: `string`, Default: `FzfLuaPathLineNr`
 
 Highlight group for the line part of paths, e.g. `file:<line>:<col>:`, used in
-pickers such as `buffers`, `lines`, `quickfix`, `lsp`, `diagnostics`, etc.
+pickers such as `buffers`, `quickfix`, `lsp`, `diagnostics`, etc.
 
 
                                                                               
@@ -735,7 +735,7 @@ globals.hls.path_colnr                   *fzf-lua-opts-globals.hls.path_colnr*
 Type: `string`, Default: `FzfLuaPathColNr`
 
 Highlight group for the column part of paths, e.g. `file:<line>:<col>:`, used
-in pickers such as `buffers`, `lines`, `quickfix`, `lsp`, `diagnostics`, etc.
+in pickers such as `buffers`, `quickfix`, `lsp`, `diagnostics`, etc.
 
 
                                                                               
@@ -743,7 +743,15 @@ globals.hls.buf_name                       *fzf-lua-opts-globals.hls.buf_name*
 
 Type: `string`, Default: `FzfLuaBufName`
 
-Highlight group for buffer name in `lines`.
+Highlight group for buffer name (filepath) in `lines`.
+
+
+                                                                              
+globals.hls.buf_id                           *fzf-lua-opts-globals.hls.buf_id*
+
+Type: `string`, Default: `FzfLuaBufId`
+
+Highlight group for buffer id (number) in `lines`.
 
 
                                                                               
@@ -751,8 +759,15 @@ globals.hls.buf_nr                           *fzf-lua-opts-globals.hls.buf_nr*
 
 Type: `string`, Default: `FzfLuaBufNr`
 
-Highlight group for buffer number in buffer type pickers, i.e. `buffers`,
-`tabs`, `lines`.
+Highlight group for buffer number in `buffers`, `tabs`.
+
+
+                                                                              
+globals.hls.buf_linenr                   *fzf-lua-opts-globals.hls.buf_linenr*
+
+Type: `string`, Default: `FzfLuaBufLineNr`
+
+Highlight group for buffer line number in `lines`, `blines` and `treesitter`.
 
 
                                                                               

--- a/lua/fzf-lua/core.lua
+++ b/lua/fzf-lua/core.lua
@@ -498,9 +498,6 @@ end
 -- Create fzf --color arguments from a table of vim highlight groups.
 M.create_fzf_colors = function(opts)
   local colors = opts and opts.fzf_colors
-  if type(colors) == "function" then
-    colors = colors(opts)
-  end
   -- auto create `fzf_colors` based on Neovim's current colorscheme
   if colors == true then
     colors = {
@@ -622,15 +619,6 @@ end
 ---@param opts table
 ---@return string[]
 M.build_fzf_cli = function(opts, fzf_win)
-  opts.fzf_opts = vim.tbl_extend("force", config.globals.fzf_opts, opts.fzf_opts or {})
-  -- copy/merge from globals
-  for _, o in ipairs({ "fzf_colors", "keymap" }) do
-    if opts[o] == nil then
-      opts[o] = config.globals[o]
-    elseif type(opts[o]) == "table" and type(config.globals[o]) == "table" then
-      opts[o] = vim.tbl_deep_extend("keep", opts[o], config.globals[o])
-    end
-  end
   -- below options can be specified directly in opts and will be
   -- prioritized: opts.<name> is prioritized over fzf_opts["--name"]
   for _, flag in ipairs({ "query", "prompt", "header", "preview" }) do

--- a/lua/fzf-lua/init.lua
+++ b/lua/fzf-lua/init.lua
@@ -81,24 +81,26 @@ function M.setup_highlights(override)
       { default = default, fg = is_light and "MediumSpringGreen" or "BlanchedAlmond" } },
     { "FzfLuaHeaderText", "header_text",
       { default = default, fg = is_light and "Brown4" or "Brown1" } },
-    { "FzfLuaPathColNr", "path_colnr",   -- lines|blines|qf|diag|lsp
+    { "FzfLuaPathColNr", "path_colnr",   -- qf|diag|lsp
       { default = default, fg = is_light and "CadetBlue4" or "CadetBlue1" } },
-    { "FzfLuaPathLineNr", "path_linenr", -- lines|blines|qf|diag|lsp
+    { "FzfLuaPathLineNr", "path_linenr", -- qf|diag|lsp
       { default = default, fg = is_light and "MediumSpringGreen" or "LightGreen" } },
-    { "FzfLuaLiveSym", "live_sym",
+    { "FzfLuaLiveSym", "live_sym",       -- lsp_live_workspace_symbols query
       { default = default, fg = is_light and "Brown4" or "Brown1" } },
-    -- Provider specific highlights
-    { "FzfLuaBufName", "buf_name",        -- lines|blines (hidden)
-      { default = default, fg = is_light and "DarkOrchid3" or "LightMagenta" } },
-    { "FzfLuaBufNr", "buf_nr",            -- buffers|tabs|lines|blines
+    -- lines|blines|treesitter
+    { "FzfLuaBufId",     "buf_id",     { default = default, link = "TabLine" } },
+    { "FzfLuaBufName",   "buf_name",   { default = default, link = "Directory" } },
+    { "FzfLuaBufLineNr", "buf_linenr", { default = default, link = "LineNr" } },
+    -- buffers|tabs
+    { "FzfLuaBufNr", "buf_nr",
       { default = default, fg = is_light and "AquaMarine3" or "BlanchedAlmond" } },
-    { "FzfLuaBufFlagCur", "buf_flag_cur", -- buffers|tabs
+    { "FzfLuaBufFlagCur", "buf_flag_cur",
       { default = default, fg = is_light and "Brown4" or "Brown1" } },
-    { "FzfLuaBufFlagAlt", "buf_flag_alt", -- buffers|tabs
+    { "FzfLuaBufFlagAlt", "buf_flag_alt",
       { default = default, fg = is_light and "CadetBlue4" or "CadetBlue1" } },
-    { "FzfLuaTabTitle", "tab_title",      -- tabs
+    { "FzfLuaTabTitle", "tab_title",   -- tabs only
       { default = default, fg = is_light and "CadetBlue4" or "LightSkyBlue1", bold = true } },
-    { "FzfLuaTabMarker", "tab_marker",    -- tabs
+    { "FzfLuaTabMarker", "tab_marker", -- tabs only
       { default = default, fg = is_light and "MediumSpringGreen" or "BlanchedAlmond", bold = true } },
     -- highlight groups for `fzf_colors=true`
     { "FzfLuaFzfNormal",     "fzf.normal",     { default = default, link = "FzfLuaNormal" } },

--- a/lua/fzf-lua/lib/utf8.lua
+++ b/lua/fzf-lua/lib/utf8.lua
@@ -1,0 +1,1084 @@
+---@diagnostic disable: codestyle-check
+-- https://gist.github.com/subsoap/05c02690956499a84708365337eb0a99
+-- https://github.com/Stepets/utf8.lua
+-- $Id: utf8.lua 179 2009-04-03 18:10:03Z pasta $
+--
+-- Provides UTF-8 aware string functions implemented in pure lua:
+-- * utf8len(s)
+-- * utf8sub(s, i, j)
+-- * utf8reverse(s)
+-- * utf8char(unicode)
+-- * utf8unicode(s, i, j)
+-- * utf8gensub(s, sub_len)
+-- * utf8find(str, regex, init, plain)
+-- * utf8match(str, regex, init)
+-- * utf8gmatch(str, regex, all)
+-- * utf8gsub(str, regex, repl, limit)
+--
+-- If utf8data.lua (containing the lower<->upper case mappings) is loaded, these
+-- additional functions are available:
+-- * utf8upper(s)
+-- * utf8lower(s)
+--
+-- All functions behave as their non UTF-8 aware counterparts with the exception
+-- that UTF-8 characters are used instead of bytes for all units.
+
+--[[
+Copyright (c) 2006-2007, Kyle Smith
+All rights reserved.
+
+Contributors:
+Alimov Stepan
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice,
+this list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+* Neither the name of the author nor the names of its contributors may be
+used to endorse or promote products derived from this software without
+specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+--]]
+
+-- ABNF from RFC 3629
+--
+-- UTF8-octets = *( UTF8-char )
+-- UTF8-char   = UTF8-1 / UTF8-2 / UTF8-3 / UTF8-4
+-- UTF8-1      = %x00-7F
+-- UTF8-2      = %xC2-DF UTF8-tail
+-- UTF8-3      = %xE0 %xA0-BF UTF8-tail / %xE1-EC 2( UTF8-tail ) /
+--               %xED %x80-9F UTF8-tail / %xEE-EF 2( UTF8-tail )
+-- UTF8-4      = %xF0 %x90-BF 2( UTF8-tail ) / %xF1-F3 3( UTF8-tail ) /
+--               %xF4 %x80-8F 2( UTF8-tail )
+-- UTF8-tail   = %x80-BF
+--
+
+local byte    = string.byte
+local char    = string.char
+local dump    = string.dump
+local find    = string.find
+local format  = string.format
+local len     = string.len
+local lower   = string.lower
+local rep     = string.rep
+local sub     = string.sub
+local upper   = string.upper
+
+-- returns the number of bytes used by the UTF-8 character at byte i in s
+-- also doubles as a UTF-8 character validator
+local function utf8charbytes (s, i)
+	-- argument defaults
+	i = i or 1
+
+	-- argument checking
+	if type(s) ~= "string" then
+		error("bad argument #1 to 'utf8charbytes' (string expected, got ".. type(s).. ")")
+	end
+	if type(i) ~= "number" then
+		error("bad argument #2 to 'utf8charbytes' (number expected, got ".. type(i).. ")")
+	end
+
+	local c = byte(s, i)
+
+	-- determine bytes needed for character, based on RFC 3629
+	-- validate byte 1
+	if c > 0 and c <= 127 then
+		-- UTF8-1
+		return 1
+
+	elseif c >= 194 and c <= 223 then
+		-- UTF8-2
+		local c2 = byte(s, i + 1)
+
+		if not c2 then
+			error("UTF-8 string terminated early")
+		end
+
+		-- validate byte 2
+		if c2 < 128 or c2 > 191 then
+			error("Invalid UTF-8 character")
+		end
+
+		return 2
+
+	elseif c >= 224 and c <= 239 then
+		-- UTF8-3
+		local c2 = byte(s, i + 1)
+		local c3 = byte(s, i + 2)
+
+		if not c2 or not c3 then
+			error("UTF-8 string terminated early")
+		end
+
+		-- validate byte 2
+		if c == 224 and (c2 < 160 or c2 > 191) then
+			error("Invalid UTF-8 character")
+		elseif c == 237 and (c2 < 128 or c2 > 159) then
+			error("Invalid UTF-8 character")
+		elseif c2 < 128 or c2 > 191 then
+			error("Invalid UTF-8 character")
+		end
+
+		-- validate byte 3
+		if c3 < 128 or c3 > 191 then
+			error("Invalid UTF-8 character")
+		end
+
+		return 3
+
+	elseif c >= 240 and c <= 244 then
+		-- UTF8-4
+		local c2 = byte(s, i + 1)
+		local c3 = byte(s, i + 2)
+		local c4 = byte(s, i + 3)
+
+		if not c2 or not c3 or not c4 then
+			error("UTF-8 string terminated early")
+		end
+
+		-- validate byte 2
+		if c == 240 and (c2 < 144 or c2 > 191) then
+			error("Invalid UTF-8 character")
+		elseif c == 244 and (c2 < 128 or c2 > 143) then
+			error("Invalid UTF-8 character")
+		elseif c2 < 128 or c2 > 191 then
+			error("Invalid UTF-8 character")
+		end
+
+		-- validate byte 3
+		if c3 < 128 or c3 > 191 then
+			error("Invalid UTF-8 character")
+		end
+
+		-- validate byte 4
+		if c4 < 128 or c4 > 191 then
+			error("Invalid UTF-8 character")
+		end
+
+		return 4
+
+	else
+		error("Invalid UTF-8 character")
+	end
+end
+
+-- returns the number of characters in a UTF-8 string
+local function utf8len (s)
+	-- argument checking
+	if type(s) ~= "string" then
+		for k,v in pairs(s) do print('"',tostring(k),'"',tostring(v),'"') end
+		error("bad argument #1 to 'utf8len' (string expected, got ".. type(s).. ")")
+	end
+
+	local pos = 1
+	local bytes = len(s)
+	local length = 0
+
+	while pos <= bytes do
+		length = length + 1
+		pos = pos + utf8charbytes(s, pos)
+	end
+
+	return length
+end
+
+-- functions identically to string.sub except that i and j are UTF-8 characters
+-- instead of bytes
+local function utf8sub (s, i, j)
+	-- argument defaults
+	j = j or -1
+
+	local pos = 1
+	local bytes = len(s)
+	local length = 0
+
+	-- only set l if i or j is negative
+	local l = (i >= 0 and j >= 0) or utf8len(s)
+	local startChar = (i >= 0) and i or l + i + 1
+	local endChar   = (j >= 0) and j or l + j + 1
+
+	-- can't have start before end!
+	if startChar > endChar then
+		return ""
+	end
+
+	-- byte offsets to pass to string.sub
+	local startByte,endByte = 1,bytes
+
+	while pos <= bytes do
+		length = length + 1
+
+		if length == startChar then
+			startByte = pos
+		end
+
+		pos = pos + utf8charbytes(s, pos)
+
+		if length == endChar then
+			endByte = pos - 1
+			break
+		end
+	end
+
+	if startChar > length then startByte = bytes+1   end
+	if endChar   < 1      then endByte   = 0         end
+
+	return sub(s, startByte, endByte)
+end
+
+--[[
+-- replace UTF-8 characters based on a mapping table
+local function utf8replace (s, mapping)
+	-- argument checking
+	if type(s) ~= "string" then
+		error("bad argument #1 to 'utf8replace' (string expected, got ".. type(s).. ")")
+	end
+	if type(mapping) ~= "table" then
+		error("bad argument #2 to 'utf8replace' (table expected, got ".. type(mapping).. ")")
+	end
+
+	local pos = 1
+	local bytes = len(s)
+	local charbytes
+	local newstr = ""
+
+	while pos <= bytes do
+		charbytes = utf8charbytes(s, pos)
+		local c = sub(s, pos, pos + charbytes - 1)
+
+		newstr = newstr .. (mapping[c] or c)
+
+		pos = pos + charbytes
+	end
+
+	return newstr
+end
+
+
+-- identical to string.upper except it knows about unicode simple case conversions
+local function utf8upper (s)
+	return utf8replace(s, utf8_lc_uc)
+end
+
+-- identical to string.lower except it knows about unicode simple case conversions
+local function utf8lower (s)
+	return utf8replace(s, utf8_uc_lc)
+end
+]]
+
+-- identical to string.reverse except that it supports UTF-8
+local function utf8reverse (s)
+	-- argument checking
+	if type(s) ~= "string" then
+		error("bad argument #1 to 'utf8reverse' (string expected, got ".. type(s).. ")")
+	end
+
+	local bytes = len(s)
+	local pos = bytes
+	local charbytes
+	local newstr = ""
+
+	while pos > 0 do
+		local c = byte(s, pos)
+		while c >= 128 and c <= 191 do
+			pos = pos - 1
+			c = byte(s, pos)
+		end
+
+		charbytes = utf8charbytes(s, pos)
+
+		newstr = newstr .. sub(s, pos, pos + charbytes - 1)
+
+		pos = pos - 1
+	end
+
+	return newstr
+end
+
+-- http://en.wikipedia.org/wiki/Utf8
+-- http://developer.coronalabs.com/code/utf-8-conversion-utility
+local function utf8char(unicode)
+	if unicode <= 0x7F then return char(unicode) end
+
+	if (unicode <= 0x7FF) then
+		local Byte0 = 0xC0 + math.floor(unicode / 0x40);
+		local Byte1 = 0x80 + (unicode % 0x40);
+		return char(Byte0, Byte1);
+	end;
+
+	if (unicode <= 0xFFFF) then
+		local Byte0 = 0xE0 +  math.floor(unicode / 0x1000);
+		local Byte1 = 0x80 + (math.floor(unicode / 0x40) % 0x40);
+		local Byte2 = 0x80 + (unicode % 0x40);
+		return char(Byte0, Byte1, Byte2);
+	end;
+
+	if (unicode <= 0x10FFFF) then
+		local code = unicode
+		local Byte3= 0x80 + (code % 0x40);
+		code       = math.floor(code / 0x40)
+		local Byte2= 0x80 + (code % 0x40);
+		code       = math.floor(code / 0x40)
+		local Byte1= 0x80 + (code % 0x40);
+		code       = math.floor(code / 0x40)
+		local Byte0= 0xF0 + code;
+
+		return char(Byte0, Byte1, Byte2, Byte3);
+	end;
+
+	error 'Unicode cannot be greater than U+10FFFF!'
+end
+
+local shift_6  = 2^6
+local shift_12 = 2^12
+local shift_18 = 2^18
+
+local utf8unicode
+utf8unicode = function(str, i, j, byte_pos)
+	i = i or 1
+	j = j or i
+
+	if i > j then return end
+
+	local ch,bytes
+
+	if byte_pos then
+		bytes = utf8charbytes(str,byte_pos)
+		ch  = sub(str,byte_pos,byte_pos-1+bytes)
+	else
+		ch,byte_pos = utf8sub(str,i,i), 0
+		bytes       = #ch
+	end
+
+	local unicode
+
+	if bytes == 1 then unicode = byte(ch) end
+	if bytes == 2 then
+		local byte0,byte1 = byte(ch,1,2)
+		local code0,code1 = byte0-0xC0,byte1-0x80
+		unicode = code0*shift_6 + code1
+	end
+	if bytes == 3 then
+		local byte0,byte1,byte2 = byte(ch,1,3)
+		local code0,code1,code2 = byte0-0xE0,byte1-0x80,byte2-0x80
+		unicode = code0*shift_12 + code1*shift_6 + code2
+	end
+	if bytes == 4 then
+		local byte0,byte1,byte2,byte3 = byte(ch,1,4)
+		local code0,code1,code2,code3 = byte0-0xF0,byte1-0x80,byte2-0x80,byte3-0x80
+		unicode = code0*shift_18 + code1*shift_12 + code2*shift_6 + code3
+	end
+
+	return unicode,utf8unicode(str, i+1, j, byte_pos+bytes)
+end
+
+-- Returns an iterator which returns the next substring and its byte interval
+local function utf8gensub(str, sub_len)
+	sub_len        = sub_len or 1
+	local byte_pos = 1
+	local length   = #str
+	return function(skip)
+		if skip then byte_pos = byte_pos + skip end
+		local char_count = 0
+		local start      = byte_pos
+		repeat
+			if byte_pos > length then return end
+			char_count  = char_count + 1
+			local bytes = utf8charbytes(str,byte_pos)
+			byte_pos    = byte_pos+bytes
+
+		until char_count == sub_len
+
+		local last  = byte_pos-1
+		local slice = sub(str,start,last)
+		return slice, start, last
+	end
+end
+
+local function binsearch(sortedTable, item, comp)
+	local head, tail = 1, #sortedTable
+	local mid = math.floor((head + tail)/2)
+	if not comp then
+		while (tail - head) > 1 do
+			if sortedTable[tonumber(mid)] > item then
+				tail = mid
+			else
+				head = mid
+			end
+			mid = math.floor((head + tail)/2)
+		end
+	end
+	if sortedTable[tonumber(head)] == item then
+		return true, tonumber(head)
+	elseif sortedTable[tonumber(tail)] == item then
+		return true, tonumber(tail)
+	else
+		return false
+	end
+end
+local function classMatchGenerator(class, plain)
+	local codes = {}
+	local ranges = {}
+	local ignore = false
+	local range = false
+	local firstletter = true
+	local unmatch = false
+
+	local it = utf8gensub(class)
+
+	local skip
+	for c, _, be in it do
+		skip = be
+		if not ignore and not plain then
+			if c == "%" then
+				ignore = true
+			elseif c == "-" then
+				table.insert(codes, utf8unicode(c))
+				range = true
+			elseif c == "^" then
+				if not firstletter then
+					error('!!!')
+				else
+					unmatch = true
+				end
+			elseif c == ']' then
+				break
+			else
+				if not range then
+					table.insert(codes, utf8unicode(c))
+				else
+					table.remove(codes) -- removing '-'
+					table.insert(ranges, {table.remove(codes), utf8unicode(c)})
+					range = false
+				end
+			end
+		elseif ignore and not plain then
+			if c == 'a' then -- %a: represents all letters. (ONLY ASCII)
+				table.insert(ranges, {65, 90}) -- A - Z
+				table.insert(ranges, {97, 122}) -- a - z
+			elseif c == 'c' then -- %c: represents all control characters.
+				table.insert(ranges, {0, 31})
+				table.insert(codes, 127)
+			elseif c == 'd' then -- %d: represents all digits.
+				table.insert(ranges, {48, 57}) -- 0 - 9
+			elseif c == 'g' then -- %g: represents all printable characters except space.
+				table.insert(ranges, {1, 8})
+				table.insert(ranges, {14, 31})
+				table.insert(ranges, {33, 132})
+				table.insert(ranges, {134, 159})
+				table.insert(ranges, {161, 5759})
+				table.insert(ranges, {5761, 8191})
+				table.insert(ranges, {8203, 8231})
+				table.insert(ranges, {8234, 8238})
+				table.insert(ranges, {8240, 8286})
+				table.insert(ranges, {8288, 12287})
+			elseif c == 'l' then -- %l: represents all lowercase letters. (ONLY ASCII)
+				table.insert(ranges, {97, 122}) -- a - z
+			elseif c == 'p' then -- %p: represents all punctuation characters. (ONLY ASCII)
+				table.insert(ranges, {33, 47})
+				table.insert(ranges, {58, 64})
+				table.insert(ranges, {91, 96})
+				table.insert(ranges, {123, 126})
+			elseif c == 's' then -- %s: represents all space characters.
+				table.insert(ranges, {9, 13})
+				table.insert(codes, 32)
+				table.insert(codes, 133)
+				table.insert(codes, 160)
+				table.insert(codes, 5760)
+				table.insert(ranges, {8192, 8202})
+				table.insert(codes, 8232)
+				table.insert(codes, 8233)
+				table.insert(codes, 8239)
+				table.insert(codes, 8287)
+				table.insert(codes, 12288)
+			elseif c == 'u' then -- %u: represents all uppercase letters. (ONLY ASCII)
+				table.insert(ranges, {65, 90}) -- A - Z
+			elseif c == 'w' then -- %w: represents all alphanumeric characters. (ONLY ASCII)
+				table.insert(ranges, {48, 57}) -- 0 - 9
+				table.insert(ranges, {65, 90}) -- A - Z
+				table.insert(ranges, {97, 122}) -- a - z
+			elseif c == 'x' then -- %x: represents all hexadecimal digits.
+				table.insert(ranges, {48, 57}) -- 0 - 9
+				table.insert(ranges, {65, 70}) -- A - F
+				table.insert(ranges, {97, 102}) -- a - f
+			else
+				if not range then
+					table.insert(codes, utf8unicode(c))
+				else
+					table.remove(codes) -- removing '-'
+					table.insert(ranges, {table.remove(codes), utf8unicode(c)})
+					range = false
+				end
+			end
+			ignore = false
+		else
+			if not range then
+				table.insert(codes, utf8unicode(c))
+			else
+				table.remove(codes) -- removing '-'
+				table.insert(ranges, {table.remove(codes), utf8unicode(c)})
+				range = false
+			end
+			ignore = false
+		end
+
+		firstletter = false
+	end
+
+	table.sort(codes)
+
+	local function inRanges(charCode)
+		for _,r in ipairs(ranges) do
+			if r[1] <= charCode and charCode <= r[2] then
+				return true
+			end
+		end
+		return false
+	end
+	if not unmatch then
+		return function(charCode)
+			return binsearch(codes, charCode) or inRanges(charCode)
+		end, skip
+	else
+		return function(charCode)
+			return charCode ~= -1 and not (binsearch(codes, charCode) or inRanges(charCode))
+		end, skip
+	end
+end
+
+--[[
+-- utf8sub with extra argument, and extra result value
+local function utf8subWithBytes (s, i, j, sb)
+	-- argument defaults
+	j = j or -1
+
+	local pos = sb or 1
+	local bytes = len(s)
+	local length = 0
+
+	-- only set l if i or j is negative
+	local l = (i >= 0 and j >= 0) or utf8len(s)
+	local startChar = (i >= 0) and i or l + i + 1
+	local endChar   = (j >= 0) and j or l + j + 1
+
+	-- can't have start before end!
+	if startChar > endChar then
+		return ""
+	end
+
+	-- byte offsets to pass to string.sub
+	local startByte,endByte = 1,bytes
+
+	while pos <= bytes do
+		length = length + 1
+
+		if length == startChar then
+			startByte = pos
+		end
+
+		pos = pos + utf8charbytes(s, pos)
+
+		if length == endChar then
+			endByte = pos - 1
+			break
+		end
+	end
+
+	if startChar > length then startByte = bytes+1   end
+	if endChar   < 1      then endByte   = 0         end
+
+	return sub(s, startByte, endByte), endByte + 1
+end
+]]
+
+local cache = setmetatable({},{
+	__mode = 'kv'
+})
+local cachePlain = setmetatable({},{
+	__mode = 'kv'
+})
+local function matcherGenerator(regex, plain)
+	local matcher = {
+		functions = {},
+		captures = {}
+	}
+	if not plain then
+		cache[regex] =  matcher
+	else
+		cachePlain[regex] = matcher
+	end
+	local function simple(func)
+		return function(cC)
+			if func(cC) then
+				matcher:nextFunc()
+				matcher:nextStr()
+			else
+				matcher:reset()
+			end
+		end
+	end
+	local function star(func)
+		return function(cC)
+			if func(cC) then
+				matcher:fullResetOnNextFunc()
+				matcher:nextStr()
+			else
+				matcher:nextFunc()
+			end
+		end
+	end
+	local function minus(func)
+		return function(cC)
+			if func(cC) then
+				matcher:fullResetOnNextStr()
+			end
+			matcher:nextFunc()
+		end
+	end
+	local function question(func)
+		return function(cC)
+			if func(cC) then
+				matcher:fullResetOnNextFunc()
+				matcher:nextStr()
+			end
+			matcher:nextFunc()
+		end
+	end
+
+	local function capture(id)
+		return function(_)
+			local l = matcher.captures[id][2] - matcher.captures[id][1]
+			local captured = utf8sub(matcher.string, matcher.captures[id][1], matcher.captures[id][2])
+			local check = utf8sub(matcher.string, matcher.str, matcher.str + l)
+			if captured == check then
+				for _ = 0, l do
+					matcher:nextStr()
+				end
+				matcher:nextFunc()
+			else
+				matcher:reset()
+			end
+		end
+	end
+	local function captureStart(id)
+		return function(_)
+			matcher.captures[id][1] = matcher.str
+			matcher:nextFunc()
+		end
+	end
+	local function captureStop(id)
+		return function(_)
+			matcher.captures[id][2] = matcher.str - 1
+			matcher:nextFunc()
+		end
+	end
+
+	local function balancer(str)
+		local sum = 0
+		local bc, ec = utf8sub(str, 1, 1), utf8sub(str, 2, 2)
+		local skip = len(bc) + len(ec)
+		bc, ec = utf8unicode(bc), utf8unicode(ec)
+		return function(cC)
+			if cC == ec and sum > 0 then
+				sum = sum - 1
+				if sum == 0 then
+					matcher:nextFunc()
+				end
+				matcher:nextStr()
+			elseif cC == bc then
+				sum = sum + 1
+				matcher:nextStr()
+			else
+				if sum == 0 or cC == -1 then
+					sum = 0
+					matcher:reset()
+				else
+					matcher:nextStr()
+				end
+			end
+		end, skip
+	end
+
+	matcher.functions[1] = function(_)
+		matcher:fullResetOnNextStr()
+		matcher.seqStart = matcher.str
+		matcher:nextFunc()
+		if (matcher.str > matcher.startStr and matcher.fromStart) or matcher.str >= matcher.stringLen then
+			matcher.stop = true
+			matcher.seqStart = nil
+		end
+	end
+
+	local lastFunc
+	local ignore = false
+	local skip = nil
+	local it = (function()
+		local gen = utf8gensub(regex)
+		return function()
+			return gen(skip)
+		end
+	end)()
+	local cs = {}
+	for c, bs, be in it do
+		skip = nil
+		if plain then
+			table.insert(matcher.functions, simple(classMatchGenerator(c, plain)))
+		else
+			if ignore then
+				if find('123456789', c, 1, true) then
+					if lastFunc then
+						table.insert(matcher.functions, simple(lastFunc))
+						lastFunc = nil
+					end
+					table.insert(matcher.functions, capture(tonumber(c)))
+				elseif c == 'b' then
+					if lastFunc then
+						table.insert(matcher.functions, simple(lastFunc))
+						lastFunc = nil
+					end
+					local b
+					b, skip = balancer(sub(regex, be + 1, be + 9))
+					table.insert(matcher.functions, b)
+				else
+					lastFunc = classMatchGenerator('%' .. c)
+				end
+				ignore = false
+			else
+				if c == '*' then
+					if lastFunc then
+						table.insert(matcher.functions, star(lastFunc))
+						lastFunc = nil
+					else
+						error('invalid regex after ' .. sub(regex, 1, bs))
+					end
+				elseif c == '+' then
+					if lastFunc then
+						table.insert(matcher.functions, simple(lastFunc))
+						table.insert(matcher.functions, star(lastFunc))
+						lastFunc = nil
+					else
+						error('invalid regex after ' .. sub(regex, 1, bs))
+					end
+				elseif c == '-' then
+					if lastFunc then
+						table.insert(matcher.functions, minus(lastFunc))
+						lastFunc = nil
+					else
+						error('invalid regex after ' .. sub(regex, 1, bs))
+					end
+				elseif c == '?' then
+					if lastFunc then
+						table.insert(matcher.functions, question(lastFunc))
+						lastFunc = nil
+					else
+						error('invalid regex after ' .. sub(regex, 1, bs))
+					end
+				elseif c == '^' then
+					if bs == 1 then
+						matcher.fromStart = true
+					else
+						error('invalid regex after ' .. sub(regex, 1, bs))
+					end
+				elseif c == '$' then
+					if be == len(regex) then
+						matcher.toEnd = true
+					else
+						error('invalid regex after ' .. sub(regex, 1, bs))
+					end
+				elseif c == '[' then
+					if lastFunc then
+						table.insert(matcher.functions, simple(lastFunc))
+					end
+					lastFunc, skip = classMatchGenerator(sub(regex, be + 1))
+				elseif c == '(' then
+					if lastFunc then
+						table.insert(matcher.functions, simple(lastFunc))
+						lastFunc = nil
+					end
+					table.insert(matcher.captures, {})
+					table.insert(cs, #matcher.captures)
+					table.insert(matcher.functions, captureStart(cs[#cs]))
+					if sub(regex, be + 1, be + 1) == ')' then matcher.captures[#matcher.captures].empty = true end
+				elseif c == ')' then
+					if lastFunc then
+						table.insert(matcher.functions, simple(lastFunc))
+						lastFunc = nil
+					end
+					local cap = table.remove(cs)
+					if not cap then
+						error('invalid capture: "(" missing')
+					end
+					table.insert(matcher.functions, captureStop(cap))
+				elseif c == '.' then
+					if lastFunc then
+						table.insert(matcher.functions, simple(lastFunc))
+					end
+					lastFunc = function(cC) return cC ~= -1 end
+				elseif c == '%' then
+					ignore = true
+				else
+					if lastFunc then
+						table.insert(matcher.functions, simple(lastFunc))
+					end
+					lastFunc = classMatchGenerator(c)
+				end
+			end
+		end
+	end
+	if #cs > 0 then
+		error('invalid capture: ")" missing')
+	end
+	if lastFunc then
+		table.insert(matcher.functions, simple(lastFunc))
+	end
+
+	table.insert(matcher.functions, function()
+		if matcher.toEnd and matcher.str ~= matcher.stringLen then
+			matcher:reset()
+		else
+			matcher.stop = true
+		end
+	end)
+
+	matcher.nextFunc = function(self)
+		self.func = self.func + 1
+	end
+	matcher.nextStr = function(self)
+		self.str = self.str + 1
+	end
+	matcher.strReset = function(self)
+		local oldReset = self.reset
+		local str = self.str
+		self.reset = function(s)
+			s.str = str
+			s.reset = oldReset
+		end
+	end
+	matcher.fullResetOnNextFunc = function(self)
+		local oldReset = self.reset
+		local func = self.func +1
+		local str = self.str
+		self.reset = function(s)
+			s.func = func
+			s.str = str
+			s.reset = oldReset
+		end
+	end
+	matcher.fullResetOnNextStr = function(self)
+		local oldReset = self.reset
+		local str = self.str + 1
+		local func = self.func
+		self.reset = function(s)
+			s.func = func
+			s.str = str
+			s.reset = oldReset
+		end
+	end
+
+	matcher.process = function(self, str, start)
+
+		self.func = 1
+		start = start or 1
+		self.startStr = (start >= 0) and start or utf8len(str) + start + 1
+		self.seqStart = self.startStr
+		self.str = self.startStr
+		self.stringLen = utf8len(str) + 1
+		self.string = str
+		self.stop = false
+
+		self.reset = function(s)
+			s.func = 1
+		end
+
+		-- local lastPos = self.str
+		-- local lastByte
+		local ch
+		while not self.stop do
+			if self.str < self.stringLen then
+				--[[ if lastPos < self.str then
+				print('last byte', lastByte)
+				ch, lastByte = utf8subWithBytes(str, 1, self.str - lastPos - 1, lastByte)
+				ch, lastByte = utf8subWithBytes(str, 1, 1, lastByte)
+				lastByte = lastByte - 1
+			else
+				ch, lastByte = utf8subWithBytes(str, self.str, self.str)
+			end
+			lastPos = self.str ]]
+			ch = utf8sub(str, self.str,self.str)
+			--print('char', ch, utf8unicode(ch))
+			self.functions[self.func](utf8unicode(ch))
+		else
+			self.functions[self.func](-1)
+		end
+	end
+
+	if self.seqStart then
+		local captures = {}
+		for _,pair in pairs(self.captures) do
+			if pair.empty then
+				table.insert(captures, pair[1])
+			else
+				table.insert(captures, utf8sub(str, pair[1], pair[2]))
+			end
+		end
+		return self.seqStart, self.str - 1, unpack(captures)
+	end
+end
+
+return matcher
+end
+
+-- string.find
+local function utf8find(str, regex, init, plain)
+local matcher = cache[regex] or matcherGenerator(regex, plain)
+return matcher:process(str, init)
+end
+
+-- string.match
+local function utf8match(str, regex, init)
+init = init or 1
+local found = {utf8find(str, regex, init)}
+if found[1] then
+	if found[3] then
+		return unpack(found, 3)
+	end
+	return utf8sub(str, found[1], found[2])
+end
+end
+
+-- string.gmatch
+local function utf8gmatch(str, regex, all)
+regex = (utf8sub(regex,1,1) ~= '^') and regex or '%' .. regex
+local lastChar = 1
+return function()
+	local found = {utf8find(str, regex, lastChar)}
+	if found[1] then
+		lastChar = found[2] + 1
+		if found[all and 1 or 3] then
+			return unpack(found, all and 1 or 3)
+		end
+		return utf8sub(str, found[1], found[2])
+	end
+end
+end
+
+local function replace(repl, args)
+local ret = ''
+if type(repl) == 'string' then
+	local ignore = false
+	local num
+	for c in utf8gensub(repl) do
+		if not ignore then
+			if c == '%' then
+				ignore = true
+			else
+				ret = ret .. c
+			end
+		else
+			num = tonumber(c)
+			if num then
+				ret = ret .. args[num]
+			else
+				ret = ret .. c
+			end
+			ignore = false
+		end
+	end
+elseif type(repl) == 'table' then
+	ret = repl[args[1] or args[0]] or ''
+elseif type(repl) == 'function' then
+	if #args > 0 then
+		ret = repl(unpack(args, 1)) or ''
+	else
+		ret = repl(args[0]) or ''
+	end
+end
+return ret
+end
+-- string.gsub
+local function utf8gsub(str, regex, repl, limit)
+limit = limit or -1
+local ret = ''
+local prevEnd = 1
+local it = utf8gmatch(str, regex, true)
+local found = {it()}
+local n = 0
+while #found > 0 and limit ~= n do
+	local args = {[0] = utf8sub(str, found[1], found[2]), unpack(found, 3)}
+	ret = ret .. utf8sub(str, prevEnd, found[1] - 1)
+	.. replace(repl, args)
+	prevEnd = found[2] + 1
+	n = n + 1
+	found = {it()}
+end
+return ret .. utf8sub(str, prevEnd), n
+end
+
+-- EXPORT
+
+local M = {}
+
+function M.len(s)
+	return utf8len(s)
+end
+function M.sub(s, i, j)
+	return utf8sub(s, i, j)
+end
+function M.reverse(s)
+	return utf8reverse(s)
+end
+function M.char(unicode)
+	return utf8char(unicode)
+end
+function M.unicode(s, i, j)
+	return utf8unicode(s, i, j)
+end
+function M.gensub(s, sub_len)
+	return utf8gensub(s, sub_len)
+end
+function M.byte(s, i, j)
+	return utf8unicode(s, i, j)
+end
+function M.find(str, regex, init, plain)
+	return utf8find(str, regex, init, plain)
+end
+function M.match(str, regex, init)
+	return utf8match(str, regex, init)
+end
+function M.gmatch(str, regex, all)
+	return utf8gmatch(str, regex, all)
+end
+function M.gsub(str, regex, repl, limit)
+	return utf8gsub(str, regex, repl, limit)
+end
+function M.dump(s)
+	return dump(s)
+end
+function M.format(s)
+	return format(s)
+end
+function M.lower(s)
+	return lower(s)
+end
+function M.upper(s)
+	return upper(s)
+end
+function M.rep(s)
+	return rep(s)
+end
+
+return M

--- a/lua/fzf-lua/previewer/builtin.lua
+++ b/lua/fzf-lua/previewer/builtin.lua
@@ -130,16 +130,16 @@ function Previewer.base:new(o, opts, fzf_win)
   self.title = self.win.winopts.preview.title
   self.title_pos = self.win.winopts.preview.title_pos
   self.title_fnamemodify = o.title_fnamemodify
-  self.render_markdown = o.render_markdown or {}
-  self.render_markdown.filetypes = type(self.render_markdown.filetypes) == "table" and
-      self.render_markdown.filetypes or {}
+  self.render_markdown = type(o.render_markdown) == "table" and o.render_markdown or {}
+  self.render_markdown.filetypes =
+      type(self.render_markdown.filetypes) == "table" and self.render_markdown.filetypes or {}
   self.winopts = self.win.winopts.preview.winopts
   self.syntax = default(o.syntax, true)
   self.syntax_delay = tonumber(default(o.syntax_delay, 0))
   self.syntax_limit_b = tonumber(default(o.syntax_limit_b, 1024 * 1024))
   self.syntax_limit_l = tonumber(default(o.syntax_limit_l, 0))
   self.limit_b = tonumber(default(o.limit_b, 1024 * 1024 * 10))
-  self.treesitter = o.treesitter or {}
+  self.treesitter = type(o.treesitter) == "table" and o.treesitter or {}
   self.toggle_behavior = o.toggle_behavior
   self.ext_ft_override = o.ext_ft_override
   self.winopts_orig = {}
@@ -870,7 +870,7 @@ end
 function Previewer.base:update_ts_context()
   if not self.win
       or not self.win:validate_preview()
-      or not self.treesitter.enable
+      or not self.treesitter.enabled
       or not self.treesitter.context
   then
     return
@@ -887,7 +887,7 @@ function Previewer.base:update_render_markdown()
   local bufnr, winid = self.preview_bufnr, self.win.preview_winid
   local ft = vim.b[bufnr] and vim.b[bufnr]._ft
   if not ft
-      or not self.render_markdown.enable
+      or not self.render_markdown.enabled
       or not self.render_markdown.filetypes[ft]
   then
     return
@@ -939,12 +939,12 @@ function Previewer.buffer_or_file:do_syntax(entry)
             end
             local ts_enabled = (function()
               if not self.treesitter or
-                  self.treesitter.enable == false or
-                  self.treesitter.disable == true or
-                  (type(self.treesitter.enable) == "table" and
-                    not utils.tbl_contains(self.treesitter.enable, ft)) or
-                  (type(self.treesitter.disable) == "table" and
-                    utils.tbl_contains(self.treesitter.disable, ft)) then
+                  self.treesitter.enabled == false or
+                  self.treesitter.disabled == true or
+                  (type(self.treesitter.enabled) == "table" and
+                    not utils.tbl_contains(self.treesitter.enabled, ft)) or
+                  (type(self.treesitter.disabled) == "table" and
+                    utils.tbl_contains(self.treesitter.disabled, ft)) then
                 return false
               end
               return true

--- a/lua/fzf-lua/profiles/default-title.lua
+++ b/lua/fzf-lua/profiles/default-title.lua
@@ -18,6 +18,7 @@ return {
   blines               = title("Buffer Lines"),
   treesitter           = title("Treesitter"),
   grep                 = title("Grep", { prompt = "> " }),
+  grep_curbuf          = title("Buffer Grep", { prompt = "> " }),
   git                  = {
     files    = title("Git Files"),
     status   = title("Git Status"),
@@ -43,7 +44,7 @@ return {
   lsp                  = {
     title_prefix = "LSP",
     winopts      = { title_pos = "center" },
-    symbols      = { title_prefix = "LSP", winopts = { title_pos = "center" } },
+    symbols      = { prompt = "> ", title_prefix = "LSP", winopts = { title_pos = "center" } },
     finder       = title("LSP Finder"),
     code_actions = title("Code Actions"),
   },

--- a/lua/fzf-lua/profiles/fzf-tmux.lua
+++ b/lua/fzf-lua/profiles/fzf-tmux.lua
@@ -9,4 +9,6 @@ return {
   lsp = { code_actions = { previewer = "codeaction_native" } },
   tags = { previewer = "bat" },
   btags = { previewer = "bat" },
+  lines = { _treesitter = false },
+  blines = { _treesitter = false },
 }

--- a/lua/fzf-lua/profiles/telescope.lua
+++ b/lua/fzf-lua/profiles/telescope.lua
@@ -50,7 +50,7 @@ return {
     ["hl+"] = { "fg", "TelescopeMatching" },
     ["info"] = { "fg", "TelescopeMultiSelection" },
     ["border"] = { "fg", "TelescopeBorder" },
-    ["gutter"] = { "bg", "TelescopeNormal" },
+    ["gutter"] = "-1",
     ["query"] = { "fg", "TelescopePromptNormal" },
     ["prompt"] = { "fg", "TelescopePromptPrefix" },
     ["pointer"] = { "fg", "TelescopeSelectionCaret" },

--- a/lua/fzf-lua/providers/buffers.lua
+++ b/lua/fzf-lua/providers/buffers.lua
@@ -59,49 +59,58 @@ local filter_buffers = function(opts, unfiltered)
   return bufnrs, excluded, max_bufnr
 end
 
+
+local getbuf = function(buf)
+  return {
+    bufnr = buf,
+    flag = (buf == core.CTX().bufnr and "%")
+        or (buf == core.CTX().alt_bufnr and "#") or " ",
+    info = utils.getbufinfo(buf),
+    readonly = vim.bo[buf].readonly
+  }
+end
+
+-- switching buffers and opening 'buffers' in quick succession
+-- can lead to incorrect sort as 'lastused' isn't updated fast
+-- enough (neovim bug?), this makes sure the current buffer is
+-- always on top (#646)
+-- Hopefully this gets solved before the year 2100
+-- DON'T FORCE ME TO UPDATE THIS HACK NEOVIM LOL
+local _FUTURE = os.time({ year = 2100, month = 1, day = 1, hour = 0, minute = 00 })
+local get_unixtime = function(buf)
+  if tonumber(buf) then
+    -- When called from `buffer_lines`
+    buf = getbuf(buf)
+  end
+  if buf.flag == "%" then
+    return _FUTURE
+  elseif buf.flag == "#" then
+    return _FUTURE - 1
+  else
+    return buf.info.lastused
+  end
+end
+
 local populate_buffer_entries = function(opts, bufnrs, winid)
   local buffers = {}
   for _, bufnr in ipairs(bufnrs) do
-    local flag = (bufnr == core.CTX().bufnr and "%")
-        or (bufnr == core.CTX().alt_bufnr and "#") or " "
-
-    local element = {
-      bufnr = bufnr,
-      flag = flag,
-      info = utils.getbufinfo(bufnr),
-      readonly = vim.bo[bufnr].readonly
-    }
+    local buf = getbuf(bufnr)
 
     -- Get the name for missing/quickfix/location list buffers
     -- NOTE: we get it here due to `gen_buffer_entry` called within a fast event
-    if not element.info.name or #element.info.name == 0 then
-      element.info.name = utils.nvim_buf_get_name(element.bufnr, element.info)
+    if not buf.info.name or #buf.info.name == 0 then
+      buf.info.name = utils.nvim_buf_get_name(buf.bufnr, buf.info)
     end
 
     -- get the correct lnum for tabbed buffers
     if winid then
-      element.info.lnum = vim.api.nvim_win_get_cursor(winid)[1]
+      buf.info.lnum = vim.api.nvim_win_get_cursor(winid)[1]
     end
 
-    table.insert(buffers, element)
+    table.insert(buffers, buf)
   end
+
   if opts.sort_lastused then
-    -- switching buffers and opening 'buffers' in quick succession
-    -- can lead to incorrect sort as 'lastused' isn't updated fast
-    -- enough (neovim bug?), this makes sure the current buffer is
-    -- always on top (#646)
-    -- Hopefully this gets solved before the year 2100
-    -- DON'T FORCE ME TO UPDATE THIS HACK NEOVIM LOL
-    local future = os.time({ year = 2100, month = 1, day = 1, hour = 0, minute = 00 })
-    local get_unixtime = function(buf)
-      if buf.flag == "%" then
-        return future
-      elseif buf.flag == "#" then
-        return future - 1
-      else
-        return buf.info.lastused
-      end
-    end
     table.sort(buffers, function(a, b)
       return get_unixtime(a) > get_unixtime(b)
     end)
@@ -221,9 +230,6 @@ end
 M.buffer_lines = function(opts)
   if not opts then return end
 
-  -- formatter doesn't work with lines|blines as only filename is displayed
-  opts._fmt = false
-
   opts.fn_pre_fzf = function() core.CTX(true) end
   opts.fn_pre_fzf()
 
@@ -242,10 +248,28 @@ M.buffer_lines = function(opts)
       local buffers = filter_buffers(opts,
         opts.current_buffer_only and { core.CTX().bufnr } or core.CTX().buflist)
 
+      if opts.sort_lastused and utils.tbl_count(buffers) > 1 then
+        table.sort(buffers, function(a, b)
+          return get_unixtime(a) > get_unixtime(b)
+        end)
+      end
+
+      local bnames = {}
+      local longest_bname = 0
+      for _, b in ipairs(buffers) do
+        local bname = utils.nvim_buf_get_name(b)
+        if not bname:match("^%[") then
+          bname = path.shorten(vim.fn.fnamemodify(bname, ":~:."))
+        end
+        longest_bname = math.max(longest_bname, #bname)
+        bnames[tostring(b)] = bname
+      end
+      local len_bufnames = math.min(15, longest_bname)
+
       for _, bufnr in ipairs(buffers) do
         local data = {}
-        local bufname, buficon, hl
-        -- use vim.schedule to avoid
+
+        -- Use vim.schedule to avoid
         -- E5560: vimL function must not be called in a lua loop callback
         vim.schedule(function()
           local filepath = vim.api.nvim_buf_get_name(bufnr)
@@ -254,21 +278,34 @@ M.buffer_lines = function(opts)
           elseif vim.fn.filereadable(filepath) ~= 0 then
             data = vim.fn.readfile(filepath, "")
           end
-          bufname = path.basename(filepath)
-          if opts.file_icons then
-            buficon, hl = devicons.get_devicon(bufname)
-            if hl and opts.color_icons then
-              buficon = utils.ansi_from_rgb(hl, buficon)
-            end
-          end
-          if not bufname or #bufname == 0 then
-            bufname = utils.nvim_buf_get_name(bufnr)
-          end
           coroutine.resume(co)
         end)
 
         -- wait for vim.schedule
         coroutine.yield()
+
+        local bname, bicon = (function()
+          if not opts.show_bufname
+              or tonumber(opts.show_bufname) and tonumber(opts.show_bufname) > vim.o.columns
+          then
+            return
+          end
+          local bicon, hl = "", nil
+          local bname = bnames[tostring(bufnr)]
+          assert(bname)
+
+          if #bname > len_bufnames + 1 then
+            bname = "…" .. bname:sub(#bname - len_bufnames + 2)
+          end
+
+          if opts.file_icons then
+            bicon, hl = devicons.get_devicon(bname)
+            if hl and opts.color_icons then
+              bicon = utils.ansi_from_rgb(hl, bicon)
+            end
+          end
+          return bname, bicon and bicon .. utils.nbsp or nil
+        end)()
 
         local offset, lines = 0, #data
         if opts.current_buffer_only and opts.start == "cursor" then
@@ -281,14 +318,20 @@ M.buffer_lines = function(opts)
           if lnum > lines then
             lnum = lnum % lines
           end
-          add_entry(string.format("[%s]%s%s%s%s:%s: %s",
-            utils.ansi_codes[opts.hls.buf_nr](tostring(bufnr)),
-            utils.nbsp,
-            buficon or "",
-            buficon and utils.nbsp or "",
-            utils.ansi_codes[opts.hls.buf_name](bufname),
-            utils.ansi_codes[opts.hls.path_linenr](tostring(lnum)),
-            data[lnum]), co)
+
+          -- NOTE: Space after `lnum` is U+00A0 (decimal: 160)
+          add_entry(string.format("[%s]\t%s\t%s%s\t%s \t%s",
+            tostring(bufnr),
+            utils.ansi_codes[opts.hls.buf_id](string.format("%3d", bufnr)),
+            bicon or "",
+            not bname and "" or utils.ansi_codes[opts.hls.buf_name](string.format(
+              "%"
+              .. (opts.file_icons and "-" or "")
+              .. tostring(len_bufnames) .. "s",
+              bname)),
+            utils.ansi_codes[opts.hls.buf_linenr](string.format("%5d", lnum)),
+            data[lnum]
+          ), co)
         end
       end
       cb(nil)
@@ -450,11 +493,11 @@ M.treesitter = function(opts)
               local lnum, col, _, _ = vim.treesitter.get_node_range(node.node)
               local node_text = vim.treesitter.get_node_text(node.node, opts.bufnr)
               local node_kind = node.kind and utils.ansi_from_hl(kind2hl(node.kind), node.kind)
-              local entry = string.format("[%s]%s%s:%s:%s:\t[%s] %s",
+              local entry = string.format("[%s]%s%s:%s:%s\t\t[%s] %s",
                 utils.ansi_codes[opts.hls.buf_nr](tostring(opts.bufnr)),
                 utils.nbsp,
                 utils.ansi_codes[opts.hls.buf_name](opts._bufname),
-                utils.ansi_codes[opts.hls.path_linenr](tostring(lnum + 1)),
+                utils.ansi_codes[opts.hls.buf_linenr](tostring(lnum + 1)),
                 utils.ansi_codes[opts.hls.path_colnr](tostring(col + 1)),
                 node_kind or "",
                 node_text)

--- a/lua/fzf-lua/providers/helptags.lua
+++ b/lua/fzf-lua/providers/helptags.lua
@@ -3,104 +3,101 @@ local core = require "fzf-lua.core"
 local utils = require "fzf-lua.utils"
 local config = require "fzf-lua.config"
 
-
 local M = {}
-
-local fzf_fn = function(cb)
-  local opts = {}
-  opts.lang = config.globals.helptags.lang or vim.o.helplang
-  opts.fallback = config.globals.helptags.fallback == nil and true
-      or config.globals.helptags.fallback
-
-  local langs = vim.split(opts.lang, ",")
-  if opts.fallback and not utils.tbl_contains(langs, "en") then
-    table.insert(langs, "en")
-  end
-  local langs_map = {}
-  for _, lang in ipairs(langs) do
-    langs_map[lang] = true
-  end
-
-  local tag_files = {}
-  local function add_tag_file(lang, file)
-    if langs_map[lang] then
-      if tag_files[lang] then
-        table.insert(tag_files[lang], file)
-      else
-        tag_files[lang] = { file }
-      end
-    end
-  end
-
-  local help_files = {}
-  local rtp = vim.o.runtimepath
-  -- If using lazy.nvim, get all the lazy loaded plugin paths (#1296)
-  local lazy = package.loaded["lazy.core.util"]
-  if lazy and lazy.get_unloaded_rtp then
-    local paths = lazy.get_unloaded_rtp("")
-    rtp = rtp .. "," .. table.concat(paths, ",")
-  end
-  local all_files = vim.fn.globpath(rtp, "doc/*", 1, 1)
-  for _, fullpath in ipairs(all_files) do
-    local file = path.tail(fullpath)
-    if file == "tags" then
-      add_tag_file("en", fullpath)
-    elseif file:match("^tags%-..$") then
-      local lang = file:sub(-2)
-      add_tag_file(lang, fullpath)
-    else
-      help_files[file] = fullpath
-    end
-  end
-
-  local hl = (function()
-    local _, _, fn = utils.ansi_from_hl("Label", "foo")
-    return function(s) return fn(s) end
-  end)()
-
-  local add_tag = function(t, fzf_cb, co)
-    local tag = string.format("%-80s %s%s%s", hl(t.tag), t.filename, utils.nbsp, t.filepath)
-    fzf_cb(tag, function()
-      coroutine.resume(co)
-    end)
-  end
-
-  coroutine.wrap(function()
-    local co = coroutine.running()
-    local tags_map = {}
-    local delimiter = string.char(9)
-    for _, lang in ipairs(langs) do
-      for _, file in ipairs(tag_files[lang] or {}) do
-        local lines = vim.split(utils.read_file(file), "\n")
-        for _, line in ipairs(lines) do
-          -- TODO: also ignore tagComment starting with ';'
-          if not line:match "^!_TAG_" then
-            local fields = vim.split(line, delimiter)
-            if #fields == 3 and not tags_map[fields[1]] then
-              add_tag({
-                tag = fields[1],
-                filename = fields[2],
-                filepath = help_files[fields[2]],
-                cmd = fields[3],
-                lang = lang,
-              }, cb, co)
-              tags_map[fields[1]] = true
-              -- pause here until we call coroutine.resume()
-              coroutine.yield()
-            end
-          end
-        end
-      end
-    end
-    cb(nil)
-  end)()
-end
-
 
 M.helptags = function(opts)
   opts = config.normalize_opts(opts, "helptags")
   if not opts then return end
-  core.fzf_exec(fzf_fn, opts)
+
+  local contents = function(cb)
+    opts.lang = opts.lang or vim.o.helplang
+    opts.fallback = opts.fallback ~= false and true
+
+    local langs = vim.split(opts.lang, ",")
+    if opts.fallback and not utils.tbl_contains(langs, "en") then
+      table.insert(langs, "en")
+    end
+    local langs_map = {}
+    for _, lang in ipairs(langs) do
+      langs_map[lang] = true
+    end
+
+    local tag_files = {}
+    local function add_tag_file(lang, file)
+      if langs_map[lang] then
+        if tag_files[lang] then
+          table.insert(tag_files[lang], file)
+        else
+          tag_files[lang] = { file }
+        end
+      end
+    end
+
+    local help_files = {}
+    local rtp = vim.o.runtimepath
+    -- If using lazy.nvim, get all the lazy loaded plugin paths (#1296)
+    local lazy = package.loaded["lazy.core.util"]
+    if lazy and lazy.get_unloaded_rtp then
+      local paths = lazy.get_unloaded_rtp("")
+      rtp = rtp .. "," .. table.concat(paths, ",")
+    end
+    local all_files = vim.fn.globpath(rtp, "doc/*", 1, 1)
+    for _, fullpath in ipairs(all_files) do
+      local file = path.tail(fullpath)
+      if file == "tags" then
+        add_tag_file("en", fullpath)
+      elseif file:match("^tags%-..$") then
+        local lang = file:sub(-2)
+        add_tag_file(lang, fullpath)
+      else
+        help_files[file] = fullpath
+      end
+    end
+
+    local hl = (function()
+      local _, _, fn = utils.ansi_from_hl("Label", "foo")
+      return function(s) return fn(s) end
+    end)()
+
+    local add_tag = function(t, fzf_cb, co)
+      local tag = string.format("%-80s %s%s%s", hl(t.tag), t.filename, utils.nbsp, t.filepath)
+      fzf_cb(tag, function()
+        coroutine.resume(co)
+      end)
+    end
+
+    coroutine.wrap(function()
+      local co = coroutine.running()
+      local tags_map = {}
+      local delimiter = string.char(9)
+      for _, lang in ipairs(langs) do
+        for _, file in ipairs(tag_files[lang] or {}) do
+          local lines = vim.split(utils.read_file(file), "\n")
+          for _, line in ipairs(lines) do
+            -- TODO: also ignore tagComment starting with ';'
+            if not line:match "^!_TAG_" then
+              local fields = vim.split(line, delimiter)
+              if #fields == 3 and not tags_map[fields[1]] then
+                add_tag({
+                  tag = fields[1],
+                  filename = fields[2],
+                  filepath = help_files[fields[2]],
+                  cmd = fields[3],
+                  lang = lang,
+                }, cb, co)
+                tags_map[fields[1]] = true
+                -- pause here until we call coroutine.resume()
+                coroutine.yield()
+              end
+            end
+          end
+        end
+      end
+      cb(nil)
+    end)()
+  end
+
+  core.fzf_exec(contents, opts)
 end
 
 return M


### PR DESCRIPTION
Semi-breaking (backward compat): builtin previewer `enable = ...` options renamed to `enabled = ...` for consistency with other plugins conventions:
- previewers.builtin.treesitter.enable -> enabled
- previewers.builtin.treesitter.disable -> disabled
- previewers.builtin.render_markdown.enable -> enabled

Warning messages will be sent to the message log about old deprecated options (old ones too), can be disabled with `silent=true`:
```lua
require("fzf-lua").setup({ defaults = { silent = true } })
```

This commits also includes many other changes:
- `winopts.treesitter` can also be enabled (disabled by default) in grep/LSP pickers, but will be disabled in `live_grep` as ts highlights will override the regex highlighting
- When enabled `fzf_colors` will automatically set `hl,hl+` to `-1:reverse` which changes the background of the character, this is done to make the TS highlights more distingished NOTE1: `reverse` doesn't work as well with skim NOTE2: To disable set `winopts.treesitter.fzf_colors=false`
- Formatting changes for `lines,blines`, will match the formatting of `fzf.vim`, `treesitter` picker formatting slightly improved
- New highlights:
    + `FzfLuaBufId`: linked to `TabLine` by default, used to highlight the bufnr in `lines`
    + `FzfLuaBufLineNr`: linked to `LineNr` by default, used in `lines,blines,treesitter` for line numbers
- New option: `lines.show_bufname`, default value is `120`, will only display buffer name (filepath) if neovim's `columns > show_bufname`
- Separated `grep_curbuf|lgrep_curbuf` options to its own category
- Disabled with fzf-tmux profile as it does nothing (not a neovim buffer and thus can't enable the TS injector)
- Fixed Telescope profile gutter color (transparent)
- Highlights picker fuzzy matching colors set to "-1:reverse"
- Added `utf8.lua` library (unsued for now)