### PR TITLE
refactor: spawn headless instances using `-u NONE -i NONE`

### DIFF
--- a/lua/fzf-lua/config.lua
+++ b/lua/fzf-lua/config.lua
@@ -811,7 +811,7 @@ function M.normalize_opts(opts, globals, __resume_key)
       -- We also want to store the cached extensions/filenames in the main thread
       -- which we do in "make_entry.postprocess"
       opts.__mt_postprocess = opts.multiprocess
-          and [[return require("make_entry").postprocess]]
+          and [[return require("fzf-lua.make_entry").postprocess]]
           -- NOTE: we don't need to update mini when running on main thread
           -- or require("fzf-lua.make_entry").postprocess
           or nil

--- a/lua/fzf-lua/core.lua
+++ b/lua/fzf-lua/core.lua
@@ -863,8 +863,8 @@ M.mt_cmd_wrapper = function(opts)
     end
     local cmd = libuv.wrap_spawn_stdio(
       serialize(filter_opts(opts)),
-      serialize(opts.__mt_transform or [[return require("make_entry").file]]),
-      serialize(opts.__mt_preprocess or [[return require("make_entry").preprocess]]),
+      serialize(opts.__mt_transform or [[return require("fzf-lua.make_entry").file]]),
+      serialize(opts.__mt_preprocess or [[return require("fzf-lua.make_entry").preprocess]]),
       serialize(opts.__mt_postprocess or "nil")
     )
     if opts.argv_expr then

