### PR TITLE
Fix: Press Esc on buffer save dialog to cancel

### DIFF
--- a/lua/fzf-lua/utils.lua
+++ b/lua/fzf-lua/utils.lua
@@ -914,7 +914,7 @@ function M.save_dialog(bufnr)
   end
   local res = vim.fn.confirm(string.format([[Save changes to "%s"?]], info.name),
     "&Yes\n&No\n&Cancel")
-  if res == 3 then
+  if res == 0 or res == 3 then
     -- user cancelled
     return false
   end


### PR DESCRIPTION
## Bug reproduce

1. Open some buffers and make an unsaved change in one
2. `:LazyLua buffers`
3. Attempt to close the unsaved buffer in the picker (default bind is `<C-x>`)
4. Press `<Esc>` or `<C-c>` when the save dialog appears
5. Note that the buffer force closes without saving instead of canceling the save dialog

## Description

A followup to #1697

I noticed that pressing `<Esc>` or `<C-c>` does not cancel on the buffer save dialog from `utils.save_dialog`. 

This is because `vim.fn.confirm()` returns `0` on `<Esc>` or `<C-c>` and `utils.save_dialog` does not account for a `0` case currently, so it reaches the final `return true` statement.

Neovim doc for `vim.fn.confirm()`: https://neovim.io/doc/user/builtin.html#confirm()