### PR TITLE
fix: new approach to NORMAL TERMINAL mode (#1657)

### DIFF
--- a/lua/fzf-lua/utils.lua
+++ b/lua/fzf-lua/utils.lua
@@ -15,6 +15,7 @@ M.__HAS_NVIM_07 = vim.fn.has("nvim-0.7") == 1
 M.__HAS_NVIM_08 = vim.fn.has("nvim-0.8") == 1
 M.__HAS_NVIM_09 = vim.fn.has("nvim-0.9") == 1
 M.__HAS_NVIM_010 = vim.fn.has("nvim-0.10") == 1
+M.__HAS_NVIM_0102 = vim.fn.has("nvim-0.10.2") == 1
 M.__HAS_NVIM_011 = vim.fn.has("nvim-0.11") == 1
 M.__IS_WINDOWS = vim.fn.has("win32") == 1 or vim.fn.has("win64") == 1
 -- `:help shellslash` (for more info see #1055)


### PR DESCRIPTION
Utilize the `ModeChanged` event to enter TERMINAL mode from NORMAL TERMINAL mode instead of the current approach which tested the mode after the job started, since mode changes are scheduled in neovim the former was bound to fail in some cases as demonstrated in #1657.

Still keeps the old approach for neovim < 0.7 as both `ModeChanged` and "normal terminal" mode didn't exist prior to that. I should probaly bump the min neovim version to 0.7 at least but what's the harm of keeping a few extra lines for supporting old versions?

This commit also fixes another bug which mapped `<C-c>` to `<Esc>` on the origin buffer when using `fzf-tmux` and removes the `<C-c>` workaround for https://github.com/neovim/neovim/issues/20726 to neovim >= v0.10.2 (previously was just removed in 0.11) - this should make exiting fzf-lua with `<C-c>` much more snappy with 0.10.2/0.10.3 (without the risk of neovim freeze).

Fixes #1657.