### PR TITLE
fix: don't reference `win._previewer` in callback to make gc work

### DIFF
--- a/lua/fzf-lua/previewer/builtin.lua
+++ b/lua/fzf-lua/previewer/builtin.lua
@@ -260,8 +260,10 @@ function Previewer.base:set_preview_buf(newbuf, min_winopts)
   -- Something went terribly wrong
   assert(curbuf ~= newbuf)
   utils.win_set_buf_noautocmd(self.win.preview_winid, newbuf)
+  -- to make gc work, don't reference `win._previewer` in a callback
+  local winid = self.win.fzf_winid
   vim.keymap.set("", "i", function()
-    vim.api.nvim_set_current_win(self.win.fzf_winid)
+    vim.api.nvim_set_current_win(winid)
     vim.cmd("startinsert")
   end, { buffer = newbuf })
   self.preview_bufnr = newbuf


### PR DESCRIPTION
Since de199f73a54a, garbage collection (0c384eb93f13) stops work for builtin previewer.

Fix by reference `win._previewer` outside, rather than in callback.

Minimal repro:
```lua
local ref
do
  local b = require('fzf-lua.utils').setmetatable__gc(
    { a = '4 gc done' },
    { __gc = function(self) print(self.a) end }
  )
  local tmp_func = function() print(b.a) end
  ref = tmp_func
end
-- ref = nil
collectgarbage('collect')
```

gc won't run in this case unless `ref` in explicitly set to nil somewhere, but in our case it's referenced by neovim's api internally...