### PR TITLE
feat(profiles): added `hide` (improved resume, #1686)

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,15 +145,17 @@ Alternatively, resuming work on a specific picker:
 > By default pressing esc or ctrl-c terminates the fzf process,
 > as such resume is not perfect and is limited to resuming the
 > picker/query and sometimes additional parameters such as regex
-> in grep, etc, for a more "complete" resume press alt-esc to
-> hide the fzf process instead, this will keep the fzf process
-> running in the background and thus will restore the process
-> entirely including cursor position and selection.
+> in grep, etc, for a more complete resume use the "hide" profile,
+> this will keep the fzf process running in the background allowing
+> `:FzfLua resume` to restore the picker state entirely, including
+> cursor position and selection.
 > To configure hiding by default:
 > ```lua
-> require("fzf-lua").setup({ keymap = { builtin = { true, ["<Esc>"] = "hide" } } })
+> require("fzf-lua").setup({
+>   "hide",
+>   -- your other settings here 
+> })
 > ```
-
 
 **LIST OF AVAILABLE COMMANDS BELOW** 👇
 
@@ -1077,10 +1079,6 @@ previewers = {
     winopts           = { height = 0.55, width = 0.30, },
     -- uncomment to ignore colorschemes names (lua patterns)
     -- ignore_patterns   = { "^delek$", "^blue$" },
-    -- uncomment to execute a callback on preview|close
-    -- e.g. a call to reset statusline highlights
-    -- cb_preview        = function() ... end,
-    -- cb_exit           = function() ... end,
   },
   awesome_colorschemes = {
     prompt            = 'Colorschemes❯ ',
@@ -1099,9 +1097,6 @@ previewers = {
       ["ctrl-r"]  = { fn = actions.cs_update, reload = true },
       ["ctrl-x"]  = { fn = actions.cs_delete, reload = true },
     },
-    -- uncomment to execute a callback on preview|close
-    -- cb_preview        = function() ... end,
-    -- cb_exit           = function() ... end,
   },
   keymaps = {
     prompt            = "Keymaps> ",
@@ -1360,6 +1355,7 @@ require('fzf-lua').setup({'fzf-vim'})
 | `borderless-full` | borderless with description in window title (instead of prompt)                                     |
 | `border-fused`    | single border around both fzf and the previewer                                                     |
 | `ivy`             | UI at bottom, similar to telescope's ivy layout                                                     |
+| `hide`            | send fzf process to background instead of termination                                               |
 
 </details>
 

--- a/lua/fzf-lua/actions.lua
+++ b/lua/fzf-lua/actions.lua
@@ -696,7 +696,8 @@ M.git_yank_commit = function(selected, opts)
   -- copy to the yank register regardless
   vim.fn.setreg(reg, commit_hash)
   vim.fn.setreg([[0]], commit_hash)
-  utils.info(string.format("commit hash %s copied to register %s, use 'p' to paste.", commit_hash, reg))
+  utils.info(string.format("commit hash %s copied to register %s, use 'p' to paste.",
+    commit_hash, reg))
 end
 
 M.git_checkout = function(selected, opts)

--- a/lua/fzf-lua/config.lua
+++ b/lua/fzf-lua/config.lua
@@ -841,6 +841,10 @@ function M.normalize_opts(opts, globals, __resume_key)
     end
   end
 
+  if type(opts.enrich) == "function" then
+    opts = opts.enrich(opts)
+  end
+
   -- mark as normalized
   opts._normalized = true
 

--- a/lua/fzf-lua/defaults.lua
+++ b/lua/fzf-lua/defaults.lua
@@ -445,7 +445,7 @@ M.defaults.git                  = {
     prompt     = "Branches> ",
     cmd        = "git branch --all --color",
     preview    = "git log --graph --pretty=oneline --abbrev-commit --color {1}",
-    remotes     = "local",
+    remotes    = "local",
     actions    = {
       ["enter"]  = actions.git_switch,
       ["ctrl-x"] = { fn = actions.git_branch_del, reload = true },

--- a/lua/fzf-lua/profiles/README.md
+++ b/lua/fzf-lua/profiles/README.md
@@ -36,6 +36,7 @@ require("fzf-lua").setup({ { "ivy", "hide" } })
 | `borderless-full`  | borderless with description in window title (instead of prompt) |
 | `border-fused`     | single border around both fzf and the previewer |
 | `ivy`              | UI at bottom, similar to telescope's ivy layout |
+| `hide`            | send fzf process to background instead of termination |
 
 
 **Custom user settings which make sense and aren't mere duplications with minimal modifications

--- a/lua/fzf-lua/profiles/hide.lua
+++ b/lua/fzf-lua/profiles/hide.lua
@@ -1,0 +1,57 @@
+local uv = vim.uv or vim.loop
+local fzf = require("fzf-lua")
+return {
+  desc     = "hide interface instead of abort",
+  keymap   = { builtin = { true, ["<M-Esc>"] = "abort" } },
+  defaults = {
+    enrich = function(opts)
+      if opts._is_fzf_tmux then
+        fzf.utils.warn("'hide' profile cannot work with tmux, ignoring.")
+        return opts
+      end
+      opts.actions = opts.actions or {}
+      opts.keymap = opts.keymap or {}
+      opts.keymap.builtin = opts.keymap.builtin or {}
+      -- `execute-silent` actions are bugged with skim
+      if fzf.utils.has(opts, "sk") then
+        opts.actions["esc"] = false
+        opts.keymap.builtin["<Esc>"] = "hide"
+        return opts
+      end
+      -- While we can use `keymap.builtin.<esc>` (to hide) this is better
+      -- as it captures the query when execute-silent action is called as
+      -- we add "{q}" as the first field index similar to `--print-query`
+      local histfile = opts.fzf_opts and opts.fzf_opts["--history"]
+      opts.actions["esc"] = { fn = fzf.actions.dummy_abort, desc = "hide" }
+      opts.actions = vim.tbl_map(function(act)
+        act = type(act) == "function" and { fn = act } or act
+        act = type(act) == "table" and type(act[1]) == "function"
+            and { fn = act[1], noclose = true } or act
+        assert(type(act) == "table" and type(act.fn) == "function" or not act)
+        if type(act) == "table" and
+            not act.exec_silent and not act.reload and not act.noclose
+        then
+          local fn = act.fn
+          act.exec_silent = true
+          act.desc = act.desc or fzf.config.get_action_helpstr(fn)
+          act.fn = function(s, o)
+            fzf.hide()
+            fn(s, o)
+            -- As the process never terminates fzf history is never written
+            -- manually append to the fzf history file if needed
+            if histfile and type(o.last_query) == "string" and #o.last_query > 0 then
+              local fd = uv.fs_open(histfile, "a", -1)
+              if fd then
+                uv.fs_write(fd, o.last_query .. "\n", nil, function(_)
+                  uv.fs_close(fd)
+                end)
+              end
+            end
+          end
+        end
+        return act
+      end, opts.actions)
+      return opts
+    end,
+  },
+}

--- a/lua/fzf-lua/providers/module.lua
+++ b/lua/fzf-lua/providers/module.lua
@@ -57,6 +57,11 @@ M.profiles = function(opts)
   opts = config.normalize_opts(opts, "profiles")
   if not opts then return end
 
+  if opts.load then
+    utils.load_profiles(opts.load)
+    return
+  end
+
   local dirs = {
     path.join({ vim.g.fzf_lua_directory, "profiles" })
   }

--- a/lua/fzf-lua/providers/ui_select.lua
+++ b/lua/fzf-lua/providers/ui_select.lua
@@ -108,7 +108,6 @@ M.ui_select = function(items, ui_opts, on_choice)
   })
 
   opts.fn_selected = function(selected, o)
-
     local function exec_choice()
       if not selected then
         -- with `actions.dummy_abort` this doesn't get called anymore
@@ -163,7 +162,8 @@ M.ui_select = function(items, ui_opts, on_choice)
     local previewer = _OPTS_ONCE.previewer
     _OPTS_ONCE.previewer = nil -- can't copy the previewer object
     opts = vim.tbl_deep_extend(opts_merge_strategy, _OPTS_ONCE, opts)
-    opts.actions = { ["enter"] = opts.actions.enter }
+    opts.actions = vim.tbl_deep_extend("force", opts.actions or {},
+      { ["enter"] = opts.actions.enter })
     opts.previewer = previewer
     -- Callback to set the coroutine so we know if the interface
     -- was opened or not (e.g. when no code actions are present)

--- a/lua/fzf-lua/shell.lua
+++ b/lua/fzf-lua/shell.lua
@@ -12,7 +12,7 @@ local M = {}
 -- provider are 2 (`live_grep` with `multiprocess=false`)
 -- and 4 (`git_status` with preview and 3 reload binds)
 -- we can always increase if we need more
-local _MAX_LEN = vim.g.fzf_lua_shell_maxlen or 10
+local _MAX_LEN = 50
 local _index = 0
 local _registry = {}
 local _protected = {}

--- a/lua/fzf-lua/utils.lua
+++ b/lua/fzf-lua/utils.lua
@@ -820,6 +820,10 @@ function M.CTX()
   return loadstring("return require'fzf-lua'.core.CTX()")()
 end
 
+function M.__CTX()
+  return loadstring("return require'fzf-lua'.core.__CTX")()
+end
+
 function M.resume_get(what, opts)
   local f = loadstring("return require'fzf-lua'.config.resume_get")()
   return f(what, opts)
@@ -841,7 +845,7 @@ end
 
 ---@param fname string
 ---@param name string|nil
----@param silent boolean|number
+---@param silent boolean|integer
 function M.load_profile_fname(fname, name, silent)
   local profile = name or vim.fn.fnamemodify(fname, ":t:r") or "<unknown>"
   local ok, res = pcall(dofile, fname)
@@ -858,6 +862,19 @@ function M.load_profile_fname(fname, name, silent)
     M.warn(string.format("Unable to load profile '%s': %s", profile, res:match("[^\n]+")))
   elseif type(res) ~= "table" then
     M.warn(string.format("Unable to load profile '%s': wrong type %s", profile, type(res)))
+  end
+end
+
+function M.load_profiles(profiles)
+  local serpent = require("fzf-lua.lib.serpent")
+  profiles = type(profiles) == "table"
+      and serpent.line(profiles, { comment = false, sortkeys = false })
+      or type(profiles) == "string" and string.format("'%s'", profiles)
+      or nil
+  if type(profiles) == "string" then
+    loadstring(string.format(
+      "require'fzf-lua'.setup(require'fzf-lua'.load_profiles(%s, false))",
+      profiles))()
   end
 end
 


### PR DESCRIPTION
The profile changes the default binds to hide the fzf-lua window instead of aborting it, therefore keeping cursor position, selection, etc.

Note that this also continues long running operations in the background so be mindful of sending fzf to background on a large mono repo, can still be aborted with `ctrl-c` or `alt-esc`.

Enable with:
```lua
-- Set as base profile
:lua require("fzf-lua").setup({"hide"})
-- More than one profile
:lua require("fzf-lua").setup({"border-fused","hide"})
-- Or with `profiles`:
:FzfLua profiles load=hide
-- More than one profile
:FzfLua profiles load={"border-fused","hide"}
```