### PR TITLE
fix(helptags): handle multibyte char align

### DIFF
--- a/lua/fzf-lua/providers/helptags.lua
+++ b/lua/fzf-lua/providers/helptags.lua
@@ -60,7 +60,9 @@ M.helptags = function(opts)
     end)()
 
     local add_tag = function(t, fzf_cb, co)
-      local tag = string.format("%-80s %s%s%s", hl(t.tag), t.filename, utils.nbsp, t.filepath)
+      local w = 80 + string.len(t.tag) - vim.fn.strwidth(t.tag)
+      local tag = string.format("%-" .. w .. "s %s%s%s", hl(t.tag), t.filename, utils.nbsp,
+        t.filepath)
       fzf_cb(tag, function()
         coroutine.resume(co)
       end)


### PR DESCRIPTION
Native lua `string.format` cannot handle multi-byte char
Related: https://github.com/ibhagwan/fzf-lua/issues/1417

Before:
![image](https://github.com/user-attachments/assets/ffb0eeaa-8534-402a-b6ff-4dc46c48f57f)

Now:
![image](https://github.com/user-attachments/assets/31101fa7-3e92-4465-80c0-9d028d6fa345)
