### PR TITLE
fix: merge existed `fzf_opts["--preview_window"]`

### DIFF
--- a/lua/fzf-lua/core.lua
+++ b/lua/fzf-lua/core.lua
@@ -382,7 +382,7 @@ M.fzf = function(contents, opts)
       -- (1) when using a split we use the previewer as placeholder
       -- (2) we use 'nohidden:right:0' to trigger preview function
       --     calls without displaying the native fzf previewer split
-      opts.fzf_opts["--preview-window"] = previewer:preview_window(opts.preview_window)
+      opts.fzf_opts["--preview-window"] = previewer:preview_window(opts.fzf_opts["--preview-window"])
     end
     -- provides preview offset when using native previewers
     -- (bat/cat/etc) with providers that supply line numbers

--- a/lua/fzf-lua/previewer/builtin.lua
+++ b/lua/fzf-lua/previewer/builtin.lua
@@ -433,11 +433,11 @@ function Previewer.base:zero(_)
   return act
 end
 
-function Previewer.base:preview_window(_)
+function Previewer.base:preview_window(old_preview_window)
   if self.win and not self.win.winopts.split then
-    return "nohidden:right:0"
+    return (old_preview_window or "") .. ":nohidden:right:0"
   else
-    return nil
+    return old_preview_window
   end
 end
 

--- a/lua/fzf-lua/previewer/fzf.lua
+++ b/lua/fzf-lua/previewer/fzf.lua
@@ -23,8 +23,8 @@ function Previewer.base:new(o, opts)
   return self
 end
 
-function Previewer.base:preview_window(_)
-  return nil
+function Previewer.base:preview_window(old_preview_window)
+  return old_preview_window
 end
 
 function Previewer.base:_preview_offset()


### PR DESCRIPTION
And `opts.preview_window` seems unused here.

e.g. When set `fzf_opts["--preview-window"] = "border-left"`, while `FzfLua git_status` still open fzf's previewer with the default border.