### PR TITLE
fix: multi-line command desc not captured properly

### DIFF
--- a/lua/fzf-lua/providers/nvim.lua
+++ b/lua/fzf-lua/providers/nvim.lua
@@ -25,7 +25,10 @@ M.commands = function(opts)
           if cmd then builtin_commands[cmd] = desc end
           cmd, desc = line:match("^|:(%S+)|%s*%S+%s*(.*%S)")
         elseif cmd then -- found
-          if line:match("^%s%+%S") then desc = desc .. (line:match("^%s*(.*%S)") or "") end
+          if line:match("^%s+%S") then
+            local desc_continue = line:match("^%s*(.*%S)")
+            desc = desc .. (desc_continue and " " .. desc_continue or "")
+          end
           if line:match("^%s*$") then break end
         end
       end


### PR DESCRIPTION
**Problem:**
If the builtin command description spans multiple lines, only the first line is captured and showed and the remaining lines won't be matched. I believe the issue lies in mistakenly writing `+` as `%+` in the regex.

**Solution:**
Correct the regex in `string.match()` and properly prepend a whitespace when concatenating multiple lines.