### PR TITLE
fix(previewer): regex escape --fixed-strings

### DIFF
--- a/lua/fzf-lua/previewer/builtin.lua
+++ b/lua/fzf-lua/previewer/builtin.lua
@@ -1013,9 +1013,10 @@ function Previewer.buffer_or_file:set_cursor_hl(entry)
       or self.opts.__ACT_TO == mgrep.live_grep and self.opts.search or nil
   if regex and self.opts.rg_glob and self.opts.glob_separator then
     regex = require("fzf-lua.make_entry").glob_parse(regex, self.opts)
-    if self.opts.cmd:match("%-%-fixed-strings") or self.opts.cmd:match("%-F") then
-      regex = utils.rg_escape(regex)
-    end
+  end
+  if regex and self.opts.cmd
+      and (self.opts.cmd:match("%-%-fixed%-strings") or self.opts.cmd:match("%-F")) then
+    regex = utils.rg_escape(regex)
   end
 
   -- If called from tags previewer, can happen when using ctags cmd


### PR DESCRIPTION
Original issue: https://github.com/ibhagwan/fzf-lua/issues/1641

https://github.com/ibhagwan/fzf-lua/commit/7307943791d7531a8a04f6ccbc5ac8e3292ea467 did not work for me.