### PR TITLE
fix(hide): better solution for storing last query on esc

### DIFF
--- a/lua/fzf-lua/win.lua
+++ b/lua/fzf-lua/win.lua
@@ -1186,7 +1186,6 @@ function FzfWin.hide()
     self:close_preview(true)
     self._hidden_had_preview = true
   end
-  self:store_last_query()
   self:detach_fzf_buf()
   self:close(nil, true)
   -- Save self as `:close()` nullifies it


### PR DESCRIPTION
This commit partially reverts 85fa30e.

Extracting last query from the prompt line is problematic, especially with new fzf features such as `--info-command` and `--input-border`.

Instead we call hide instantly (keeping the perf from the old commit) and send <esc> to the terminal to execute the esc action and store the last query using `{q}`.

Closes #1731

Ty @phanen for the `chan_send` idea, worked great with `\x1b` (escape).