### PR TITLE
fix: clean up dangling socket and tempfile for `fzf_live`

### DIFF
--- a/lua/fzf-lua/shell_helper.lua
+++ b/lua/fzf-lua/shell_helper.lua
@@ -73,6 +73,16 @@ local function rpc_nvim_exec_lua(opts)
     vim.fn.chanclose(chan_id)
   end)
 
+  -- Avoid dangling temp dir on premature process kills (live grep)
+  -- see more complete note in spawn.lua
+  local tmpdir = vim.fn.fnamemodify(vim.fn.tempname(), ":h")
+  if tmpdir and #tmpdir > 0 then
+    vim.fn.delete(tmpdir, "rf")
+  end
+  if vim.v.servername and #vim.v.servername > 0 then
+    pcall(vim.fn.serverstop, vim.v.servername)
+  end
+
   if not success or opts.debug then
     io.stderr:write(("[DEBUG] debug = %s\n"):format(opts.debug))
     io.stderr:write(("[DEBUG] function ID = %d\n"):format(opts.fnc_id))


### PR DESCRIPTION
Use the following cmd on a large monorepo, typing quickly to ensure fzf kill process before it finished.
```vim
lua require('fzf-lua').fzf_live(function(q) return 'rg ' .. q end)
```

Then notes there're some dangling sockets and tempfiles
```sh
watch -n.1 ls -lh /run/user/1000/nvim*
watch -n.1 ls -lh /tmp/nvim.$USER/
```

## Related
* https://github.com/ibhagwan/fzf-lua/issues/329
* https://github.com/neovim/neovim/issues/30123