### PR TITLE
fix: disable netrw to avoid piping `!wget ..` to stdout

### DIFF
--- a/lua/fzf-lua/libuv.lua
+++ b/lua/fzf-lua/libuv.lua
@@ -769,7 +769,8 @@ M.wrap_spawn_stdio = function(opts, fn_transform, fn_preprocess, fn_postprocess)
         _is_win and [[set VIMRUNTIME=%s& ]] or "VIMRUNTIME=%s ",
         _is_win and vim.fs.normalize(vim.env.VIMRUNTIME) or M.shellescape(vim.env.VIMRUNTIME)
       )
-  local lua_cmd = ("lua %sloadfile([[%s]])().spawn_stdio(%s,%s,%s,%s)"):format(
+  local lua_cmd = ("lua %s%sloadfile([[%s]])().spawn_stdio(%s,%s,%s,%s)"):format(
+    "vim.g.loaded_netrwPlugin=1;",
     _has_nvim_010 and "vim.g.did_load_filetypes=1; " or "",
     _is_win and vim.fs.normalize(__FILE__) or __FILE__,
     opts, fn_transform, fn_preprocess, fn_postprocess

--- a/lua/fzf-lua/shell.lua
+++ b/lua/fzf-lua/shell.lua
@@ -101,7 +101,8 @@ function M.raw_async_action(fn, fzf_field_expression, debug)
   local action_cmd = ("%s%s -n --headless --clean --cmd %s -- %s"):format(
     nvim_runtime,
     libuv.shellescape(path.normalize(nvim_bin)),
-    libuv.shellescape(("lua %sloadfile([[%s]])().rpc_nvim_exec_lua({%s})"):format(
+    libuv.shellescape(("lua %s%sloadfile([[%s]])().rpc_nvim_exec_lua({%s})"):format(
+      "vim.g.loaded_netrwPlugin=1;",
       utils.__HAS_NVIM_010 and "vim.g.did_load_filetypes=1; " or "",
       path.join { vim.g.fzf_lua_directory, "shell_helper.lua" },
       call_args


### PR DESCRIPTION
Sometime pasting long url cause `!wget https:/xxx` appear in fzf win.

To reproduce with `mini.sh`
* `FzfLua live_grep`
* Paste a long url `https://a.com/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb`
![image](https://github.com/user-attachments/assets/8e7d2588-c5a4-4127-b7a6-87f8b4d4f595)

Just disable `netrw` then it seems fixed.