--- a/lua/fzf-lua/devicons.lua
+++ b/lua/fzf-lua/devicons.lua
@@ -359,7 +359,7 @@ M.plugin_load = function(provider, do_not_lazy_load)
       or provider == "mini" and M.__MINI
       or provider == "devicons" and M.__DEVICONS
       or (function()
-        if vim.g.fzf_lua_is_headless then
+        if _G._fzf_lua_is_headless then
           -- headless instance, fzf-lua server exists, attempt
           -- to load icons from main neovim instance
           ---@diagnostic disable-next-line: undefined-field
@@ -391,7 +391,7 @@ M.plugin_load = function(provider, do_not_lazy_load)
           ret = M.__MINI
         end
         -- Load custom setup file
-        if vim.g.fzf_lua_is_headless
+        if _G._fzf_lua_is_headless
             ---@diagnostic disable-next-line: undefined-field
             and _G._devicons_setup and uv.fs_stat(_G._devicons_setup) then
           ---@diagnostic disable-next-line: undefined-field

--- a/lua/fzf-lua/init.lua
+++ b/lua/fzf-lua/init.lua
@@ -1,9 +1,3 @@
--- make value truthy so we can load the path module and subsequently
--- the libuv module without overriding the global require used only
--- for spawn_stdio headless instances, this way we can call
--- require("fzf-lua") from test specs (which also run headless)
-vim.g.fzf_lua_directory = ""
-
 local uv = vim.uv or vim.loop
 local path = require "fzf-lua.path"
 local utils = require "fzf-lua.utils"

--- a/lua/fzf-lua/make_entry.lua
+++ b/lua/fzf-lua/make_entry.lua
@@ -15,7 +15,7 @@ do
 end
 
 local function load_config_section(s, datatype, optional)
-  if not vim.g.fzf_lua_is_headless then
+  if not _G._fzf_lua_is_headless then
     local val = utils.map_get(config, s)
     return type(val) == datatype and val or nil
     ---@diagnostic disable-next-line: undefined-field
@@ -79,7 +79,7 @@ M.get_diff_files = function(opts)
     local exec_str = string.format([[require"fzf-lua".utils.warn(]] ..
       [["'git status' took %.2f seconds, consider using `git_icons=false` in this repository or use `silent=true` to supress this message.")]]
       , seconds)
-    if not vim.g.fzf_lua_is_headless then
+    if not _G._fzf_lua_is_headless then
       loadstring(exec_str)()
     else
       ---@diagnostic disable-next-line: undefined-field

--- a/lua/fzf-lua/providers/git.lua
+++ b/lua/fzf-lua/providers/git.lua
@@ -56,7 +56,7 @@ M.status = function(opts)
     --
     -- preprocess is required since the addition of `path.filename_first`
     -- will be set by `core.mt_cmd_wrapper` by commenting out the above
-    opts.__mt_transform = [[return require("make_entry").git_status]]
+    opts.__mt_transform = [[return require("fzf-lua.make_entry").git_status]]
     contents = core.mt_cmd_wrapper(opts)
   else
     opts.__fn_transform = opts.__fn_transform or

--- a/lua/fzf-lua/providers/tags.lua
+++ b/lua/fzf-lua/providers/tags.lua
@@ -144,7 +144,7 @@ local function tags(opts)
   -- prevents 'file|git_icons=false' from overriding processing
   opts.requires_processing = true
   if opts.multiprocess then
-    opts.__mt_transform = [[return require("make_entry").tag]]
+    opts.__mt_transform = [[return require("fzf-lua.make_entry").tag]]
   else
     opts.__mt_transform = make_entry.tag
   end

--- a/lua/fzf-lua/shell.lua
+++ b/lua/fzf-lua/shell.lua
@@ -98,7 +98,7 @@ function M.raw_async_action(fn, fzf_field_expression, debug)
   -- special shell chars ('+', '-', etc), examples where this can
   -- happen are the `git status` command and git branches from diff
   -- worktrees (#600)
-  local action_cmd = ("%s%s -n --headless --clean --cmd %s -- %s"):format(
+  local action_cmd = ("%s%s -n --headless -u NONE -i NONE --cmd %s -- %s"):format(
     nvim_runtime,
     libuv.shellescape(path.normalize(nvim_bin)),
     libuv.shellescape(("lua %sloadfile([[%s]])().rpc_nvim_exec_lua({%s})"):format(

--- a/lua/fzf-lua/spawn.lua
+++ b/lua/fzf-lua/spawn.lua
@@ -1,0 +1,35 @@
+-- This file should only be loaded from the headless instance
+assert(#vim.api.nvim_list_uis() == 0)
+
+-- path to this file
+local __FILE__ = debug.getinfo(1, "S").source:gsub("^@", "")
+
+-- add the current folder to package.path so we can 'require'
+-- prepend this folder first, so our modules always get first
+-- priority over some unknown random module with the same name
+package.path = ("%s/?.lua;"):format(vim.fn.fnamemodify(__FILE__, ":h:h")) .. package.path
+
+-- due to 'os.exit' neovim doesn't delete the temporary
+-- directory, save it so we can delete prior to exit (#329)
+-- NOTE: opted to delete the temp dir at the start due to:
+--   (1) spawn_stdio doesn't need a temp directory
+--   (2) avoid dangling temp dirs on process kill (i.e. live_grep)
+local tmpdir = vim.fn.fnamemodify(vim.fn.tempname(), ":h")
+if tmpdir and #tmpdir > 0 then
+  -- io.stdout:write(string.format("[DEBUG] tmpdir=%s\n", tmpdir))
+  -- _G.dump(vim.uv.fs_stat(tmpdir))
+  vim.fn.delete(tmpdir, "rf")
+end
+
+-- neovim might also automatically start the RPC server which will
+-- generate a named pipe temp file, e.g. `/run/user/1000/nvim.14249.0`
+-- we don't need the server in the headless "child" process, stopping
+-- the server also deletes the temp file
+if vim.v.servername and #vim.v.servername > 0 then
+  pcall(vim.fn.serverstop, vim.v.servername)
+end
+
+-- global var indicating a headless instance
+_G._fzf_lua_is_headless = true
+
+return { spawn_stdio = require("fzf-lua.libuv").spawn_stdio }

--- a/scripts/headless_fd.sh
+++ b/scripts/headless_fd.sh
@@ -130,8 +130,8 @@ if [ $# -gt 0 ]; then
 fi
 
 VIMRUNTIME=/usr/share/nvim/runtime \
-/usr/bin/nvim -n --headless --clean --cmd "lua vim.g.did_load_filetypes=1; loadfile(
-  [[${BASEDIR}/../lua/fzf-lua/libuv.lua]])().spawn_stdio(
+/usr/bin/nvim -n --headless -u NONE -i NONE --cmd "lua vim.g.did_load_filetypes=1; loadfile(
+  [[${BASEDIR}/../lua/fzf-lua/spawn.lua]])().spawn_stdio(
   -- opts
   {
     g = {
@@ -149,10 +149,10 @@ VIMRUNTIME=/usr/share/nvim/runtime \
   },
   -- fn_transform
   [==[
-    return require(\"make_entry\").file
+    return require(\"fzf-lua.make_entry\").file
   ]==],
   -- fn_preprocess
   [==[
-    return require(\"make_entry\").preprocess
+    return require(\"fzf-lua.make_entry\").preprocess
   ]==]
 )"

--- a/tests/devicons_spec.lua
+++ b/tests/devicons_spec.lua
@@ -8,7 +8,7 @@ describe("Testing NvimWebDevicons", function()
   local devicons = require("fzf-lua.devicons")
 
   local function load_package()
-    vim.g.fzf_lua_is_headless = nil
+    _G._fzf_lua_is_headless = nil
     _G._devicons_path = nil
     _G._fzf_lua_server = nil
     vim.opt.runtimepath:append(devicons_path)
@@ -63,7 +63,7 @@ describe("Testing NvimWebDevicons", function()
   it("headless: _G.devicons_path", function()
     _G._devicons_path = devicons_path
     _G._fzf_lua_server = nil
-    vim.g.fzf_lua_is_headless = true
+    _G._fzf_lua_is_headless = true
     unload_package()
     devicons.load()
     assert.is.True(devicons.plugin_loaded())
@@ -73,7 +73,7 @@ describe("Testing NvimWebDevicons", function()
   it(string.format("headless RPC: '%s'", vim.g.fzf_lua_server), function()
     unload_package()
     load_package()
-    vim.g.fzf_lua_is_headless = true
+    _G._fzf_lua_is_headless = true
     _G._devicons_path = nil
     _G._fzf_lua_server = vim.g.fzf_lua_server
     devicons.load({ plugin = "srv", srv_plugin = "devicons" })

--- a/tests/minicons.spec.lua
+++ b/tests/minicons.spec.lua
@@ -12,7 +12,7 @@ describe("Testing MiniIcons", function()
   vim.cmd("colorscheme default")
 
   local function load_package()
-    vim.g.fzf_lua_is_headless = nil
+    _G._fzf_lua_is_headless = nil
     _G._devicons_path = nil
     _G._fzf_lua_server = nil
     vim.opt.runtimepath:append(mini_path)
@@ -94,7 +94,7 @@ describe("Testing MiniIcons", function()
     validate_mini()
   end)
   it("headless: _G.devicons_path", function()
-    vim.g.fzf_lua_is_headless = true
+    _G._fzf_lua_is_headless = true
     _G._devicons_path = mini_path
     _G._fzf_lua_server = nil
     unload_package()
@@ -109,7 +109,7 @@ describe("Testing MiniIcons", function()
     unload_package()
     load_package()
     assert.are.same(devicons.plugin_name(), "mini")
-    vim.g.fzf_lua_is_headless = true
+    _G._fzf_lua_is_headless = true
     _G._devicons_path = nil
     _G._fzf_lua_server = vim.g.fzf_lua_server
     devicons.load({ plugin = "srv", srv_plugin = "mini" })


### PR DESCRIPTION
Was using `--clean` which wasn't disabling nvim plugins, this had some rare side effects with netrw.

Other changes:
- Separated the spawn code to its own lua script and eliminating the need to test if running headless.
- Eliminated the `require` hack by going up one more level in the the `package.path` prefix
- Using `_G` instead of `vim.g` for global `fzf_lua_is_headless` in case we decide one day to use `nvim -ll` which doesn't have access to `vim.g`

ref: #1717