### PR TITLE
fix(lsp): fix invalid access in `fzf_lsp_locations`

### DIFF
--- a/lua/fzf-lua/providers/lsp.lua
+++ b/lua/fzf-lua/providers/lsp.lua
@@ -660,7 +660,7 @@ local function fzf_lsp_locations(opts, fn_contents)
   if not opts then return end
   opts = core.set_fzf_field_index(opts)
   opts = fn_contents(opts)
-  if not opts.__contents then
+  if not opts or not opts.__contents then
     core.__CTX = nil
     return
   end


### PR DESCRIPTION
`fzf_lsp_locations` was making an access to a nil value, for example when calling `lsp_incoming_calls` on a element that does not have any incoming calls.