### PR TITLE
introduce option to filter registers types

### DIFF
--- a/README.md
+++ b/README.md
@@ -1353,6 +1353,12 @@ require'fzf-lua'.setup {
     -- you would set this option as %a this would match characters from [A-Za-z]
     -- or if you want to show only numbers you would set the pattern to %d (0-9).
   },
+  registers = {
+    filter = "", -- only show certain registers
+    -- "alpha" -> [a-z] registers
+    -- "named" -> [0-9] registers
+    -- leave empty for all
+  },
   complete_path = {
     cmd          = nil, -- default: auto detect fd|rg|find
     complete     = { ["enter"] = actions.complete },

--- a/lua/fzf-lua/providers/nvim.lua
+++ b/lua/fzf-lua/providers/nvim.lua
@@ -269,14 +269,26 @@ M.registers = function(opts)
   opts = config.normalize_opts(opts, "registers")
   if not opts then return end
 
-  local registers = { [["]], "_", "#", "=", "_", "/", "*", "+", ":", ".", "%" }
+  local filter = opts.filter and opts.filter or ""
+  local registers = {}
+
+  if filter == "" then
+    local special_registers = { [["]], "_", "#", "=", "_", "/", "*", "+", ":", ".", "%" }
+    for i = 1, #special_registers do
+      table.insert(registers, special_registers[i])
+    end
+  end
   -- named
-  for i = 0, 9 do
-    table.insert(registers, tostring(i))
+  if filter ~= "alpha" then
+    for i = 0, 9 do
+      table.insert(registers, tostring(i))
+    end
   end
   -- alphabetical
-  for i = 65, 90 do
-    table.insert(registers, string.char(i))
+  if filter ~= "named" then
+    for i = 65, 90 do
+      table.insert(registers, string.char(i))
+    end
   end
 
   local function register_escape_special(reg, nl)


### PR DESCRIPTION
Would you be open to consider the introduction of an option to filter register types?

This PR proposes a parameter:
```lua
registers = {
  filter = "..." -- "alpha" | "named" | ""
}
```
to only show a subset of the register types.

The rationale is that some users only need registers to paste specific content they just copied into 2-3 specific registers, and reducing the list may help glancing at what you need at once.

P. S. Unrelated to the PR (for future references): do you have pre-commit hooks or CI in place to format the code with `stylua`? I have run it locally but it produced a bigger diff than expected, not sure if `.stylua.toml` settings are not respected by my formatter or else.