### PR TITLE
fix: type of `fzf_live` param

### DIFF
--- a/lua/fzf-lua/core.lua
+++ b/lua/fzf-lua/core.lua
@@ -193,7 +193,7 @@ M.fzf_exec = function(contents, opts)
   return M.fzf_wrap(opts, contents)
 end
 
----@param contents fun(query: string): string|string[]|function
+---@param contents string|fun(query: string): string|string[]|function
 ---@param opts? table
 M.fzf_live = function(contents, opts)
   assert(contents)


### PR DESCRIPTION
I think this is right, matching the type of `fn_reload` in `fzf_exec`.