### PR TITLE
fix: spell_apply with no value selected

### DIFF
--- a/lua/fzf-lua/actions.lua
+++ b/lua/fzf-lua/actions.lua
@@ -551,6 +551,7 @@ for _, fname in ipairs({ "edit", "split", "vsplit", "tabedit" }) do
 end
 
 M.spell_apply = function(selected)
+  if not selected[1] then return false end
   local word = selected[1]
   vim.cmd("normal! ciw" .. word)
   vim.cmd("stopinsert")


### PR DESCRIPTION
Without this patch, spell_apply will throw an exception if no value is selected as it attempts to concatenate a nil value with a string.

Previously: 9226c5a2291ef623ef157e0e1ffea034ffc8b8de