### PR TITLE
fix: clean scratch buffer introduced in #1721

### DIFF
--- a/lua/fzf-lua/utils.lua
+++ b/lua/fzf-lua/utils.lua
@@ -1280,6 +1280,14 @@ function M.create_user_command_callback(provider, arg, altmap)
   end
 end
 
+-- setmetatable wrapper, also enable `__gc`
+function M.setmetatable__gc(t, mt)
+  local prox = newproxy(true)
+  getmetatable(prox).__gc = function() mt.__gc(t) end
+  t[prox] = true
+  return setmetatable(t, mt)
+end
+
 --- Checks if treesitter parser for language is installed
 ---@param lang string
 function M.has_ts_parser(lang)

--- a/lua/fzf-lua/win.lua
+++ b/lua/fzf-lua/win.lua
@@ -633,7 +633,16 @@ function FzfWin:new(o)
   end
   o = o or {}
   self._o = o
-  self = setmetatable({}, { __index = self })
+  self = utils.setmetatable__gc({}, {
+    __index = self,
+    __gc = function(s)
+      vim.schedule(function()
+        if s._previewer and s._previewer.clear_cached_buffers then
+          s._previewer:clear_cached_buffers()
+        end
+      end)
+    end
+  })
   self.hls = o.hls
   self.actions = o.actions
   self.fullscreen = o.winopts.fullscreen


### PR DESCRIPTION
After #1721, buffer cache will not be clean after `hide`.

Old scratch buffer need a way to be delete when switching to a different picker.
