### PR TITLE
chore: cleanup deprecated things

### DIFF
--- a/lua/fzf-lua/core.lua
+++ b/lua/fzf-lua/core.lua
@@ -382,7 +382,7 @@ M.fzf = function(contents, opts)
       -- (1) when using a split we use the previewer as placeholder
       -- (2) we use 'nohidden:right:0' to trigger preview function
       --     calls without displaying the native fzf previewer split
-      opts.fzf_opts["--preview-window"] = previewer:preview_window(opts.preview_window)
+      opts.fzf_opts["--preview-window"] = previewer:preview_window()
     end
     -- provides preview offset when using native previewers
     -- (bat/cat/etc) with providers that supply line numbers
@@ -1074,7 +1074,7 @@ M.convert_reload_actions = function(reload_cmd, opts)
       end
     end
   end
-  if has_reload and reload_cmd and type(reload_cmd) ~= "string" then
+  if opts.silent ~= true and has_reload and reload_cmd and type(reload_cmd) ~= "string" then
     utils.warn(
       "actions with `reload` are only supported with string commands, using resume fallback")
   end

--- a/lua/fzf-lua/fzf.lua
+++ b/lua/fzf-lua/fzf.lua
@@ -3,7 +3,7 @@
 -- does not close the pipe before all writes are complete
 -- option to not add '\n' on content function callbacks
 -- https://github.com/vijaymarupudi/nvim-fzf/blob/master/lua/fzf.lua
-local uv = vim.loop
+local uv = vim.uv or vim.loop
 
 local utils = require "fzf-lua.utils"
 local libuv = require "fzf-lua.libuv"
@@ -213,13 +213,6 @@ function M.raw_fzf(contents, fzf_cli_args, opts)
       vim.keymap.set("t", "<C-c>", "<Esc>", { buffer = 0 })
     end
 
-    -- Workaround for upstream issue, see #1714
-    -- https://github.com/neovim/neovim/issues/32019
-    if utils.__HAS_NVIM_011 then
-      vim.keymap.set("t", "<C-j>", "<C-j>", { buffer = 0 })
-      vim.keymap.set("t", "<C-k>", "<C-k>", { buffer = 0 })
-    end
-
     -- A more robust way of entering TERMINAL mode "t". We had quite a few issues
     -- sending `feedkeys|startinsert` after the term job is started, this approach
     -- seems more consistent as it triggers when entering terminal normal mode "nt"
@@ -250,7 +243,7 @@ function M.raw_fzf(contents, fzf_cli_args, opts)
   end
 
   local co = coroutine.running()
