### PR TITLE
refactoring of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,108 +4,38 @@
 
 ![Neovim version](https://img.shields.io/badge/Neovim-0.5-57A143?style=flat-square&logo=neovim)
 
-[Quickstart](#quickstart) • [Installation](#installation) • [Usage](#usage) • [Commands](#commands) • [Customization](#customization) • [Wiki](https://github.com/ibhagwan/fzf-lua/wiki)
+[Installation](#installation) • [Quickstart](#quickstart) • [Commands](#commands) • [Customization](#options) • [Wiki](https://github.com/ibhagwan/fzf-lua/wiki)
 
 ![Demo](https://raw.githubusercontent.com/wiki/ibhagwan/fzf-lua/demo.gif)
 
-[fzf](https://github.com/junegunn/fzf) changed my command life, it can change
-yours too, if you allow it.
+> “because you can and you love `fzf`” ([@junegunn](https://github.com/junegunn))
+
+> [fzf](https://github.com/junegunn/fzf) is the single most impactful tool for my command line workflow, it changed my life and it can change yours too, if you allow it.
 
 </div>
 
-# Contents
+## Installation
 
-- [Quickstart](#quickstart)
-- [Rationale](#rationale)
-- [Why Fzf-lua](#why-fzf-lua)
-- [Dependencies](#dependencies)
-  + [Optional Dependencies](#optional-dependencies)
-  + [Windows Notes](#windows-notes)
-- [Installation](#installation)
-- [Usage](#usage)
-  + [Resume](#resume)
-  + [Options](#options)
-- [Commands](#commands)
-  + [Buffers and Files](#buffers-and-files)
-  + [Search](#search)
-  + [Tags](#tags)
-  + [Git](#git)
-  + [LSP | Diagnostics](#lspdiagnostics)
-  + [Misc](#misc)
-  + [Neovim API](#neovim-api)
-  + [`nvim-dap`](#nvim-dap)
-  + [`tmux`](#tmux)
-  + [Completion Functions](#completion-functions)
-- [Customization](#customization)
-  + [Profiles](#profiles)
-- [Insert-mode Completion](#insert-mode-completion)
-  + [Custom Completion](#custom-completion)
-- [Default Options](#default-options)
-- [Highlights](#highlights)
-  + [Fzf Colors](#fzf-colors)
-- [Credits](#credits)
+[![LuaRocks](https://img.shields.io/luarocks/v/ibhagwan/fzf-lua?logo=lua&color=purple)](https://luarocks.org/modules/ibhagwan/fzf-lua)
 
+Using [lazy.nvim](https://github.com/folke/lazy.nvim)
 
-## Quickstart
-
-To quickly test this plugin without changing your configuration run (will run in it's own sandbox
-with the default keybinds below):
-> [!NOTE]
-> it's good practice to first
-> [read the script](https://github.com/ibhagwan/fzf-lua/blob/main/scripts/mini.sh)
-> before running `sh -c` directly from the web
-```sh
-sh -c "$(curl -s https://raw.githubusercontent.com/ibhagwan/fzf-lua/main/scripts/mini.sh)"
+```lua
+{
+  "ibhagwan/fzf-lua",
+  -- optional for icon support
+  dependencies = { "nvim-tree/nvim-web-devicons" },
+  config = function()
+    -- calling `setup` is optional for customization
+    require("fzf-lua").setup({})
+  end
+}
 ```
 
-| Key       | Command           | Key       | Command           |
-| ----------| ------------------| ----------| ------------------|
-| `<C-\>`     | buffers           | `<C-p>`     | files             |
-| `<C-g>`     | grep              | `<C-l>`     | live_grep         |
-| `<C-k>`     | builtin commands  | `<F1>`      | neovim help       |
+<details>
+<summary>Show dependencies</summary>
 
-#### Coming from fzf.vim?
-
-Easy! run `:FzfLua setup_fzfvim_cmds` and use the same familiar commands
-used by fzf.vim, i.e. `:Files`, `:Rg`, etc.
-
-> Using the builtin `fzf-vim` profile will also create fzf.vim's user
-> commands, i.e. `require("fzf-lua").setup({ "fzf-vim" })`
-
-## Rationale
-
-What more can be said about [fzf](https://github.com/junegunn/fzf)? It is the
-single most impactful tool for my command line workflow, once I started using
-fzf I couldn’t see myself living without it.
-> **To understand fzf properly I highly recommended [fzf
-> screencast](https://www.youtube.com/watch?v=qgG5Jhi_Els) by
-> [@samoshkin](https://github.com/samoshkin)**
-
-This is my take on the original
-[fzf.vim](https://github.com/junegunn/fzf.vim), written in lua for neovim 0.5,
-it builds on the elegant
-[nvim-fzf](https://github.com/vijaymarupudi/nvim-fzf) as an async interface to
-create a performant and lightweight fzf client for neovim that rivals any of
-the new shiny fuzzy finders for neovim.
-
-## Why Fzf-Lua
-
-... and not
-[telescope](https://github.com/nvim-telescope/telescope.nvim)
-or any other vim/neovim household name?
-
-As [@junegunn](https://github.com/junegunn) himself put it, “because you can
-and you love `fzf`”.
-
-If you’re happy with your current setup there is absolutely no reason to switch.
-
-That said, without taking anything away from the greatness of other plugins I
-found it more efficient having a uniform experience between my shell and my
-nvim. In addition `fzf` has been a rock for me since I started using it and
-hadn’t failed me once, it never hangs and can handle almost anything you throw
-at it. That, **and colorful file icons and git indicators!**.
-
-## Dependencies
+### Dependencies
 
 - [`neovim`](https://github.com/neovim/neovim/releases) version > `0.5.0`
 - [`fzf`](https://github.com/junegunn/fzf) version > `0.25`
@@ -127,11 +57,13 @@ at it. That, **and colorful file icons and git indicators!**.
 - [nvim-treesitter-context](https://github.com/nvim-treesitter/nvim-treesitter-context) - for
   viewing treesitter context within the previewer
 - [render-markdown.nvim](https://github.com/MeanderingProgrammer/render-markdown.nvim) or
-  [markview.nvim](https://github.com/OXY2DEV/markview.nvim) - for rendering markdown
+  [markview.nvim](https://github.com/OXY2DEV/markview.nvim - for rendering markdown
   files in the previewer
+  )
 
 Below are a few optional dependencies for viewing media files (which you need
 to configure in `previewer.builtin.extensions`):
+
 - [chafa](https://github.com/hpjansson/chafa) - terminal image previewer
   (recommended, supports most file formats)
 - [viu](https://github.com/atanunq/viu) - terminal image previewer
@@ -149,66 +81,13 @@ to configure in `previewer.builtin.extensions`):
   [chocolatey](https://chocolatey.org/install) or
   [winget-cli](https://github.com/microsoft/winget-cli)
 
-- Although almost everything works on Windows exactly as the *NIX/OSX check out
+- Although almost everything works on Windows exactly as the \*NIX/OSX check out
   the [Windows README](https://github.com/ibhagwan/fzf-lua/blob/main/README-Win.md)
   for known issues and limitations.
 
+</details>
 
-## Installation
-
-[![LuaRocks](https://img.shields.io/luarocks/v/ibhagwan/fzf-lua?logo=lua&color=purple)](https://luarocks.org/modules/ibhagwan/fzf-lua)
-
-Using [vim-plug](https://github.com/junegunn/vim-plug)
-
-```vim
-Plug 'ibhagwan/fzf-lua', {'branch': 'main'}
-" optional for icon support
-Plug 'nvim-tree/nvim-web-devicons'
-" or if using mini.icons/mini.nvim
-" Plug 'echasnovski/mini.icons'
-```
-
-Using [packer.nvim](https://github.com/wbthomason/packer.nvim)
-
-```lua
-use { "ibhagwan/fzf-lua",
-  -- optional for icon support
-  requires = { "nvim-tree/nvim-web-devicons" }
-  -- or if using mini.icons/mini.nvim
-  -- requires = { "echasnovski/mini.icons" }
-}
-```
-
-Using [lazy.nvim](https://github.com/folke/lazy.nvim)
-
-```lua
-{
-  "ibhagwan/fzf-lua",
-  -- optional for icon support
-  dependencies = { "nvim-tree/nvim-web-devicons" },
-  config = function()
-    -- calling `setup` is optional for customization
-    require("fzf-lua").setup({})
-  end
-}
-```
-> [!NOTE]
-> if you already have fzf installed you do not need to install `fzf` or
-> `fzf.vim`, however if you do not have it installed, **you only need** fzf
-> which can be installed with (fzf.vim is not a requirement nor conflict):
-> ```vim
-> Plug "junegunn/fzf", { "do": { -> fzf#install() } }
-> ```
-> or with [packer.nvim](https://github.com/wbthomason/packer.nvim):
->```lua
->use = { "junegunn/fzf", run = "./install --bin" }
->```
-> or with [lazy.nvim](https://github.com/folke/lazy.nvim)
->```lua
->{ "junegunn/fzf", build = "./install --bin" }
->```
-
-## Usage
+## Quickstart
 
 Fzf-lua aims to be as plug and play as possible with sane defaults, you can
 run any fzf-lua command like this:
@@ -220,73 +99,47 @@ run any fzf-lua command like this:
 ```
 
 or with arguments:
+
 ```lua
 :lua require('fzf-lua').files({ cwd = '~/.config' })
 -- or using the `FzfLua` vim command:
 :FzfLua files cwd=~/.config
 ```
 
-which can be easily mapped to:
-```vim
-nnoremap <c-P> <cmd>lua require('fzf-lua').files()<CR>
-```
-
-or if using `init.lua`:
-> Neovim versions below 0.7 can use `vim.api.nvim_set_keymap` instead
-```lua
-vim.keymap.set("n", "<c-P>", require('fzf-lua').files, { desc = "Fzf Files" })
--- Or, with args
-vim.keymap.set("n", "<c-P>", function() require('fzf-lua').files({ ... }) end, { desc = "Fzf Files" })
-```
-
-### Resume
-
-Resuming work from where you left off is as easy as:
-```lua
-:lua require('fzf-lua').resume()
--- or
-:FzfLua resume
-```
-
-Alternatively, resuming work on a specific provider:
-```lua
-:lua require('fzf-lua').files({ resume = true })
--- or
-:FzfLua files resume=true
-```
-
-### Options
-
-**Refer to [OPTIONS](https://github.com/ibhagwan/fzf-lua/blob/main/OPTIONS.md)
-to see detailed usage notes and a comprehensive list of all available options.**
+Choose among the many pickers we offer!!👇
 
 ## Commands
 
+<details>
+<summary>Browse commands!</summary>
+
 ### Buffers and Files
-| Command          | List                                       |
-| ---------------- | ------------------------------------------ |
-| `buffers`          | open buffers                               |
-| `files`            | `find` or `fd` on a path                       |
-| `oldfiles`         | opened files history                       |
-| `quickfix`         | quickfix list                              |
-| `quickfix_stack`   | quickfix stack                             |
-| `loclist`          | location list                              |
-| `loclist_stack`    | location stack                             |
-| `lines`            | open buffers lines                         |
-| `blines`           | current buffer lines                       |
-| `treesitter`       | current buffer treesitter symbols          |
-| `tabs`             | open tabs                                  |
-| `args`             | argument list                              |
+
+| Command          | List                              |
+| ---------------- | --------------------------------- |
+| `buffers`        | open buffers                      |
+| `files`          | `find` or `fd` on a path          |
+| `oldfiles`       | opened files history              |
+| `quickfix`       | quickfix list                     |
+| `quickfix_stack` | quickfix stack                    |
+| `loclist`        | location list                     |
+| `loclist_stack`  | location stack                    |
+| `lines`          | open buffers lines                |
+| `blines`         | current buffer lines              |
+| `treesitter`     | current buffer treesitter symbols |
+| `tabs`           | open tabs                         |
+| `args`           | argument list                     |
 
 ### Search
-| Command          | List                                       |
-| ---------------- | ------------------------------------------ |
-| `grep`             | search for a pattern with `grep` or `rg`       |
+
+| Command            | List                                       |
+| ------------------ | ------------------------------------------ |
+| `grep`             | search for a pattern with `grep` or `rg`   |
 | `grep_last`        | run search again with the last pattern     |
 | `grep_cword`       | search word under cursor                   |
 | `grep_cWORD`       | search WORD under cursor                   |
 | `grep_visual`      | search visual selection                    |
-| `grep_project`     | search all project lines (fzf.vim's `:Rg`)   |
+| `grep_project`     | search all project lines (fzf.vim's `:Rg`) |
 | `grep_curbuf`      | search current buffer lines                |
 | `grep_quickfix`    | search the quickfix list                   |
 | `grep_loclist`     | search the location list                   |
@@ -295,35 +148,38 @@ to see detailed usage notes and a comprehensive list of all available options.**
 | `lgrep_loclist`    | live grep the location list                |
 | `live_grep`        | live grep current project                  |
 | `live_grep_resume` | live grep continue last search             |
-| `live_grep_glob`   | live_grep with `rg --glob` support           |
-| `live_grep_native` | performant version of `live_grep`            |
+| `live_grep_glob`   | live_grep with `rg --glob` support         |
+| `live_grep_native` | performant version of `live_grep`          |
 
 ### Tags
-| Command          | List                                       |
-| ---------------- | ------------------------------------------ |
-| `tags`             | search project tags                        |
-| `btags`            | search buffer tags                         |
-| `tags_grep`        | grep project tags                          |
-| `tags_grep_cword`  | `tags_grep` word under cursor                |
-| `tags_grep_cWORD`  | `tags_grep` WORD under cursor                |
-| `tags_grep_visual` | `tags_grep` visual selection                 |
-| `tags_live_grep`   | live grep project tags                     |
+
+| Command            | List                          |
+| ------------------ | ----------------------------- |
+| `tags`             | search project tags           |
+| `btags`            | search buffer tags            |
+| `tags_grep`        | grep project tags             |
+| `tags_grep_cword`  | `tags_grep` word under cursor |
+| `tags_grep_cWORD`  | `tags_grep` WORD under cursor |
+| `tags_grep_visual` | `tags_grep` visual selection  |
+| `tags_live_grep`   | live grep project tags        |
 
 ### Git
-| Command          | List                                       |
-| ---------------- | ------------------------------------------ |
-| `git_files`        | `git ls-files`                               |
-| `git_status`       | `git status`                                 |
-| `git_commits`      | git commit log (project)                   |
-| `git_bcommits`     | git commit log (buffer)                    |
-| `git_blame`        | git blame (buffer)                         |
-| `git_branches`     | git branches                               |
-| `git_tags`         | git tags                                   |
-| `git_stash`        | git stash                                  |
+
+| Command        | List                     |
+| -------------- | ------------------------ |
+| `git_files`    | `git ls-files`           |
+| `git_status`   | `git status`             |
+| `git_commits`  | git commit log (project) |
+| `git_bcommits` | git commit log (buffer)  |
+| `git_blame`    | git blame (buffer)       |
+| `git_branches` | git branches             |
+| `git_tags`     | git tags                 |
+| `git_stash`    | git stash                |
 
 ### LSP/Diagnostics
-| Command          | List                                       |
-| ---------------- | ------------------------------------------ |
+
+| Command                      | List                             |
+| ---------------------------- | -------------------------------- |
 | `lsp_references`             | References                       |
 | `lsp_definitions`            | Definitions                      |
 | `lsp_declarations`           | Declarations                     |
@@ -338,235 +194,147 @@ to see detailed usage notes and a comprehensive list of all available options.**
 | `lsp_finder`                 | All LSP locations, combined view |
 | `diagnostics_document`       | Document Diagnostics             |
 | `diagnostics_workspace`      | Workspace Diagnostics            |
-| `lsp_document_diagnostics`   | alias to `diagnostics_document`    |
-| `lsp_workspace_diagnostics`  | alias to `diagnostics_workspace`   |
+| `lsp_document_diagnostics`   | alias to `diagnostics_document`  |
+| `lsp_workspace_diagnostics`  | alias to `diagnostics_workspace` |
 
 ### Misc
-| Command          | List                                       |
-| ---------------- | ------------------------------------------ |
-| `resume`               | resume last command/query              |
-| `builtin`              | fzf-lua builtin commands               |
-| `profiles`             | fzf-lua configuration profiles         |
-| `helptags`             | help tags                              |
-| `manpages`             | man pages                              |
-| `colorschemes`         | color schemes                          |
-| `awesome_colorschemes` | Awesome Neovim color schemes           | 
-| `highlights`           | highlight groups                       |
-| `commands`             | neovim commands                        |
-| `command_history`      | command history                        |
-| `search_history`       | search history                         |
-| `marks`                | :marks                                 |
-| `jumps`                | :jumps                                 |
-| `changes`              | :changes                               |
-| `registers`            | :registers                             |
-| `tagstack`             | :tags                                  |
-| `autocmds`             | :autocmd                               |
-| `keymaps`              | key mappings                           |
-| `filetypes`            | filetypes                              |
-| `menus`                | menus                                  |
-| `spell_suggest`        | spelling suggestions                   |
-| `packadd`              | :packadd <package>                     |
+
+| Command                | List                           |
+| ---------------------- | ------------------------------ |
+| `resume`               | resume last command/query      |
+| `builtin`              | fzf-lua builtin commands       |
+| `profiles`             | fzf-lua configuration profiles |
+| `helptags`             | help tags                      |
+| `manpages`             | man pages                      |
+| `colorschemes`         | color schemes                  |
+| `awesome_colorschemes` | Awesome Neovim color schemes   |
+| `highlights`           | highlight groups               |
+| `commands`             | neovim commands                |
+| `command_history`      | command history                |
+| `search_history`       | search history                 |
+| `marks`                | :marks                         |
+| `jumps`                | :jumps                         |
+| `changes`              | :changes                       |
+| `registers`            | :registers                     |
+| `tagstack`             | :tags                          |
+| `autocmds`             | :autocmd                       |
+| `keymaps`              | key mappings                   |
+| `filetypes`            | filetypes                      |
+| `menus`                | menus                          |
+| `spell_suggest`        | spelling suggestions           |
+| `packadd`              | :packadd <package>             |
 
 ### Neovim API
 
 > `:help vim.ui.select` for more info
 
-| Command              | List                                   |
-| -------------------- | -------------------------------------- |
-| `register_ui_select`   | register fzf-lua as the UI interface for `vim.ui.select`|
-| `deregister_ui_select` | de-register fzf-lua with `vim.ui.select` |
+| Command                | List                                                     |
+| ---------------------- | -------------------------------------------------------- |
+| `register_ui_select`   | register fzf-lua as the UI interface for `vim.ui.select` |
+| `deregister_ui_select` | de-register fzf-lua with `vim.ui.select`                 |
 
 ### nvim-dap
 
 > Requires [`nvim-dap`](https://github.com/mfussenegger/nvim-dap)
 
-| Command              | List                                       |
-| -------------------- | ------------------------------------------ |
-| `dap_commands`         | list,run `nvim-dap` builtin commands         |
-| `dap_configurations`   | list,run debug configurations              |
-| `dap_breakpoints`      | list,delete breakpoints                    |
-| `dap_variables`        | active session variables                   |
-| `dap_frames`           | active session jump to frame               |
+| Command              | List                                 |
+| -------------------- | ------------------------------------ |
+| `dap_commands`       | list,run `nvim-dap` builtin commands |
+| `dap_configurations` | list,run debug configurations        |
+| `dap_breakpoints`    | list,delete breakpoints              |
+| `dap_variables`      | active session variables             |
+| `dap_frames`         | active session jump to frame         |
 
 ### tmux
-| Command              | List                                       |
-| -------------------- | ------------------------------------------ |
-| `tmux_buffers`         | list tmux paste buffers                    |
+
+| Command        | List                    |
+| -------------- | ----------------------- |
+| `tmux_buffers` | list tmux paste buffers |
 
 ### Completion Functions
-| Command              | List                                       |
-| -------------------- | ------------------------------------------ |
-| `complete_path`        | complete path under cursor (incl dirs)     |
-| `complete_file`        | complete file under cursor (excl dirs)     |
-| `complete_line`        | complete line (all open buffers)           |
-| `complete_bline`       | complete line (current buffer only)        |
 
-## Customization
+| Command          | List                                   |
+| ---------------- | -------------------------------------- |
+| `complete_path`  | complete path under cursor (incl dirs) |
+| `complete_file`  | complete file under cursor (excl dirs) |
+| `complete_line`  | complete line (all open buffers)       |
+| `complete_bline` | complete line (current buffer only)    |
 
-> **[ADVANCED CUSTOMIZATION](https://github.com/ibhagwan/fzf-lua/wiki/Advanced)
-: to create your own fzf-lua commands see
-[Wiki/ADVANCED](https://github.com/ibhagwan/fzf-lua/wiki/Advanced)**
-
-Customization can be achieved by calling the `setup()` function (optional) or
-individually sending parameters to a builtin command, A few examples below:
-
-> Different `fzf` layout:
-```lua
-:lua require('fzf-lua').files({ fzf_opts = {['--layout'] = 'reverse-list'} })
-```
-
-> Using `files` with a different command and working directory:
-```lua
-:lua require'fzf-lua'.files({ prompt="LS> ", cmd = "ls", cwd="~/<folder>" })
-```
-
-> Using `live_grep` with `git grep`:
-```lua
-:lua require'fzf-lua'.live_grep({ cmd = "git grep --line-number --column --color=always" })
-```
-
-> `colorschemes` with non-default window size:
-```lua
-:lua require'fzf-lua'.colorschemes({ winopts = { height=0.33, width=0.33 } })
-```
-
-Use `setup()` If you wish for a setting to persist and not have to send it using the call
-arguments, e.g:
-```lua
-require('fzf-lua').setup{
-  winopts = {
-    ...
-  }
-}
-```
-
-Can also be called from a `.vim` file:
-```lua
-lua << EOF
-require('fzf-lua').setup{
-  ...
-}
-EOF
-```
-
-### Profiles
-
-Conveniently, fzf-lua comes with a set of preconfigured profiles, notably:
-| Profile          | Details                                    |
-| ---------------- | ------------------------------------------ |
-| `default`          | fzf-lua defaults, uses neovim "builtin" previewer and devicons (if available) for git/files/buffers |
-| `default-title`    | fzf-lua defaults, using title instead of prompt |
-| `fzf-native`       | utilizes fzf's native previewing ability in the terminal where possible using `bat` for previews |
-| `fzf-tmux`         | similar to `fzf-native` and opens in a tmux popup (requires tmux > 3.2) |
-| `fzf-vim`          | closest to `fzf.vim`'s defaults (+icons), also sets up user commands (`:Files`, `:Rg`, etc) |
-| `max-perf`         | similar to `fzf-native` and disables icons globally for max performance |
-| `telescope`        | closest match to telescope defaults in look and feel and keybinds |
-| `skim`             | uses [`skim`](https://github.com/skim-rs/skim) as an fzf alternative, (requires the `sk` binary) |
-
-Use `:FzfLua profiles` to experiment with the different profiles, once you've found what
-you like and wish to make the profile persist, send a `string` argument at the first index
-of the table sent to the `setup` function:
-> [!NOTE]
-> `setup` can be called multiple times for profile "live" switching
-```lua
-require('fzf-lua').setup({'fzf-native'})
-```
-
-You can also start with a profile as "baseline" and customize it, for example,
-telescope defaults with `bat` previewer:
-```lua
-:lua require"fzf-lua".setup({"telescope",winopts={preview={default="bat"}}})
-```
-
-Combining of profiles is also available by sending table instead of string as
-the first argument:
-```lua
-:lua require"fzf-lua".setup({{"telescope","fzf-native"},winopts={fullscreen=true}})
-```
-
-See [profiles](https://github.com/ibhagwan/fzf-lua/tree/main/lua/fzf-lua/profiles)
-for more info.
-
-### Insert-mode Completion
-
-Fzf-lua comes with a set of completion functions for paths/files and lines from open buffers as
-well as custom completion, for example, set path/completion using `<C-x><C-f>`:
-```vim
-inoremap <c-x><c-f> <cmd>lua require("fzf-lua").complete_path()<cr>
-```
-
-Or in all modes using lua:
-```lua
-vim.keymap.set({ "n", "v", "i" }, "<C-x><C-f>",
-  function() require("fzf-lua").complete_path() end,
-  { silent = true, desc = "Fuzzy complete path" })
-```
-
-Or with a custom command and preview:
-> [!NOTE]
-> only `complete_file` supports a previewer
-```lua
-vim.keymap.set({ "i" }, "<C-x><C-f>",
-  function()
-    require("fzf-lua").complete_file({
-      cmd = "rg --files",
-      winopts = { preview = { hidden = "nohidden" } }
-    })
-  end, { silent = true, desc = "Fuzzy complete file" })
-```
-
-#### Custom Completion
-
-Every fzf-lua function can be easily converted to a completion function by sending
-`complete = true` in the options:
-> By default fzf-lua will insert the entry at the cursor location as if you used
-> `p` to paste the selected entry.
-```lua
-require("fzf-lua").fzf_exec({"foo", "bar"}, {complete = true})
-```
-
-Custom completion is possible using a custom completion callback, the example below
-will replace the text from the current cursor column with the selected entry:
-```lua
-require("fzf-lua").fzf_exec({"foo", "bar"}, {
-  -- @param selected: the selected entry or entries
-  -- @param opts: fzf-lua caller/provider options
-  -- @param line: originating buffer completed line
-  -- @param col: originating cursor column location
-  -- @return newline: will replace the current buffer line
-  -- @return newcol?: optional, sets the new cursor column
-  complete = function(selected, opts, line, col)
-    local newline = line:sub(1, col) .. selected[1]
-    -- set cursor to EOL, since `nvim_win_set_cursor`
-    -- is 0-based we have to lower the col value by 1
-    return newline, #newline - 1
-  end
-})
-```
-
-### Default Options
-
-**Below is a list of most (still, not all default settings), please also
-consult the issues if there's something you need and you can't find as there
-have been many obscure requests which have been fulfilled and are yet to be
-documented. If you're still having issues and/or questions do not hesitate to open an
-issue and I'll be more than happy to help.**
+</details>
 
 <details>
-<summary>CLICK HERE TO EXPLORE THE DEFAULT OPTIONS</summary>
+<summary>Resume commands!</summary>
+
+Resuming work from where you left off is as easy as:
 
 ```lua
-local actions = require "fzf-lua.actions"
-require'fzf-lua'.setup {
-  -- fzf_bin         = 'sk',            -- use skim instead of fzf?
-                                        -- https://github.com/skim-rs/skim
-                                        -- can also be set to 'fzf-tmux'
+:lua require('fzf-lua').resume()
+-- or
+:FzfLua resume
+```
+
+Alternatively, resuming work on a specific provider:
+
+```lua
+:lua require('fzf-lua').files({ resume = true })
+-- or
+:FzfLua files resume=true
+```
+
+</details>
+
+## Options
+
+```lua
+require('fzf-lua').setup{
+  -- MISC GLOBAL SETUP OPTIONS, SEE BELOW
+  -- fzf_bin = ...,
   winopts = {
-    -- split         = "belowright new",-- open in a split instead?
-                                        -- "belowright new"  : split below
-                                        -- "aboveleft new"   : split above
-                                        -- "belowright vnew" : split right
-                                        -- "aboveleft vnew   : split left
+    ...
+  },
+  keymap = {
+    ...
+  },
+  actions = {
+    ...
+  },
+  hls = {
+    ...
+  },
+}
+```
+
+Where each of the above sections can be fully configured as below:
+
+<details>
+<summary>globals</summary>
+
+```lua
+ -- Use skim (or a speccific fzf binary/version) instead of fzf?
+  fzf_bin = 'sk',
+  -- Padding can help kitty term users with double-width icon rendering
+  file_icon_padding = '',
+  -- Uncomment if your terminal/font does not support unicode character
+  -- 'EN SPACE' (U+2002), the below sets it to 'NBSP' (U+00A0) instead
+  -- nbsp = '\xc2\xa0',
+  -- Function override for opening the help window (default bound to `<F1>`)
+  -- Override this function if you want to customize window config of the
+  -- help window (location, width, border, etc.)
+  help_open_win = vim.api.nvim_open_win,
+```
+
+</details>
+
+<details>
+<summary>winopts</summary>
+
+```lua
+winopts = {
+    -- split = "belowright new",-- open in a split instead?
+            -- "belowright new"  : split below
+            -- "aboveleft new"   : split above
+            -- "belowright vnew" : split right
+            -- "aboveleft vnew   : split left
     -- Only valid when using a float window
     -- (i.e. when 'split' is not defined, default)
     height           = 0.85,            -- window height
@@ -574,14 +342,10 @@ require'fzf-lua'.setup {
     row              = 0.35,            -- window row position (0=top, 1=bottom)
     col              = 0.50,            -- window col position (0=left, 1=right)
     -- border argument passthrough to nvim_open_win(), also used
-    -- to manually draw the border characters around the preview
-    -- window, can be set to 'false' to remove all borders or to
     -- 'none', 'single', 'double', 'thicc' (+cc) or 'rounded' (default)
     border           = { '╭', '─', '╮', '│', '╯', '─', '╰', '│' },
     -- Backdrop opacity, 0 is fully opaque, 100 is fully transparent (i.e. disabled)
     backdrop         = 60,
-    -- requires neovim > v0.9.0, passed as is to `nvim_open_win`
-    -- can be sent individually to any provider to set the win title
     -- title         = "Title",
     -- title_pos     = "center",    -- 'left', 'center' or 'right'
     fullscreen       = false,           -- start fullscreen?
@@ -633,8 +397,16 @@ require'fzf-lua'.setup {
     end,
     -- called once _after_ the fzf interface is closed
     -- on_close = function() ... end
-  },
-  keymap = {
+}
+```
+
+</details>
+
+<details>
+<summary>keymaps</summary>
+
+```lua
+keymap = {
     -- Below are the default binds, setting any value in these tables will override
     -- the defaults, to inherit from the defaults change [1] from `false` to `true`
     builtin = {
@@ -677,8 +449,17 @@ require'fzf-lua'.setup {
       ["shift-down"]  = "preview-page-down",
       ["shift-up"]    = "preview-page-up",
     },
-  },
-  actions = {
+},
+```
+
+</details>
+
+<details>
+<summary>actions</summary>
+
+```lua
+local actions = require "fzf-lua.actions"
+actions = {
     -- Below are the default actions, setting any value in these tables will override
     -- the defaults, to inherit from the defaults change [1] from `false` to `true`
     files = {
@@ -696,8 +477,16 @@ require'fzf-lua'.setup {
       ["alt-q"]       = actions.file_sel_to_qf,
       ["alt-Q"]       = actions.file_sel_to_ll,
     },
-  },
-  fzf_opts = {
+  }
+```
+
+</details>
+
+<details>
+<summary>fzf_opts</summary>
+
+```lua
+fzf_opts = {
     -- options are sent as `<left>=<right>`
     -- set to `false` to remove a flag
     -- set to `true` for a no-value flag
@@ -708,50 +497,22 @@ require'fzf-lua'.setup {
     ["--layout"]         = "reverse",
     ["--border"]         = "none",
     ["--highlight-line"] = true,           -- fzf >= v0.53
-  },
-  -- Only used when fzf_bin = "fzf-tmux", by default opens as a
-  -- popup 80% width, 80% height (note `-p` requires tmux > 3.2)
-  -- and removes the sides margin added by `fzf-tmux` (fzf#3162)
-  -- for more options run `fzf-tmux --help`
-  fzf_tmux_opts       = { ["-p"] = "80%,80%", ["--margin"] = "0,0" },
-  -- 
-  -- Set fzf's terminal colorscheme (optional)
-  --
-  -- Set to `true` to automatically generate an fzf's colorscheme from
-  -- Neovim's current colorscheme:
-  -- fzf_colors       = true,
-  -- 
-  -- Building a custom colorscheme, has the below specifications:
-  -- If rhs is of type "string" rhs will be passed raw, e.g.:
-  --   `["fg"] = "underline"` will be translated to `--color fg:underline`
-  -- If rhs is of type "table", the following convention is used:
-  --   [1] "what" field to extract from the hlgroup, i.e "fg", "bg", etc.
-  --   [2] Neovim highlight group(s), can be either "string" or "table"
-  --       when type is "table" the first existing highlight group is used
-  --   [3+] any additional fields are passed raw to fzf's command line args
-  -- Example of a "fully loaded" color option:
-  --   `["fg"] = { "fg", { "NonExistentHl", "Comment" }, "underline", "bold" }`
-  -- Assuming `Comment.fg=#010101` the resulting fzf command line will be:
-  --   `--color fg:#010101:underline:bold`
-  -- NOTE: to pass raw arguments `fzf_opts["--color"]` or `fzf_args`
-  --[[ fzf_colors = {
-      true,   -- inherit fzf colors that aren't specified below from
-              -- the auto-generated theme similar to `fzf_colors=true`
-      ["fg"]          = { "fg", "CursorLine" },
-      ["bg"]          = { "bg", "Normal" },
-      ["hl"]          = { "fg", "Comment" },
-      ["fg+"]         = { "fg", "Normal" },
-      ["bg+"]         = { "bg", "CursorLine" },
-      ["hl+"]         = { "fg", "Statement" },
-      ["info"]        = { "fg", "PreProc" },
-      ["prompt"]      = { "fg", "Conditional" },
-      ["pointer"]     = { "fg", "Exception" },
-      ["marker"]      = { "fg", "Keyword" },
-      ["spinner"]     = { "fg", "Label" },
-      ["header"]      = { "fg", "Comment" },
-      ["gutter"]      = "-1",
-  }, ]]
-  previewers = {
+  }
+
+-- Only used when fzf_bin = "fzf-tmux", by default opens as a
+-- popup 80% width, 80% height (note `-p` requires tmux > 3.2)
+-- and removes the sides margin added by `fzf-tmux` (fzf#3162)
+-- for more options run `fzf-tmux --help`
+fzf_tmux_opts       = { ["-p"] = "80%,80%", ["--margin"] = "0,0" },
+```
+
+</details>
+
+<details>
+<summary>previewers</summary>
+
+```lua
+previewers = {
     cat = {
       cmd             = "cat",
       args            = "-n",
@@ -759,8 +520,6 @@ require'fzf-lua'.setup {
     bat = {
       cmd             = "bat",
       args            = "--color=always --style=numbers,changes",
-      -- uncomment to set a bat theme, `bat --list-themes`
-      -- theme           = 'Coldark-Dark',
     },
     head = {
       cmd             = "head",
@@ -839,7 +598,17 @@ require'fzf-lua'.setup {
       -- recommended styling for delta
       --pager = [[delta --width=$COLUMNS --hunk-header-style="omit" --file-style="omit"]],
     },
-  },
+}
+```
+
+</details>
+
+<details>
+<summary>providers setups</summary>
+
+```lua
+
+
   -- PROVIDERS SETUP
   -- use `defaults` (table or function) if you wish to set "global-provider" defaults
   -- for example, using "mini.icons" globally and open the quickfix list at the top
@@ -1239,6 +1008,8 @@ require'fzf-lua'.setup {
     includeDeclaration = true,      -- include current declaration in LSP context
     -- settings for 'lsp_{document|workspace|lsp_live_workspace}_symbols'
     symbols = {
+        lsp_query         = ""          -- query passed to vim.lsp.buf.workspace_symbol({query=<lsp_query>}, {opts})
+        query             = ""          -- query passed to the fzf prompt to open the fuzzy search already
         async_or_timeout  = true,       -- symbols are async by default
         symbol_style      = 1,          -- style for document/workspace symbols
                                         -- false: disable,    1: icon+kind
@@ -1299,7 +1070,7 @@ require'fzf-lua'.setup {
         color_icons = true,
         git_icons   = false,
         async       = true,         -- async by default
-        silent      = true,         -- suppress "not found" 
+        silent      = true,         -- suppress "not found"
         separator   = "| ",         -- separator after provider prefix, `false` to disable
         includeDeclaration = true,  -- include current declaration in LSP context
         -- by default display all LSP locations
@@ -1324,25 +1095,6 @@ require'fzf-lua'.setup {
     diag_source       = true,   -- display diag source (e.g. [pycodestyle])
     icon_padding      = '',     -- add padding for wide diagnostics signs
     multiline         = true,   -- concatenate multi-line diags into a single line
-                                -- set to `false` to display the first line only
-    -- by default icons and highlights are extracted from 'DiagnosticSignXXX'
-    -- and highlighted by a highlight group of the same name (which is usually
-    -- set by your colorscheme, for more info see:
-    --   :help DiagnosticSignHint'
-    --   :help hl-DiagnosticSignHint'
-    -- only uncomment below if you wish to override the signs/highlights
-    -- define only text, texthl or both (':help sign_define()' for more info)
-    -- signs = {
-    --   ["Error"] = { text = "", texthl = "DiagnosticError" },
-    --   ["Warn"]  = { text = "", texthl = "DiagnosticWarn" },
-    --   ["Info"]  = { text = "", texthl = "DiagnosticInfo" },
-    --   ["Hint"]  = { text = "󰌵", texthl = "DiagnosticHint" },
-    -- },
-    -- limit to specific severity, use either a string or num:
-    --   1 or "hint"
-    --   2 or "information"
-    --   3 or "warning"
-    --   4 or "error"
     -- severity_only:   keep any matching exact severity
     -- severity_limit:  keep any equal or more severe (lower)
     -- severity_bound:  keep any equal or less severe (higher)
@@ -1371,143 +1123,248 @@ require'fzf-lua'.setup {
   -- (instead of using a neovim floating window)
   -- manpages = { previewer = "man_native" },
   -- helptags = { previewer = "help_native" },
-  -- 
-  -- padding can help kitty term users with double-width icon rendering
-  file_icon_padding = '',
-  -- uncomment if your terminal/font does not support unicode character
-  -- 'EN SPACE' (U+2002), the below sets it to 'NBSP' (U+00A0) instead
-  -- nbsp = '\xc2\xa0',
-  -- Function override for opening the help window (default bound to `<F1>`)
-  -- Override this function if you want to customize window config of the
-  -- help window (location, width, border, etc.)
-  help_open_win = vim.api.nvim_open_win,
+```
+
+</details>
+
+<details>
+<summary>hls</summary>
+
+```lua
+hls = {
+    normal = "..." -- highlight group for normal bg
+    preview_normal = "..." -- highlight group for preview bg
+    ...
+>>>>>>> 50bbf33 (docs: refactoring of README.md)
 }
+```
+
+where all the available highlight groups are listed in the [highlights](#highlights) section below.
+
+</details>
+
+If still not enough, check a more comprehensive list of [options](https://github.com/ibhagwan/fzf-lua/blob/main/OPTIONS.md) and detailed usage!
+
+If you wish to customise only specific calls without changing the general behaviours, you can individually send option parameters inline to the function calls: see the examples below
+
+<details>
+<summary>Examples of inline customisation</summary>
+
+> Different `fzf` layout:
+
+```lua
+:lua require('fzf-lua').files({ fzf_opts = {['--layout'] = 'reverse-list'} })
+```
+
+> Using `files` with a different command and working directory:
+
+```lua
+:lua require'fzf-lua'.files({ prompt="LS> ", cmd = "ls", cwd="~/<folder>" })
+```
+
+> Using `live_grep` with `git grep`:
+
+```lua
+:lua require'fzf-lua'.live_grep({ cmd = "git grep --line-number --column --color=always" })
+```
+
+> `colorschemes` with non-default window size:
+
+```lua
+:lua require'fzf-lua'.colorschemes({ winopts = { height=0.33, width=0.33 } })
+```
+
+</details>
+
+### Profiles
+
+Conveniently, fzf-lua comes with a set of preconfigured profiles if you do not want to tinker with customisation:
+
+<details>
+<summary>Browse profiles!</summary>
+
+| Profile         | Details                                                                                             |
+| --------------- | --------------------------------------------------------------------------------------------------- |
+| `default`       | fzf-lua defaults, uses neovim "builtin" previewer and devicons (if available) for git/files/buffers |
+| `default-title` | fzf-lua defaults, using title instead of prompt                                                     |
+| `fzf-native`    | utilizes fzf's native previewing ability in the terminal where possible using `bat` for previews    |
+| `fzf-tmux`      | similar to `fzf-native` and opens in a tmux popup (requires tmux > 3.2)                             |
+| `fzf-vim`       | closest to `fzf.vim`'s defaults (+icons), also sets up user commands (`:Files`, `:Rg`, etc)         |
+| `max-perf`      | similar to `fzf-native` and disables icons globally for max performance                             |
+| `telescope`     | closest match to telescope defaults in look and feel and keybinds                                   |
+| `skim`          | uses [`skim`](https://github.com/skim-rs/skim) as an fzf alternative, (requires the `sk` binary)    |
+
+</details>
+
+Use `:FzfLua profiles` to experiment with the different profiles, once you've found what
+you like and wish to make the profile persist, send a `string` argument at the first index
+of the table sent to the `setup` function:
+
+> [!NOTE] > `setup` can be called multiple times for profile "live" switching
+
+```lua
+require('fzf-lua').setup({'fzf-native'})
+```
+
+You can also start with a profile as "baseline" and customize it, for example,
+telescope defaults with `bat` previewer:
+
+```lua
+:lua require"fzf-lua".setup({"telescope",winopts={preview={default="bat"}}})
+```
+
+Combining of profiles is also available by sending table instead of string as
+the first argument:
+
+```lua
+:lua require"fzf-lua".setup({{"telescope","fzf-native"},winopts={fullscreen=true}})
+```
+
+See [profiles](https://github.com/ibhagwan/fzf-lua/tree/main/lua/fzf-lua/profiles) for more info.
+
+### Extensibility
+
+Fzf-lua can be easily extended and customised for your own needs: have a look at a full list of examples and plugins browsing the 💡[Wiki](https://github.com/ibhagwan/fzf-lua/wiki/Advanced) 💡!
+
+Have you gotten any ideas for new pickers, plugins or extensions? Create a plugin and add it to the wiki!
+
+### Advanced completion modes
+
+<details>
+<summary>Insert-mode completion</summary>
+
+Fzf-lua comes with a set of completion functions for paths/files and lines from open buffers as
+well as custom completion, for example, set path/completion using `<C-x><C-f>`:
+
+```lua
+vim.keymap.set({ "n", "v", "i" }, "<C-x><C-f>",
+  function() require("fzf-lua").complete_path() end,
+  { silent = true, desc = "Fuzzy complete path" })
+```
+
+Or with a custom command and preview:
+
+> [!NOTE]
+> only `complete_file` supports a previewer
+
+```lua
+vim.keymap.set({ "i" }, "<C-x><C-f>",
+  function()
+    require("fzf-lua").complete_file({
+      cmd = "rg --files",
+      winopts = { preview = { hidden = "nohidden" } }
+    })
+  end, { silent = true, desc = "Fuzzy complete file" })
+```
+
+</details>
+
+<details>
+<summary>custom completion</summary>
+
+Every fzf-lua function can be easily converted to a completion function by sending
+`complete = true` in the options:
+
+> By default fzf-lua will insert the entry at the cursor location as if you used
+> `p` to paste the selected entry.
+
+```lua
+require("fzf-lua").fzf_exec({"foo", "bar"}, {complete = true})
+```
+
+Custom completion is possible using a custom completion callback, the example below
+will replace the text from the current cursor column with the selected entry:
+
+```lua
+require("fzf-lua").fzf_exec({"foo", "bar"}, {
+  -- @param selected: the selected entry or entries
+  -- @param opts: fzf-lua caller/provider options
+  -- @param line: originating buffer completed line
+  -- @param col: originating cursor column location
+  -- @return newline: will replace the current buffer line
+  -- @return newcol?: optional, sets the new cursor column
+  complete = function(selected, opts, line, col)
+    local newline = line:sub(1, col) .. selected[1]
+    -- set cursor to EOL, since `nvim_win_set_cursor`
+    -- is 0-based we have to lower the col value by 1
+    return newline, #newline - 1
+  end
+})
 ```
 
 </details>
 
 ### Highlights
 
+<details>
+<summary>Highlight groups</summary>
 FzfLua conveniently creates the below highlights, each hlgroup can be
 temporarily overridden by its corresponding `winopts` option:
 
-| Highlight Group       | Default     | Override Via              | Notes |
-|-----------------------|-------------|---------------------------|-------|
-|FzfLuaNormal           |Normal       |`hls.normal`        |Main win `fg/bg`|
-|FzfLuaBorder           |Normal       |`hls.border`        |Main win border|
-|FzfLuaTitle            |FzfLuaNormal |`hls.title`         |Main win title|
-|FzfLuaBackdrop         |*bg=Black    |`hls.backdrop`      |Backdrop color|
-|FzfLuaPreviewNormal    |FzfLuaNormal |`hls.preview_normal`|Builtin preview `fg/bg`|
-|FzfLuaPreviewBorder    |FzfLuaBorder |`hls.preview_border`|Builtin preview border|
-|FzfLuaPreviewTitle     |FzfLuaTitle  |`hls.preview_title` |Builtin preview title|
-|FzfLuaCursor           |Cursor       |`hls.cursor`        |Builtin preview `Cursor`|
-|FzfLuaCursorLine       |CursorLine   |`hls.cursorline`    |Builtin preview `Cursorline`|
-|FzfLuaCursorLineNr     |CursorLineNr |`hls.cursorlinenr`  |Builtin preview `CursorLineNr`|
-|FzfLuaSearch           |IncSearch    |`hls.search`        |Builtin preview search matches|
-|FzfLuaScrollBorderEmpty|FzfLuaBorder |`hls.scrollborder_e`|Builtin preview `border` scroll empty|
-|FzfLuaScrollBorderFull |FzfLuaBorder |`hls.scrollborder_f`|Builtin preview `border` scroll full|
-|FzfLuaScrollFloatEmpty |PmenuSbar    |`hls.scrollfloat_e` |Builtin preview `float` scroll empty|
-|FzfLuaScrollFloatFull  |PmenuThumb   |`hls.scrollfloat_f` |Builtin preview `float` scroll full|
-|FzfLuaHelpNormal       |FzfLuaNormal |`hls.help_normal`   |Help win `fg/bg`|
-|FzfLuaHelpBorder       |FzfLuaBorder |`hls.help_border`   |Help win border|
-|FzfLuaHeaderBind   |*BlanchedAlmond  |`hls.header_bind`   |Header keybind|
-|FzfLuaHeaderText   |*Brown1          |`hls.header_text`   |Header text|
-|FzfLuaPathColNr    |*CadetBlue1      |`hls.path_colnr`    |Path col nr (`qf,lsp,diag`)|
-|FzfLuaPathLineNr   |*LightGreen      |`hls.path_linenr`   |Path line nr (`qf,lsp,diag`)|
-|FzfLuaBufName      |Directory        |`hls.buf_name`      |Buffer name (`lines`)|
-|FzfLuaBufId        |TabLine          |`hls.buf_id`        |Buffer ID (`lines`)|
-|FzfLuaBufNr        |*BlanchedAlmond  |`hls.buf_nr`        |Buffer number (`buffers,tabs`)|
-|FzfLuaBufLineNr    |LineNr           |`hls.buf_linenr`    |Buffer line nr (`lines,blines`)|
-|FzfLuaBufFlagCur   |*Brown1          |`hls.buf_flag_cur`  |Buffer line (`buffers`)|
-|FzfLuaBufFlagAlt   |*CadetBlue1      |`hls.buf_flag_alt`  |Buffer line (`buffers`)|
-|FzfLuaTabTitle     |*LightSkyBlue1   |`hls.tab_title`     |Tab title (`tabs`)|
-|FzfLuaTabMarker    |*BlanchedAlmond  |`hls.tab_marker`    |Tab marker (`tabs`)|
-|FzfLuaDirIcon      |Directory        |`hls.dir_icon`      |Paths directory icon|
-|FzfLuaDirPart      |Comment          |`hls.dir_part`      |Path formatters directory hl group|
-|FzfLuaFilePart     |@none            |`hls.file_part`     |Path formatters file hl group|
-|FzfLuaLiveSym      |*Brown1          |`hls.live_sym`      |LSP live symbols query match|
-|FzfLuaFzfNormal    |FzfLuaNormal     |`fzf.normal`        |fzf's `fg\|bg`|
-|FzfLuaFzfCursorLine|FzfLuaCursorLine |`fzf.cursorline`    |fzf's `fg+\|bg+`|
-|FzfLuaFzfMatch     |Special          |`fzf.match`         |fzf's `hl+`|
-|FzfLuaFzfBorder    |FzfLuaBorder     |`fzf.border`        |fzf's `border`|
-|FzfLuaFzfScrollbar |FzfLuaFzfBorder  |`fzf.scrollbar`     |fzf's `scrollbar`|
-|FzfLuaFzfSeparator |FzfLuaFzfBorder  |`fzf.separator`     |fzf's `separator`|
-|FzfLuaFzfGutter    |FzfLuaNormal     |`fzf.gutter`        |fzf's `gutter` (hl `bg` is used)|
-|FzfLuaFzfHeader    |FzfLuaTitle      |`fzf.header`        |fzf's `header`|
-|FzfLuaFzfInfo      |NonText          |`fzf.info`          |fzf's `info`|
-|FzfLuaFzfPointer   |Special          |`fzf.pointer`       |fzf's `pointer`|
-|FzfLuaFzfMarker    |FzfLuaFzfPointer |`fzf.marker`        |fzf's `marker`|
-|FzfLuaFzfSpinner   |FzfLuaFzfPointer |`fzf.spinner`       |fzf's `spinner`|
-|FzfLuaFzfPrompt    |Special          |`fzf.prompt`        |fzf's `prompt`|
-|FzfLuaFzfQuery     |FzfLuaNormal     |`fzf.query`         |fzf's `header`|
+| Highlight Group         | Default          | Override Via         | Notes                                 |
+| ----------------------- | ---------------- | -------------------- | ------------------------------------- |
+| FzfLuaNormal            | Normal           | `hls.normal`         | Main win `fg/bg`                      |
+| FzfLuaBorder            | Normal           | `hls.border`         | Main win border                       |
+| FzfLuaTitle             | FzfLuaNormal     | `hls.title`          | Main win title                        |
+| FzfLuaBackdrop          | \*bg=Black       | `hls.backdrop`       | Backdrop color                        |
+| FzfLuaPreviewNormal     | FzfLuaNormal     | `hls.preview_normal` | Builtin preview `fg/bg`               |
+| FzfLuaPreviewBorder     | FzfLuaBorder     | `hls.preview_border` | Builtin preview border                |
+| FzfLuaPreviewTitle      | FzfLuaTitle      | `hls.preview_title`  | Builtin preview title                 |
+| FzfLuaCursor            | Cursor           | `hls.cursor`         | Builtin preview `Cursor`              |
+| FzfLuaCursorLine        | CursorLine       | `hls.cursorline`     | Builtin preview `Cursorline`          |
+| FzfLuaCursorLineNr      | CursorLineNr     | `hls.cursorlinenr`   | Builtin preview `CursorLineNr`        |
+| FzfLuaSearch            | IncSearch        | `hls.search`         | Builtin preview search matches        |
+| FzfLuaScrollBorderEmpty | FzfLuaBorder     | `hls.scrollborder_e` | Builtin preview `border` scroll empty |
+| FzfLuaScrollBorderFull  | FzfLuaBorder     | `hls.scrollborder_f` | Builtin preview `border` scroll full  |
+| FzfLuaScrollFloatEmpty  | PmenuSbar        | `hls.scrollfloat_e`  | Builtin preview `float` scroll empty  |
+| FzfLuaScrollFloatFull   | PmenuThumb       | `hls.scrollfloat_f`  | Builtin preview `float` scroll full   |
+| FzfLuaHelpNormal        | FzfLuaNormal     | `hls.help_normal`    | Help win `fg/bg`                      |
+| FzfLuaHelpBorder        | FzfLuaBorder     | `hls.help_border`    | Help win border                       |
+| FzfLuaHeaderBind        | \*BlanchedAlmond | `hls.header_bind`    | Header keybind                        |
+| FzfLuaHeaderText        | \*Brown1         | `hls.header_text`    | Header text                           |
+| FzfLuaPathColNr         | \*CadetBlue1     | `hls.path_colnr`     | Path col nr (`qf,lsp,diag`)           |
+| FzfLuaPathLineNr        | \*LightGreen     | `hls.path_linenr`    | Path line nr (`qf,lsp,diag`)          |
+| FzfLuaBufName           | Directory        | `hls.buf_name`       | Buffer name (`lines`)                 |
+| FzfLuaBufId             | TabLine          | `hls.buf_id`         | Buffer ID (`lines`)                   |
+| FzfLuaBufNr             | \*BlanchedAlmond | `hls.buf_nr`         | Buffer number (`buffers,tabs`)        |
+| FzfLuaBufLineNr         | LineNr           | `hls.buf_linenr`     | Buffer line nr (`lines,blines`)       |
+| FzfLuaBufFlagCur        | \*Brown1         | `hls.buf_flag_cur`   | Buffer line (`buffers`)               |
+| FzfLuaBufFlagAlt        | \*CadetBlue1     | `hls.buf_flag_alt`   | Buffer line (`buffers`)               |
+| FzfLuaTabTitle          | \*LightSkyBlue1  | `hls.tab_title`      | Tab title (`tabs`)                    |
+| FzfLuaTabMarker         | \*BlanchedAlmond | `hls.tab_marker`     | Tab marker (`tabs`)                   |
+| FzfLuaDirIcon           | Directory        | `hls.dir_icon`       | Paths directory icon                  |
+| FzfLuaDirPart           | Comment          | `hls.dir_part`       | Path formatters directory hl group    |
+| FzfLuaFilePart          | @none            | `hls.file_part`      | Path formatters file hl group         |
+| FzfLuaLiveSym           | \*Brown1         | `hls.live_sym`       | LSP live symbols query match          |
+| FzfLuaFzfNormal         | FzfLuaNormal     | `fzf.normal`         | fzf's `fg\|bg`                        |
+| FzfLuaFzfCursorLine     | FzfLuaCursorLine | `fzf.cursorline`     | fzf's `fg+\|bg+`                      |
+| FzfLuaFzfMatch          | Special          | `fzf.match`          | fzf's `hl+`                           |
+| FzfLuaFzfBorder         | FzfLuaBorder     | `fzf.border`         | fzf's `border`                        |
+| FzfLuaFzfScrollbar      | FzfLuaFzfBorder  | `fzf.scrollbar`      | fzf's `scrollbar`                     |
+| FzfLuaFzfSeparator      | FzfLuaFzfBorder  | `fzf.separator`      | fzf's `separator`                     |
+| FzfLuaFzfGutter         | FzfLuaNormal     | `fzf.gutter`         | fzf's `gutter` (hl `bg` is used)      |
+| FzfLuaFzfHeader         | FzfLuaTitle      | `fzf.header`         | fzf's `header`                        |
+| FzfLuaFzfInfo           | NonText          | `fzf.info`           | fzf's `info`                          |
+| FzfLuaFzfPointer        | Special          | `fzf.pointer`        | fzf's `pointer`                       |
+| FzfLuaFzfMarker         | FzfLuaFzfPointer | `fzf.marker`         | fzf's `marker`                        |
+| FzfLuaFzfSpinner        | FzfLuaFzfPointer | `fzf.spinner`        | fzf's `spinner`                       |
+| FzfLuaFzfPrompt         | Special          | `fzf.prompt`         | fzf's `prompt`                        |
+| FzfLuaFzfQuery          | FzfLuaNormal     | `fzf.query`          | fzf's `header`                        |
 
-<sup><sub>&ast;Not a highlight group, RGB color from `nvim_get_color_map`</sub></sup>
+</details>
 
-These can be easily customized either via the lua API:
+Highlight groups can be easily customized either via the lua API:
+
 ```lua
 :lua vim.api.nvim_set_hl(0, "FzfLuaBorder", { link = "FloatBorder" })
 ```
 
-Or vimscript:
-```vim
-:hi! link FzfLuaBorder FloatBorder
-```
+or via `setup`:
 
-If you wish to override a highlight without having to modify your
-colorscheme highlights, set the corresponding `hls` override or
-specify it directly via a call argument.
-
-Temporary highlight override:
-```lua
-:lua require'fzf-lua'.files({ hls={preview_title="IncSearch"} })
-```
-
-Permanent global override via `setup`:
 ```lua
 require('fzf-lua').setup {
   hls = { border = "FloatBorder" }
 }
-```
-
-#### Fzf Colors
-
-Fzf's terminal colors are controlled by fzf's `--color` flag which can be
-configured during setup via `fzf_colors`.
-
-Set to `true` to have fzf-lua automatically generate an fzf colorscheme from
-your current Neovim colorscheme:
-```lua
-require("fzf-lua").setup({ fzf_colors = true })
--- Or in the direct call options
-:lua require("fzf-lua").files({ fzf_colors = true })
-:FzfLua files fzf_colors=true
-```
-
-Customizing the fzf colorscheme (see `man fzf` for all color options):
-```lua
-require('fzf-lua').setup {
-  fzf_colors = {
-    -- First existing highlight group will be used
-    -- values in 3rd+ index will be passed raw
-    -- i.e:  `--color fg+:#010101:bold:underline`
-    ["fg+"] = { "fg" , { "Comment", "Normal" }, "bold", "underline" },
-    -- It is also possible to pass raw values directly
-    ["gutter"] = "-1"
-  }
-}
-```
-
-Conveniently, fzf-lua can also be configured using fzf.vim's `g:fzf_colors`, i.e:
-```lua
--- Similarly, first existing highlight group will be used
-:lua vim.g.fzf_colors = { ["gutter"] = { "bg", "DoesNotExist", "IncSearch" } }
-```
-
-However, the above doesn't allow combining both neovim highlights and raw args,
-if you're only using fzf-lua we can hijack `g:fzf_colors` to accept fzf-lua style
-values (i.e. table at 2nd index and 3rd+ raw args):
-```lua
-:lua vim.g.fzf_colors = { ["fg+"] = { "fg", { "ErrorMsg" }, "bold", "underline" } }
 ```
 
 ## Credits

--- a/README.md
+++ b/README.md
@@ -4,15 +4,34 @@
 
 ![Neovim version](https://img.shields.io/badge/Neovim-0.5-57A143?style=flat-square&logo=neovim)
 
-[Installation](#installation) • [Quickstart](#quickstart) • [Commands](#commands) • [Customization](#options) • [Wiki](https://github.com/ibhagwan/fzf-lua/wiki)
+[Quickstart](#quickstart) • [Installation](#installation) • [Usage](#usage) • [Commands](#commands) • [Customization](#customization) • [Wiki](https://github.com/ibhagwan/fzf-lua/wiki)
 
 ![Demo](https://raw.githubusercontent.com/wiki/ibhagwan/fzf-lua/demo.gif)
 
-> “because you can and you love `fzf`” ([@junegunn](https://github.com/junegunn))
+“because you can and you love fzf”  - [@junegunn](https://github.com/junegunn)
 
-> [fzf](https://github.com/junegunn/fzf) is the single most impactful tool for my command line workflow, it changed my life and it can change yours too, if you allow it.
+"fzf changed my command life, it can change yours too, if you allow it" -
+[@ibhagwan](https://github.com/ibhagwan)
 
 </div>
+
+## Quickstart
+
+To quickly test this plugin without changing your configuration run (will run in it's own sandbox
+with the default keybinds below):
+> [!NOTE]
+> it's good practice to first
+> [read the script](https://github.com/ibhagwan/fzf-lua/blob/main/scripts/mini.sh)
+> before running `sh -c` directly from the web
+```sh
+sh -c "$(curl -s https://raw.githubusercontent.com/ibhagwan/fzf-lua/main/scripts/mini.sh)"
+```
+
+| Key       | Command           | Key       | Command           |
+| ----------| ------------------| ----------| ------------------|
+| `<C-\>`     | buffers           | `<C-p>`     | files             |
+| `<C-g>`     | grep              | `<C-l>`     | live_grep         |
+| `<C-k>`     | builtin commands  | `<F1>`      | neovim help       |
 
 ## Installation
 
@@ -25,10 +44,9 @@ Using [lazy.nvim](https://github.com/folke/lazy.nvim)
   "ibhagwan/fzf-lua",
   -- optional for icon support
   dependencies = { "nvim-tree/nvim-web-devicons" },
-  config = function()
-    -- calling `setup` is optional for customization
-    require("fzf-lua").setup({})
-  end
+  -- or if using mini.icons/mini.nvim
+  -- dependencies = { "echasnovski/mini.icons" },
+  opts = {}
 }
 ```
 
@@ -39,9 +57,9 @@ Using [lazy.nvim](https://github.com/folke/lazy.nvim)
 
 - [`neovim`](https://github.com/neovim/neovim/releases) version > `0.5.0`
 - [`fzf`](https://github.com/junegunn/fzf) version > `0.25`
-  **or** [`skim`](https://github.com/skim-rs/skim) binary installed
+  or [`skim`](https://github.com/skim-rs/skim) binary installed
 - [nvim-web-devicons](https://github.com/nvim-tree/nvim-web-devicons)
-  **or** [mini.icons](https://github.com/echasnovski/mini.icons)
+  or [mini.icons](https://github.com/echasnovski/mini.icons)
   (optional)
 
 ### Optional dependencies
@@ -57,9 +75,8 @@ Using [lazy.nvim](https://github.com/folke/lazy.nvim)
 - [nvim-treesitter-context](https://github.com/nvim-treesitter/nvim-treesitter-context) - for
   viewing treesitter context within the previewer
 - [render-markdown.nvim](https://github.com/MeanderingProgrammer/render-markdown.nvim) or
-  [markview.nvim](https://github.com/OXY2DEV/markview.nvim - for rendering markdown
+  [markview.nvim](https://github.com/OXY2DEV/markview.nvim) - for rendering markdown
   files in the previewer
-  )
 
 Below are a few optional dependencies for viewing media files (which you need
 to configure in `previewer.builtin.extensions`):
@@ -87,7 +104,7 @@ to configure in `previewer.builtin.extensions`):
 
 </details>
 
-## Quickstart
+## Usage
 
 Fzf-lua aims to be as plug and play as possible with sane defaults, you can
 run any fzf-lua command like this:
@@ -106,12 +123,44 @@ or with arguments:
 :FzfLua files cwd=~/.config
 ```
 
-Choose among the many pickers we offer!!👇
+### Resume
+
+Resuming work from where you left off is as easy as:
+
+```lua
+:lua require('fzf-lua').resume()
+-- or
+:FzfLua resume
+```
+
+Alternatively, resuming work on a specific picker:
+
+```lua
+:lua require('fzf-lua').files({ resume = true })
+-- or
+:FzfLua files resume=true
+```
+
+> [!TIP]
+> By default pressing esc or ctrl-c terminates the fzf process,
+> as such resume is not perfect and is limited to resuming the
+> picker/query and sometimes additional parameters such as regex
+> in grep, etc, for a more "complete" resume press alt-esc to
+> hide the fzf process instead, this will keep the fzf process
+> running in the background and thus will restore the process
+> entirely including cursor position and selection.
+> To configure hiding by default:
+> ```lua
+> require("fzf-lua").setup({ keymap = { builtin = { true, ["<Esc>"] = "hide" } } })
+> ```
+
+
+**LIST OF AVAILABLE COMMANDS BELOW** 👇
 
 ## Commands
 
 <details>
-<summary>Browse commands!</summary>
+<summary>Buffers and Files</summary>
 
 ### Buffers and Files
 
@@ -129,6 +178,10 @@ Choose among the many pickers we offer!!👇
 | `treesitter`     | current buffer treesitter symbols |
 | `tabs`           | open tabs                         |
 | `args`           | argument list                     |
+
+</details>
+<details>
+<summary>Search</summary>
 
 ### Search
 
@@ -151,6 +204,10 @@ Choose among the many pickers we offer!!👇
 | `live_grep_glob`   | live_grep with `rg --glob` support         |
 | `live_grep_native` | performant version of `live_grep`          |
 
+</details>
+<details>
+<summary>Tags</summary>
+
 ### Tags
 
 | Command            | List                          |
@@ -162,6 +219,10 @@ Choose among the many pickers we offer!!👇
 | `tags_grep_cWORD`  | `tags_grep` WORD under cursor |
 | `tags_grep_visual` | `tags_grep` visual selection  |
 | `tags_live_grep`   | live grep project tags        |
+
+</details>
+<details>
+<summary>Git</summary>
 
 ### Git
 
@@ -175,6 +236,10 @@ Choose among the many pickers we offer!!👇
 | `git_branches` | git branches             |
 | `git_tags`     | git tags                 |
 | `git_stash`    | git stash                |
+
+</details>
+<details>
+<summary>LSP / Diagnostics</summary>
 
 ### LSP/Diagnostics
 
@@ -196,6 +261,10 @@ Choose among the many pickers we offer!!👇
 | `diagnostics_workspace`      | Workspace Diagnostics            |
 | `lsp_document_diagnostics`   | alias to `diagnostics_document`  |
 | `lsp_workspace_diagnostics`  | alias to `diagnostics_workspace` |
+
+</details>
+<details>
+<summary>Misc</summary>
 
 ### Misc
 
@@ -224,6 +293,10 @@ Choose among the many pickers we offer!!👇
 | `spell_suggest`        | spelling suggestions           |
 | `packadd`              | :packadd <package>             |
 
+</details>
+<details>
+<summary>Neovim API</summary>
+
 ### Neovim API
 
 > `:help vim.ui.select` for more info
@@ -232,6 +305,10 @@ Choose among the many pickers we offer!!👇
 | ---------------------- | -------------------------------------------------------- |
 | `register_ui_select`   | register fzf-lua as the UI interface for `vim.ui.select` |
 | `deregister_ui_select` | de-register fzf-lua with `vim.ui.select`                 |
+
+</details>
+<details>
+<summary>nvim-dap</summary>
 
 ### nvim-dap
 
@@ -245,11 +322,19 @@ Choose among the many pickers we offer!!👇
 | `dap_variables`      | active session variables             |
 | `dap_frames`         | active session jump to frame         |
 
+</details>
+<details>
+<summary>Tmux</summary>
+
 ### tmux
 
 | Command        | List                    |
 | -------------- | ----------------------- |
 | `tmux_buffers` | list tmux paste buffers |
+
+</details>
+<details>
+<summary>Completion Functions</summary>
 
 ### Completion Functions
 
@@ -262,56 +347,36 @@ Choose among the many pickers we offer!!👇
 
 </details>
 
-<details>
-<summary>Resume commands!</summary>
+## Customization
 
-Resuming work from where you left off is as easy as:
-
-```lua
-:lua require('fzf-lua').resume()
--- or
-:FzfLua resume
-```
-
-Alternatively, resuming work on a specific provider:
+> [!NOTE]
+> Refer to [OPTIONS](https://github.com/ibhagwan/fzf-lua/blob/main/OPTIONS.md)
+> to see detailed usage notes and a comprehensive list of yet more(!) available options.
 
 ```lua
-:lua require('fzf-lua').files({ resume = true })
--- or
-:FzfLua files resume=true
-```
-
-</details>
-
-## Options
-
-```lua
-require('fzf-lua').setup{
+require("fzf-lua").setup{
   -- MISC GLOBAL SETUP OPTIONS, SEE BELOW
   -- fzf_bin = ...,
-  winopts = {
-    ...
-  },
-  keymap = {
-    ...
-  },
-  actions = {
-    ...
-  },
-  hls = {
-    ...
-  },
+  winopts = { ...  },     -- UI Options
+  keymap = { ...  },      -- Neovim keymaps / fzf binds
+  actions = { ...  },     -- Fzf "accept" binds
+  fzf_opts = { ...  },    -- Fzf CLI flags
+  fzf_colors = { ...  },  -- Fzf `--color` specification
+  hls = { ...  },         -- Highlights
+  previewers = { ...  },  -- Previewers options
+  -- SPECIFIC COMMAND/PICKER OPTIONS, SEE BELOW
+  -- files = { ... },
 }
 ```
 
-Where each of the above sections can be fully configured as below:
+**DEFAULT OPTIONS OF THE DIFFERENT CONFIG SECTIONS BELOW** 👇
 
 <details>
 <summary>globals</summary>
 
 ```lua
- -- Use skim (or a speccific fzf binary/version) instead of fzf?
-  fzf_bin = 'sk',
+  -- Use skim (or a speccific fzf binary/version) instead of fzf?
+  -- fzf_bin = 'sk',
   -- Padding can help kitty term users with double-width icon rendering
   file_icon_padding = '',
   -- Uncomment if your terminal/font does not support unicode character
@@ -403,15 +468,15 @@ winopts = {
 </details>
 
 <details>
-<summary>keymaps</summary>
+<summary>keymap</summary>
 
 ```lua
 keymap = {
     -- Below are the default binds, setting any value in these tables will override
     -- the defaults, to inherit from the defaults change [1] from `false` to `true`
     builtin = {
-      false,          -- do not inherit from defaults
       -- neovim `:tmap` mappings for the fzf win
+      -- true,        -- uncomment to inherit all the below in your custom config
       ["<M-Esc>"]     = "hide",     -- hide fzf-lua, `:FzfLua resume` to continue
       ["<F1>"]        = "toggle-help",
       ["<F2>"]        = "toggle-fullscreen",
@@ -432,8 +497,8 @@ keymap = {
       ["<M-S-up>"]    = "preview-up",
     },
     fzf = {
-      false,          -- do not inherit from defaults
       -- fzf '--bind=' options
+      -- true,        -- uncomment to inherit all the below in your custom config
       ["ctrl-z"]      = "abort",
       ["ctrl-u"]      = "unix-line-discard",
       ["ctrl-f"]      = "half-page-down",
@@ -458,12 +523,12 @@ keymap = {
 <summary>actions</summary>
 
 ```lua
-local actions = require "fzf-lua.actions"
+local actions = require("fzf-lua").actions
 actions = {
     -- Below are the default actions, setting any value in these tables will override
     -- the defaults, to inherit from the defaults change [1] from `false` to `true`
     files = {
-      false,          -- do not inherit from defaults
+      -- true,        -- uncomment to inherit all the below in your custom config
       -- Pickers inheriting these actions:
       --   files, git_files, git_status, grep, lsp, oldfiles, quickfix, loclist,
       --   tags, btags, args, buffers, tabs, lines, blines
@@ -505,6 +570,72 @@ fzf_opts = {
 -- for more options run `fzf-tmux --help`
 fzf_tmux_opts       = { ["-p"] = "80%,80%", ["--margin"] = "0,0" },
 ```
+
+</details>
+
+<details>
+<summary>fzf_colors</summary>
+
+> [!NOTE]
+> See the [Fzf Colors](#fzf-colors) section for more info.
+
+```lua
+  -- 
+  -- Set fzf's terminal colorscheme (optional)
+  --
+  -- Set to `true` to automatically generate an fzf's colorscheme from
+  -- Neovim's current colorscheme:
+  -- fzf_colors       = true,
+  -- 
+  -- Building a custom colorscheme, has the below specifications:
+  -- If rhs is of type "string" rhs will be passed raw, e.g.:
+  --   `["fg"] = "underline"` will be translated to `--color fg:underline`
+  -- If rhs is of type "table", the following convention is used:
+  --   [1] "what" field to extract from the hlgroup, i.e "fg", "bg", etc.
+  --   [2] Neovim highlight group(s), can be either "string" or "table"
+  --       when type is "table" the first existing highlight group is used
+  --   [3+] any additional fields are passed raw to fzf's command line args
+  -- Example of a "fully loaded" color option:
+  --   `["fg"] = { "fg", { "NonExistentHl", "Comment" }, "underline", "bold" }`
+  -- Assuming `Comment.fg=#010101` the resulting fzf command line will be:
+  --   `--color fg:#010101:underline:bold`
+  -- NOTE: to pass raw arguments `fzf_opts["--color"]` or `fzf_args`
+  -- NOTE: below is an example, not the defaults:
+  fzf_colors = {
+      true,   -- inherit fzf colors that aren't specified below from
+              -- the auto-generated theme similar to `fzf_colors=true`
+      ["fg"]          = { "fg", "CursorLine" },
+      ["bg"]          = { "bg", "Normal" },
+      ["hl"]          = { "fg", "Comment" },
+      ["fg+"]         = { "fg", "Normal", "underline" },
+      ["bg+"]         = { "bg", { "CursorLine", "Normal" } },
+      ["hl+"]         = { "fg", "Statement" },
+      ["info"]        = { "fg", "PreProc" },
+      ["prompt"]      = { "fg", "Conditional" },
+      ["pointer"]     = { "fg", "Exception" },
+      ["marker"]      = { "fg", "Keyword" },
+      ["spinner"]     = { "fg", "Label" },
+      ["header"]      = { "fg", "Comment" },
+      ["gutter"]      = "-1",
+  },
+```
+
+</details>
+
+<details>
+<summary>hls</summary>
+
+> [!NOTE]
+> See the [highlights](#highlights) section below for all available highlight groups.
+
+```lua
+hls = {
+    normal = "Normal"          -- highlight group for normal fg/bg
+    preview_normal = "Normal"  -- highlight group for preview fg/bg
+    ...
+}
+```
+
 
 </details>
 
@@ -604,13 +735,10 @@ previewers = {
 </details>
 
 <details>
-<summary>providers setups</summary>
+<summary>picker options</summary>
 
 ```lua
-
-
-  -- PROVIDERS SETUP
-  -- use `defaults` (table or function) if you wish to set "global-provider" defaults
+  -- use `defaults` (table or function) if you wish to set "global-picker" defaults
   -- for example, using "mini.icons" globally and open the quickfix list at the top
   --   defaults = {
   --     file_icons   = "mini",
@@ -1008,8 +1136,8 @@ previewers = {
     includeDeclaration = true,      -- include current declaration in LSP context
     -- settings for 'lsp_{document|workspace|lsp_live_workspace}_symbols'
     symbols = {
-        lsp_query         = ""          -- query passed to vim.lsp.buf.workspace_symbol({query=<lsp_query>}, {opts})
-        query             = ""          -- query passed to the fzf prompt to open the fuzzy search already
+        -- lsp_query      = "foo"       -- query passed to the LSP directly
+        -- query          = "bar"       -- query passed to fzf prompt for fuzzy matching
         async_or_timeout  = true,       -- symbols are async by default
         symbol_style      = 1,          -- style for document/workspace symbols
                                         -- false: disable,    1: icon+kind
@@ -1127,48 +1255,37 @@ previewers = {
 
 </details>
 
-<details>
-<summary>hls</summary>
+> [!TIP]
+> To experiment with different options without modifying the global config, options
+> can be sent as inline parameters to the function calls. Expand below to see examples
+> of inline customization and Refer to
+> [OPTIONS](https://github.com/ibhagwan/fzf-lua/blob/main/OPTIONS.md) for yet more examples.
 
-```lua
-hls = {
-    normal = "..." -- highlight group for normal bg
-    preview_normal = "..." -- highlight group for preview bg
-    ...
->>>>>>> 50bbf33 (docs: refactoring of README.md)
-}
-```
-
-where all the available highlight groups are listed in the [highlights](#highlights) section below.
-
-</details>
-
-If still not enough, check a more comprehensive list of [options](https://github.com/ibhagwan/fzf-lua/blob/main/OPTIONS.md) and detailed usage!
-
-If you wish to customise only specific calls without changing the general behaviours, you can individually send option parameters inline to the function calls: see the examples below
 
 <details>
-<summary>Examples of inline customisation</summary>
+<summary>CLICK FOR EXAMPLES OF INLINE CUSTOMIZATION</summary>
 
-> Different `fzf` layout:
+#### Inline Customization
+
+Different `fzf` layout:
 
 ```lua
 :lua require('fzf-lua').files({ fzf_opts = {['--layout'] = 'reverse-list'} })
 ```
 
-> Using `files` with a different command and working directory:
+Using `files` with a different command and working directory:
 
 ```lua
 :lua require'fzf-lua'.files({ prompt="LS> ", cmd = "ls", cwd="~/<folder>" })
 ```
 
-> Using `live_grep` with `git grep`:
+Using `live_grep` with `git grep`:
 
 ```lua
 :lua require'fzf-lua'.live_grep({ cmd = "git grep --line-number --column --color=always" })
 ```
 
-> `colorschemes` with non-default window size:
+`colorschemes` with non-default window size:
 
 ```lua
 :lua require'fzf-lua'.colorschemes({ winopts = { height=0.33, width=0.33 } })
@@ -1178,29 +1295,17 @@ If you wish to customise only specific calls without changing the general behavi
 
 ### Profiles
 
-Conveniently, fzf-lua comes with a set of preconfigured profiles if you do not want to tinker with customisation:
-
-<details>
-<summary>Browse profiles!</summary>
-
-| Profile         | Details                                                                                             |
-| --------------- | --------------------------------------------------------------------------------------------------- |
-| `default`       | fzf-lua defaults, uses neovim "builtin" previewer and devicons (if available) for git/files/buffers |
-| `default-title` | fzf-lua defaults, using title instead of prompt                                                     |
-| `fzf-native`    | utilizes fzf's native previewing ability in the terminal where possible using `bat` for previews    |
-| `fzf-tmux`      | similar to `fzf-native` and opens in a tmux popup (requires tmux > 3.2)                             |
-| `fzf-vim`       | closest to `fzf.vim`'s defaults (+icons), also sets up user commands (`:Files`, `:Rg`, etc)         |
-| `max-perf`      | similar to `fzf-native` and disables icons globally for max performance                             |
-| `telescope`     | closest match to telescope defaults in look and feel and keybinds                                   |
-| `skim`          | uses [`skim`](https://github.com/skim-rs/skim) as an fzf alternative, (requires the `sk` binary)    |
-
-</details>
+Conveniently, fzf-lua comes with a set of preconfigured profiles if you do not want to tinker with
+customization.
 
 Use `:FzfLua profiles` to experiment with the different profiles, once you've found what
 you like and wish to make the profile persist, send a `string` argument at the first index
 of the table sent to the `setup` function:
 
-> [!NOTE] > `setup` can be called multiple times for profile "live" switching
+> [!TIP]
+> `setup` can be called multiple times for profile "live" switching,
+> see [profiles](https://github.com/ibhagwan/fzf-lua/tree/main/lua/fzf-lua/profiles)
+> page for more info.
 
 ```lua
 require('fzf-lua').setup({'fzf-native'})
@@ -1220,18 +1325,44 @@ the first argument:
 :lua require"fzf-lua".setup({{"telescope","fzf-native"},winopts={fullscreen=true}})
 ```
 
-See [profiles](https://github.com/ibhagwan/fzf-lua/tree/main/lua/fzf-lua/profiles) for more info.
+#### Coming from fzf.vim?
+
+Easy! just use the `fzf-vim` profile:
+```lua
+require('fzf-lua').setup({'fzf-vim'})
+```
+
+> [!TIP]
+> Using the `fzf-vim` profile will automatically create `fzf.vim`'s user commands
+> (i.e. `:Files`, `:Rg`), if you wish to use a different profile you can create the same
+> user commands by running `:FzfLua setup_fzfvim_cmds`.
+
+<details>
+<summary>CLICK TO SEE THE AVAILABLE PROFILES</summary>
+
+#### Available Profiles
+
+| Profile         | Details                                                                                             |
+| --------------- | --------------------------------------------------------------------------------------------------- |
+| `default`       | fzf-lua defaults, uses neovim "builtin" previewer and devicons (if available) for git/files/buffers |
+| `default-title` | fzf-lua defaults, using title instead of prompt                                                     |
+| `fzf-native`    | utilizes fzf's native previewing ability in the terminal where possible using `bat` for previews    |
+| `fzf-tmux`      | similar to `fzf-native` and opens in a tmux popup (requires tmux > 3.2)                             |
+| `fzf-vim`       | closest to `fzf.vim`'s defaults (+icons), also sets up user commands (`:Files`, `:Rg`, etc)         |
+| `max-perf`      | similar to `fzf-native` and disables icons globally for max performance                             |
+| `telescope`     | closest match to telescope defaults in look and feel and keybinds                                   |
+| `skim`          | uses [`skim`](https://github.com/skim-rs/skim) as an fzf alternative, (requires the `sk` binary)    |
+
+</details>
 
 ### Extensibility
 
-Fzf-lua can be easily extended and customised for your own needs: have a look at a full list of examples and plugins browsing the 💡[Wiki](https://github.com/ibhagwan/fzf-lua/wiki/Advanced) 💡!
+Fzf-lua can be easily extended and customised for your own needs: have a look at a full list of
+examples and plugins browsing the 💡[Wiki](https://github.com/ibhagwan/fzf-lua/wiki/Advanced) 💡
 
-Have you gotten any ideas for new pickers, plugins or extensions? Create a plugin and add it to the wiki!
+Have ideas for new pickers, plugins or extensions? Add it to the wiki, it's open edit!
 
-### Advanced completion modes
-
-<details>
-<summary>Insert-mode completion</summary>
+### Insert-mode completion
 
 Fzf-lua comes with a set of completion functions for paths/files and lines from open buffers as
 well as custom completion, for example, set path/completion using `<C-x><C-f>`:
@@ -1245,7 +1376,7 @@ vim.keymap.set({ "n", "v", "i" }, "<C-x><C-f>",
 Or with a custom command and preview:
 
 > [!NOTE]
-> only `complete_file` supports a previewer
+> only `complete_file` supports a previewer as `complete_path` mixes both files and directories.
 
 ```lua
 vim.keymap.set({ "i" }, "<C-x><C-f>",
@@ -1257,10 +1388,10 @@ vim.keymap.set({ "i" }, "<C-x><C-f>",
   end, { silent = true, desc = "Fuzzy complete file" })
 ```
 
-</details>
-
 <details>
-<summary>custom completion</summary>
+<summary>CLICK FOR CUSTOM COMPLETION DETAILS</summary>
+
+#### Custom Completion
 
 Every fzf-lua function can be easily converted to a completion function by sending
 `complete = true` in the options:
@@ -1296,8 +1427,32 @@ require("fzf-lua").fzf_exec({"foo", "bar"}, {
 
 ### Highlights
 
+Highlight groups can be easily customized either via the lua API:
+
+```lua
+:lua vim.api.nvim_set_hl(0, "FzfLuaBorder", { link = "FloatBorder" })
+```
+
+or via `setup`:
+
+```lua
+require('fzf-lua').setup {
+  hls = { border = "FloatBorder" }
+}
+```
+
+or temporarily in the call:
+```lua
+:lua require'fzf-lua'.files({ hls={preview_title="IncSearch"} })
+-- vimL equivalent
+:FzfLua files hls.preview_title=IncSearch
+```
+
 <details>
-<summary>Highlight groups</summary>
+<summary>CLICK TO SEE AVAILABLE HIGHLIGHT GROUPS</summary>
+
+#### Highlight groups
+
 FzfLua conveniently creates the below highlights, each hlgroup can be
 temporarily overridden by its corresponding `winopts` option:
 
@@ -1351,21 +1506,55 @@ temporarily overridden by its corresponding `winopts` option:
 | FzfLuaFzfPrompt         | Special          | `fzf.prompt`         | fzf's `prompt`                        |
 | FzfLuaFzfQuery          | FzfLuaNormal     | `fzf.query`          | fzf's `header`                        |
 
+<sup><sub>&ast;Not a highlight group, RGB color from `nvim_get_color_map`</sub></sup>
+
 </details>
 
-Highlight groups can be easily customized either via the lua API:
+<details>
+<summary>CLICK FOR FZF COLORS DETAILS</summary>
 
+#### Fzf Colors
+
+Fzf's terminal colors are controlled by fzf's `--color` flag which can be
+configured during setup via `fzf_colors`.
+
+Set to `true` to have fzf-lua automatically generate an fzf colorscheme from
+your current Neovim colorscheme:
 ```lua
-:lua vim.api.nvim_set_hl(0, "FzfLuaBorder", { link = "FloatBorder" })
+require("fzf-lua").setup({ fzf_colors = true })
+-- Or in the direct call options
+:lua require("fzf-lua").files({ fzf_colors = true })
+:FzfLua files fzf_colors=true
 ```
 
-or via `setup`:
-
+Customizing the fzf colorscheme (see `man fzf` for all color options):
 ```lua
 require('fzf-lua').setup {
-  hls = { border = "FloatBorder" }
+  fzf_colors = {
+    -- First existing highlight group will be used
+    -- values in 3rd+ index will be passed raw
+    -- i.e:  `--color fg+:#010101:bold:underline`
+    ["fg+"] = { "fg" , { "Comment", "Normal" }, "bold", "underline" },
+    -- It is also possible to pass raw values directly
+    ["gutter"] = "-1"
+  }
 }
 ```
+
+Conveniently, fzf-lua can also be configured using fzf.vim's `g:fzf_colors`, i.e:
+```lua
+-- Similarly, first existing highlight group will be used
+:lua vim.g.fzf_colors = { ["gutter"] = { "bg", "DoesNotExist", "IncSearch" } }
+```
+
+However, the above doesn't allow combining both neovim highlights and raw args,
+if you're only using fzf-lua we can hijack `g:fzf_colors` to accept fzf-lua style
+values (i.e. table at 2nd index and 3rd+ raw args):
+```lua
+:lua vim.g.fzf_colors = { ["fg+"] = { "fg", { "ErrorMsg" }, "bold", "underline" } }
+```
+
+</details>
 
 ## Credits
 
@@ -1373,21 +1562,18 @@ Big thank you to all those I borrowed code/ideas from, I read so many configs
 and plugin codes that I probably forgot where I found some samples from so if
 I missed your name feel free to contact me and I'll add it below:
 
-- [@vijaymarupudi](https://github.com/vijaymarupudi/) for his wonderful
-  [nvim-fzf](https://github.com/vijaymarupudi/nvim-fzf) plugin which is at the
-  core of this plugin
++ [@junegunn](https://github.com/junegunn/) for creating the magical
+  [fzf](https://github.com/junegunn/fzf) and
+  [fzf.vim](https://github.com/junegunn/fzf.vim)
+- [@vijaymarupudi](https://github.com/vijaymarupudi/) for the wonderful
+  [nvim-fzf](https://github.com/vijaymarupudi/nvim-fzf) plugin which started
+  this endeavour
 - [@tjdevries](https://github.com/tjdevries/) for too many great things to
-  list here and for borrowing some of his
-  [nvim-telescope](https://github.com/nvim-telescope/telescope.nvim) provider
-  code
-- [@lukas-reineke](https://github.com/lukas-reineke) for inspiring the
-  solution after browsing his
-  [dotfiles](https://github.com/lukas-reineke/dotfiles) and coming across his
-  [fuzzy.lua](https://github.com/lukas-reineke/dotfiles/blob/master/vim/lua/fuzzy.lua)
-  , and while we're, also here for his great lua plugin
-  [indent-blankline](https://github.com/lukas-reineke/indent-blankline.nvim)
-- [@sindrets](https://github.com/sindrets) for borrowing utilities from his
-  fantastic lua plugin [diffview.nvim](https://github.com/sindrets/diffview.nvim)
-- [@kevinhwang91](https://github.com/kevinhwang91) for using his previewer
-  code as baseline for the builtin previewer and his must have plugin
-  [nvim-bqf](https://github.com/kevinhwang91/nvim-bqf)
+  list here and borrowing code from
+  [nvim-telescope](https://github.com/nvim-telescope/telescope.nvim)
+- [@lukas-reineke](https://github.com/lukas-reineke) for inspiration after browsing
+  [dotfiles](https://github.com/lukas-reineke/dotfiles)
+- [@sindrets](https://github.com/sindrets) for borrowing utilities from
+  [diffview.nvim](https://github.com/sindrets/diffview.nvim)
+- [@kevinhwang91](https://github.com/kevinhwang91) for inspiring the builtin
+  previewer code while using [nvim-bqf](https://github.com/kevinhwang91/nvim-bqf)


### PR DESCRIPTION
I have seen [this comment](https://www.reddit.com/r/neovim/comments/1hgvt7c/comment/m2nvwxx/?utm_source=share&utm_medium=web3x&utm_name=web3xcss&utm_term=1&utm_content=share_button) of yours on reddit and have decided to come up with a proposal to help you clear up the docs. Let me try to explain the rationale of this PR before you get a heart attack by looking at the diff :D 

I have been a long-term Fzf-lua user and more or less know my way around this project, in the sense that I know where to find information I need; however, I sometimes do struggle navigating through the README, the Wiki and the issues just because of course there are so many options and contributions and it is hard to have a unified glance. For this reason I have proposed a strong refactoring of the README based on the below considerations:

1. the vast majority of users, the vast majority of times (say 90% of users 90% of times) exclusively look for configuration options, hence such must be the impact focus of the README, easily reachable, easily browsable. I have moved sections around to focus on Options first and foremost.
2. Installation and configuration instructions nowadays are done in lua only, I have removed all the bits that contain vimscript instructions (they are relevant for a minority of users only)
3. I have folder most if not all sections into `<details>` expandables: the README is very long and it cannot be browsed otherwise
4. I have separated the configuration options into different (foldable) sections according to the type: at the moment there is one long list that is difficult to search through
5. I have removed the table of contents because GitHub provides it already by itself (top right of the README rendering), so that we can save some "visual space"

As I said, this is a _strong_ refactoring of the README and it serves as proposal only, I did not mean to intentionally remove instructions or else, only instead to provide a basis for thoughts in case you would like to offer a leaner documentation (especially for first time users).

README diffs are hard to read, to see what it looks like directly in the browser hop on [the fork](https://github.com/gennaro-tedesco/fzf-lua/tree/readme_proposal?tab=readme-ov-file) and check it out.