### PR TITLE
prototype for preview buffer for git_branches picker

### DIFF
--- a/lua/fzf-lua/defaults.lua
+++ b/lua/fzf-lua/defaults.lua
@@ -439,8 +439,9 @@ M.defaults.git                  = {
   },
   branches = {
     prompt     = "Branches> ",
-    cmd        = "git branch --all --color",
-    preview    = "git log --graph --pretty=oneline --abbrev-commit --color {1}",
+    cmd        = "git branch --all --color --format='%(refname:short)'",
+    log_cmd    = "git log --date=relative --date-order --pretty=format:%h%x09%an%x09%ad%x09%s",
+    previewer  = { _ctor = previewers.builtin.branches },
     actions    = {
       ["enter"]  = actions.git_switch,
       ["ctrl-x"] = { fn = actions.git_branch_del, reload = true },

--- a/lua/fzf-lua/previewer/init.lua
+++ b/lua/fzf-lua/previewer/init.lua
@@ -25,5 +25,6 @@ Previewer.builtin.highlights = function() return require "fzf-lua.previewer.buil
 Previewer.builtin.autocmds = function() return require "fzf-lua.previewer.builtin".autocmds end
 Previewer.builtin.keymaps = function() return require "fzf-lua.previewer.builtin".keymaps end
 Previewer.builtin.codeaction = function() return require "fzf-lua.previewer.codeaction".builtin end
+Previewer.builtin.branches = function() return require "fzf-lua.previewer.builtin".branches end
 
 return Previewer


### PR DESCRIPTION
This PR is a prototype for a builtin preview for the `git_branches` picker in case you would be open to consider it.

1. The user can specify what type of `log_cmd` to display, in the demo below you can see different commands in action.
2. I have modified the original `cmd` for branches by adding `--format='%(refname:short)'`: it should help with the parsing of the branches names (removing `*`, spaces and all other symbols)

I might need some guidance for the following:

- can one use the treesitter parser to syntax highlight the git logs? I saw in the codebase that there is such option but I could not make it work
- if the user specifies a `log_cmd` that isn't a "git command", then the preview _may_ fail with some obscure errors: how can one ensure that for "bad commands" we catch the exception first and default to the default `self.opts.log_cmd`? I tried to `pcall` the `vim.system` but I do not what type of exception we want to capture.

Examples:

With the default `log_cmd` we have:
![demo1](https://github.com/user-attachments/assets/5461b49c-828a-4951-ac0e-4bbfa2c221a1)

With 
```lua
git = {
  branches = {
    log_cmd = "git diff --stat main",
..
}
```
we have 
![demo2](https://github.com/user-attachments/assets/2ee1047b-0524-41ed-a0b4-255fbd0f08ed)

