### PR TITLE
fix: prompt should be concatenated with cwd_prompt

### DIFF
--- a/lua/fzf-lua/core.lua
+++ b/lua/fzf-lua/core.lua
@@ -889,7 +889,7 @@ M.set_header = function(opts, hdr_tbl)
 
   if not opts then opts = {} end
   if opts.cwd_prompt then
-    opts.prompt = normalize_cwd(opts.cwd or uv.cwd())
+    opts.prompt = opts.prompt .. normalize_cwd(opts.cwd or uv.cwd())
     if tonumber(opts.cwd_prompt_shorten_len) and
         #opts.prompt >= tonumber(opts.cwd_prompt_shorten_len) then
       opts.prompt = path.shorten(opts.prompt, tonumber(opts.cwd_prompt_shorten_val) or 1)


### PR DESCRIPTION
not sure if whether to classify this as `fix` or `feat`

hoping to achieve something like that in the prompt via 

```lua
files = {
      prompt = "❯ ",
      cwd_prompt = true,
}
```
![image](https://github.com/user-attachments/assets/57389103-221f-4a8c-961a-8ec33ab76dfa)
