### PR TITLE
chore: update mini.sh

### DIFF
--- a/scripts/init.lua
+++ b/scripts/init.lua
@@ -1,7 +1,7 @@
 -- add temp path from scripts/mini.sh in case this is running locally
 local tempdir = vim.trim(vim.fn.system([[sh -c "dirname $(mktemp -u)"]]))
 local packpath = os.getenv("PACKPATH") or tempdir .. "/fzf-lua.tmp/nvim/site"
-vim.cmd("set packpath=" .. packpath)
+vim.cmd("set packpath+=" .. packpath)
 
 vim.o.termguicolors = true
 

--- a/scripts/mini.sh
+++ b/scripts/mini.sh
@@ -8,7 +8,7 @@ trap 'echo "EXIT detected with exit status $?"' EXIT
 TEMPDIR=$(dirname $(mktemp -u))
 BASEDIR=$(cd "$(dirname "$0")" ; pwd -P)
 
-nvim_bin=${NVIM:-nvim}
+nvim_bin=${NVIM_BIN:-nvim}
 plug_name=fzf-lua
 plug_dir="${BASEDIR}/../../${plug_name}"
 tmp_dir="${TEMPDIR}/${plug_name}.tmp"


### PR DESCRIPTION
* `$NVIM` is exported to nvim builtin terminal by default on neovim +v0.8.0
* netrw will print errmsg on nightly (https://github.com/neovim/neovim/blob/e08e3d15f66db3fba9f164f0c18b71d72ffb4877/runtime/plugin/netrwPlugin.vim#L7)
```
Error detected while processing /usr/share/nvim/runtime/plugin/netrwPlugin.vim:
line    7:
E919: Directory not found in 'packpath': "pack/*/opt/netrw"
```