-  local jobstart = opts.is_fzf_tmux and vim.fn.jobstart or vim.fn.termopen
+  local jobstart = opts.is_fzf_tmux and vim.fn.jobstart or utils.termopen
   local shell_cmd = utils.__IS_WINDOWS
       -- MSYS2 comes with "/usr/bin/cmd" that precedes "cmd.exe" (#1396)
       and { "cmd.exe", "/d", "/e:off", "/f:off", "/v:off", "/c" }

--- a/lua/fzf-lua/init.lua
+++ b/lua/fzf-lua/init.lua
@@ -16,9 +16,6 @@ do
   vim.g.fzf_lua_directory = path.normalize(path.parent(currFile))
   vim.g.fzf_lua_root = path.parent(path.parent(vim.g.fzf_lua_directory))
 
-  -- Manually source the vimL script containing ':FzfLua' cmd
-  -- does nothing if already loaded due to `vim.g.loaded_fzf_lua`
-  source_vimL({ vim.g.fzf_lua_root, "plugin", "fzf-lua.vim" })
   -- Autoload scipts dynamically loaded on `vim.fn[fzf_lua#...]` call
   -- `vim.fn.exists("*fzf_lua#...")` will return 0 unless we manuall source
   source_vimL({ vim.g.fzf_lua_root, "autoload", "fzf_lua.vim" })

--- a/lua/fzf-lua/previewer/builtin.lua
+++ b/lua/fzf-lua/previewer/builtin.lua
@@ -678,7 +678,7 @@ function Previewer.buffer_or_file:populate_terminal_cmd(tmpbuf, cmd, entry)
     -- must be modifiable or 'termopen' fails
     vim.bo[tmpbuf].modifiable = true
     vim.api.nvim_buf_call(tmpbuf, function()
-      self._job_id = vim.fn.termopen(cmd, {
+      self._job_id = utils.termopen(cmd, {
         cwd = self.opts.cwd,
         on_exit = function()
           -- run post only after terminal job finished

--- a/lua/fzf-lua/providers/colorschemes.lua
+++ b/lua/fzf-lua/providers/colorschemes.lua
@@ -7,7 +7,7 @@ local actions = require "fzf-lua.actions"
 
 -- For AsyncDownloadManager
 local Object = require "fzf-lua.class"
-local uv = vim.loop
+local uv = vim.uv or vim.loop
 
 local function get_current_colorscheme()
   if vim.g.colors_name then

--- a/lua/fzf-lua/providers/lsp.lua
+++ b/lua/fzf-lua/providers/lsp.lua
@@ -507,12 +507,12 @@ local function gen_lsp_contents(opts)
         end
       end
       if utils.tbl_isempty(results) then
-        if not opts.fn_reload and not opts.silent then
-          utils.info(string.format("No %s found", string.lower(lsp_handler.label)))
-        else
+        if opts.fn_reload then
           -- return an empty set or the results wouldn't be
           -- cleared on live_workspace_symbols (#468)
           opts.__contents = {}
+        elseif not opts.silent then
+          utils.info(string.format("No %s found", string.lower(lsp_handler.label)))
         end
       elseif not (opts.jump_to_single_result and #results == 1) then
         -- LSP request was synchronous but we still asyncify the fzf feeding
@@ -899,10 +899,7 @@ end
 -- TODO: not needed anymore, it seems that `vim.lsp.buf.code_action` still
 -- uses the old `vim.lsp.diagnostic` API, we will do the same until neovim
 -- stops using this API
---[[ local function get_line_diagnostics(_)
-  if not vim.diagnostic then
-    return vim.lsp.diagnostic.get_line_diagnostics()
-  end
+local get_line_diagnostics = utils.__HAS_NVIM_011 and function(_)
   local diag = vim.diagnostic.get(core.CTX().bufnr, { lnum = vim.api.nvim_win_get_cursor(0)[1] - 1 })
   return diag and diag[1]
       and { {
@@ -926,7 +923,7 @@ end
       } }
       -- Must return an empty table or some LSP servers fail (#707)
       or {}
-end ]]
+end or vim.lsp.diagnostic.get_line_diagnostics
 
 M.code_actions = function(opts)
   opts = normalize_lsp_opts(opts, "lsp.code_actions")
@@ -958,7 +955,7 @@ M.code_actions = function(opts)
         -- Neovim still uses `vim.lsp.diagnostic` API in "nvim/runtime/lua/vim/lsp/buf.lua"
         -- continue to use it until proven otherwise, this also fixes #707 as diagnostics
         -- must not be nil or some LSP servers will fail (e.g. ruff_lsp, rust_analyzer)
-        diagnostics = vim.lsp.diagnostic.get_line_diagnostics(core.CTX().bufnr) or {}
+        diagnostics = get_line_diagnostics(core.CTX().bufnr) or {}
       }
       return params
     end

--- a/lua/fzf-lua/shell.lua
+++ b/lua/fzf-lua/shell.lua
@@ -1,6 +1,6 @@
 -- modified version of:
 -- https://github.com/vijaymarupudi/nvim-fzf/blob/master/lua/fzf/actions.lua
-local uv = vim.loop
+local uv = vim.uv or vim.loop
 local utils = require "fzf-lua.utils"
 local path = require "fzf-lua.path"
 local libuv = require "fzf-lua.libuv"

--- a/lua/fzf-lua/shell_helper.lua
+++ b/lua/fzf-lua/shell_helper.lua
@@ -1,6 +1,6 @@
 -- modified version of:
 -- https://github.com/vijaymarupudi/nvim-fzf/blob/master/action_helper.lua
-local uv = vim.loop
+local uv = vim.uv or vim.loop
 
 local _is_win = vim.fn.has("win32") == 1 or vim.fn.has("win64") == 1
 

--- a/lua/fzf-lua/utils.lua
+++ b/lua/fzf-lua/utils.lua
@@ -1289,4 +1289,15 @@ function M.jump_to_location(location, offset_encoding, reuse_win)
   end
 end
 
+--- Wrapper around vim.fn.termopen which was deprecated in v0.11
+function M.termopen(cmd, opts)
+  if M.__HAS_NVIM_011 then
+    opts = opts or {}
+    opts.term = true
+    return vim.fn.jobstart(cmd, opts)
+  else
+    return vim.fn.termopen(cmd, opts)
+  end
+end
+
 return M


### PR DESCRIPTION
* legacy `opts.preview_window` -> `fzf_opts.--preview_window`
* `vim.fn.termopen` -> `vim.fn.jobstart` + `{ term = true }`
* `vim.loop` -> `vim.uv`
* `vim.lsp.diagnostics.get_line_diagnostics` -> `vim.lsp.diagnostic.get`
* remove term workaround 9a755f225bc6 (fixed now)
* `opts.silent` when `reload` fallback to `resume`
