### PR TITLE
feat: auto remove non-compat flags from fzf/skim

### DIFF
--- a/lua/fzf-lua/config.lua
+++ b/lua/fzf-lua/config.lua
@@ -600,25 +600,18 @@ function M.normalize_opts(opts, globals, __resume_key)
     opts.__FZF_VERSION = FZF_VERSION
     vim.g.fzf_lua_fzf_version = FZF_VERSION
     if not opts.__FZF_VERSION then
-      utils.err(string.format(
-        "'fzf --version' failed with error %s: %s", rc, err))
+      utils.err(string.format("'fzf --version' failed with error %s: %s", rc, err))
       return nil
-    elseif opts.__FZF_VERSION < 0.24 then
-      utils.err(string.format(
-        "fzf version %.2f is lower than minimum (0.24), aborting.",
+    elseif opts.__FZF_VERSION < 0.25 then
+      utils.err(string.format("fzf version %.2f is lower than minimum (0.25), aborting.",
         opts.__FZF_VERSION))
       return nil
-    elseif opts.__FZF_VERSION < 0.27 then
-      -- remove `--border=none`, fails when < 0.27
-      opts.fzf_opts = opts.fzf_opts or {}
-      opts.fzf_opts["--border"] = false
     end
   else
     local SK_VERSION, rc, err = utils.sk_version(opts)
     opts.__SK_VERSION = SK_VERSION
     if not opts.__SK_VERSION then
-      utils.err(string.format(
-        "'sk --version' failed with error %s: %s", rc, err))
+      utils.err(string.format("'sk --version' failed with error %s: %s", rc, err))
       return nil
     end
   end
@@ -632,6 +625,110 @@ function M.normalize_opts(opts, globals, __resume_key)
   else
     -- If not possible (fzf v<0.53|skim), nullify the option
     opts.multiline = nil
+  end
+
+  do
+    -- Remove incompatible flags / values
+    --   (1) `true` flags are removed entirely (regardless of value)
+    --   (2) `string` flags are removed only if the values match
+    --   (3) `table` flags are removed if the value is contained
+    local version, changelog = (function()
+      if opts._is_skim then
+        return opts.__SK_VERSION, {
+          ["0.144"] = { fzf_opts = { ["--tmux"] = true } },
+          -- TODO: better version management that takes into account
+          -- major.minor.patch, the below will fail as 0.5.3 > 0.14.4
+          -- ["0.53"] = { fzf_opts = { ["--inline-info"] = true } },
+          -- All fzf flags not existing in skim
+          ["all"] = {
+            fzf_opts = {
+              ["--gap"]            = false,
+              ["--info"]           = false,
+              ["--border"]         = false,
+              ["--scrollbar"]      = false,
+              ["--no-scrollbar"]   = false,
+              ["--highlight-line"] = false,
+            }
+          },
+        }
+      else
+        return opts.__FZF_VERSION, {
+          ["0.56"] = { fzf_opts = { ["--gap"] = true } },
+          ["0.54"] = {
+            fzf_opts = {
+              ["-wrap"]            = true,
+              ["-wrap-sign"]       = true,
+              ["--highlight-line"] = true,
+            }
+          },
+          ["0.52"] = { fzf_opts = { ["--highlight-line"] = true } },
+          ["0.42"] = {
+            fzf_opts = {
+              ["--info"] = { "right", "inline-right" },
+            }
+          },
+          ["0.39"] = { fzf_opts = { ["--track"] = true } },
+          ["0.36"] = {
+            fzf_opts = {
+              ["--listen"]       = true,
+              ["--scrollbar"]    = true,
+              ["--no-scrollbar"] = true,
+            }
+          },
+          ["0.35"] = {
+            fzf_opts = {
+              ["--border"]            = { "bold", "double" },
+              ["--border-label"]      = true,
+              ["--border-label-pos"]  = true,
+              ["--preview-label"]     = true,
+              ["--preview-label-pos"] = true,
+            }
+          },
+          ["0.33"] = { fzf_opts = { ["--scheme"] = true } },
+          ["0.30"] = { fzf_opts = { ["--ellipsis"] = true } },
+          ["0.28"] = {
+            fzf_opts = {
+              ["--header-first"] = true,
+              ["--scroll-off"]   = true,
+            }
+          },
+          ["0.27"] = { fzf_opts = { ["--border"] = "none" } },
+          -- All skim flags not existing in fzf
+          ["all"] = {
+            fzf_opts = {
+              ["--inline-info"] = false,
+            }
+          },
+        }
+      end
+    end)()
+    local function warn(flag, val, min_ver)
+      local bin = opts._is_skim and "skim" or "fzf"
+      return utils.warn(string.format("Removed flag '%s%s', %s.",
+        flag, type(val) == "string" and "=" .. val or "",
+        not min_ver and string.format("not supported with %s", bin)
+        or string.format("only supported with %s v%s (has=%s)",
+          bin, tostring(min_ver), tostring(version))))
+    end
+    for min_ver, ver_data in pairs(changelog) do
+      for flag, non_compat_value in pairs(ver_data.fzf_opts) do
+        (function()
+          local opt_value = opts.fzf_opts[flag]
+          if not opt_value then return end
+          non_compat_value = type(non_compat_value) == "string"
+              and { non_compat_value } or non_compat_value
+          if not tonumber(min_ver) or tonumber(min_ver) > version
+              and (non_compat_value == true or type(non_compat_value) == "table"
+                and utils.tbl_contains(non_compat_value, opt_value))
+          then
+            if opts.compat_warn == true then
+              warn(flag, opt_value, tonumber(min_ver))
+            end
+            opts.fzf_opts[flag] = nil
+          end
+        end)()
+      end
+    end
   end
 
   -- Are we using fzf-tmux? if so get available columns

--- a/lua/fzf-lua/core.lua
+++ b/lua/fzf-lua/core.lua
@@ -660,30 +660,6 @@ M.build_fzf_cli = function(opts, fzf_win)
     opts.fzf_opts["--preview-window"] =
         opts.fzf_opts["--preview-window"] .. ":" .. opts.preview_offset
   end
-  if opts.__FZF_VERSION
-      and opts.__FZF_VERSION < 0.42
-      and opts.fzf_opts["--info"] == "inline-right"
-  then
-    opts.fzf_opts["--info"] = "inline"
-  end
-  if opts._is_skim or opts.__FZF_VERSION and opts.__FZF_VERSION < 0.53 then
-    opts.fzf_opts["--highlight-line"] = nil
-  end
-  if opts._is_skim then
-    -- skim (rust version of fzf) doesn't support the '--info=' flag
-    local info = opts.fzf_opts["--info"]
-    opts.fzf_opts["--info"] = nil
-    if type(info) == "string" and info:match("^inline") then
-      -- inline for skim is defined as:
-      opts.fzf_opts["--inline-info"] = true
-    end
-    -- skim doesn't accept border args
-    if opts.fzf_opts["--border"] == "none" then
-      opts.fzf_opts["--border"] = nil
-    else
-      opts.fzf_opts["--border"] = true
-    end
-  end
   -- build the cli args
   local cli_args = {}
   -- fzf-tmux args must be included first
@@ -1125,7 +1101,8 @@ end
 ---@param opts table
 ---@return table
 M.convert_exec_silent_actions = function(opts)
-  if opts._is_skim then
+  -- Does not work with fzf version < 0.36, fzf fails with
+  if not opts.__FZF_VERSION or opts.__FZF_VERSION < 0.36 then
     return opts
   end
   for k, v in pairs(opts.actions) do

--- a/lua/fzf-lua/profiles/skim.lua
+++ b/lua/fzf-lua/profiles/skim.lua
@@ -1,5 +1,5 @@
 return {
   desc = "fzf-lua defaults with `sk` as binary",
   fzf_bin = "sk",
-  fzf_opts = { ["--no-separator"] = false },
+  defaults = { compat_warn = false },
 }


### PR DESCRIPTION
Will remove any non-compat options from `fzf_opts`.

For exmaple, having `["--no-scrollbar"] = true` will fail on skim and any fzf version below 0.36.

ref: https://github.com/LazyVim/LazyVim/issues/5193

By default compat warnings are supressed unless `compat_warn=true`, for example running:
```vim
:FzfLua files fzf_bin=sk compat_warn=true
```
Will result in:
![image](https://github.com/user-attachments/assets/3f7c8b9d-8e75-4817-a11b-d85ddcacfe2b)

Or if running an older fzf version:
```vim
:FzfLua files fzf_bin=~/Downloads/fzf/fzf-0.25.0 compat_warn=true
```
![image](https://github.com/user-attachments/assets/bdae7489-36f9-4706-b328-85107376e96b)
