### PR TITLE
fix: `search_history` and `command_history` not showing custom actions

### DIFF
--- a/lua/fzf-lua/providers/nvim.lua
+++ b/lua/fzf-lua/providers/nvim.lua
@@ -116,7 +116,7 @@ M.command_history = function(opts)
   opts = config.normalize_opts(opts, "command_history")
   if not opts then return end
   if opts.fzf_opts["--header"] == nil then
-    opts.fzf_opts["--header"] = arg_header("<CR>", "<Ctrl-e>", "execute")
+    opts = core.set_header(opts, opts.headers)
   end
   history(opts, "cmd")
 end
@@ -125,7 +125,7 @@ M.search_history = function(opts)
   opts = config.normalize_opts(opts, "search_history")
   if not opts then return end
   if opts.fzf_opts["--header"] == nil then
-    opts.fzf_opts["--header"] = arg_header("<CR>", "<Ctrl-e>", "search")
+    opts = core.set_header(opts, opts.headers)
   end
   history(opts, "search")
 end


### PR DESCRIPTION
The headers of `search_history` and `command_history` are always set to `:: <CR> to execute, <Ctrl-e> to edit` despite custom configs, for example, users can disable `ctrl-e` for its original purpose (move cursor to the end of prompt). This PR dynamically set the header using `core.set_header()`.