### PR TITLE
feat(config): allow setup via global variable

### DIFF
--- a/lua/fzf-lua/cmd.lua
+++ b/lua/fzf-lua/cmd.lua
@@ -6,6 +6,10 @@ local serpent = require "fzf-lua.lib.serpent"
 
 local M = {}
 
+if _G.fzf_lua ~= nil then
+  builtin.setup(_G.fzf_lua)
+end
+
 function M.run_command(cmd, ...)
   local args = { ... }
   cmd = cmd or "builtin"


### PR DESCRIPTION
currently, fzf-lua takes 0.075ms on nvim startup if you don't use the setup function, but jumps up to 9.8ms if you use the setup function. It would be nice to keep the short startup time without needing an external lazy-loader (lazy.nvim).

still needs adding documentation, but I'd like to know what you think of the idea first.

prior art: [rustaceanvim](https://github.com/mrcjkb/rustaceanvim) uses `vim.g.rustaceanvim` for configuration (they also accept a function so you can do more advanced stuff but I don't think fzf-lua needs that)