### PR TITLE
Feat: enable closing dirty buffer

### DIFF
--- a/lua/fzf-lua/actions.lua
+++ b/lua/fzf-lua/actions.lua
@@ -405,8 +405,15 @@ M.buf_switch_or_edit = M.file_switch_or_edit
 M.buf_del = function(selected, opts)
   for _, sel in ipairs(selected) do
     local entry = path.entry_to_file(sel, opts)
-    if entry.bufnr and not utils.buffer_is_dirty(entry.bufnr, true, false) then
-      vim.api.nvim_buf_delete(entry.bufnr, { force = true })
+    if entry.bufnr then
+      if not utils.buffer_is_dirty(entry.bufnr, true, false) then
+        vim.api.nvim_buf_delete(entry.bufnr, { force = true })
+      elseif vim.api.nvim_buf_call(entry.bufnr, function()
+            return utils.save_dialog(entry.bufnr)
+          end)
+      then
+        vim.api.nvim_buf_delete(entry.bufnr, { force = true })
+      end
     end
   end
 end


### PR DESCRIPTION
## Issue

https://github.com/ibhagwan/fzf-lua/issues/1696

## Description

This adds support to closing buffers using `buf_del` (`<C-x>`) for unsaved buffers as well. The current version only supports closing "clean" buffers.

It uses `utils.save_dialog` to confirm closing an unsaved buffer.

Let me know if there is anything that I missed or can be improved. Thank you!