### PR TITLE
fix: Use `strict_render` to reduce the number of times things get drawn

### DIFF
--- a/lua/fzf-lua/previewer/builtin.lua
+++ b/lua/fzf-lua/previewer/builtin.lua
@@ -887,8 +887,12 @@ function Previewer.base:update_render_markdown()
   if package.loaded["render-markdown"] then
     require("render-markdown.core.ui").update(bufnr, winid, "FzfLua", true)
   elseif package.loaded["markview"] then
-    local cmds = package.loaded["markview"].commands
-    if cmds and cmds.redraw then cmds.attach(bufnr, true) end
+    --- Render strictly to save performance.
+    ---
+    --- Use `strict:render(bufnr, 1000)` to stop rendering if
+    --- line count >= 1000.
+    local strict = package.loaded["markview"].strict_render;
+    if strict then strict:render(bufnr); end
   end
 end
 


### PR DESCRIPTION
Issues this commit is trying to solve,

- Removes any extra logical checks that may lead to performance loss(mostly caused by `markview.clean()`).
- Removes any need to listen to events or mode changes for preview buffers(preview buffers are assumed to be *immutable*).
- Only renders once per file during an active `:FzfLua` session.
- Disables previewing when line count exceeds the configured `max_buf_lines` in markview(See the comments in the commit on how to manually set it).

> After weighing the pros & cons of partially rendering on the preview the cons out-weight the pros.