### PR TITLE
fix(grep): allow matching query on line when query contains @

### DIFF
--- a/lua/fzf-lua/utils.lua
+++ b/lua/fzf-lua/utils.lua
@@ -183,7 +183,9 @@ end
 function M.regex_to_magic(str)
   -- Convert regex to "very magic" pattern, basically a regex
   -- with special meaning for "=&<>", `:help /magic`
-  return [[\v]] .. str:gsub("[=&<>]", function(x) return [[\]] .. x end)
+  return [[\v]] .. str:gsub("[=&@<>]", function(x)
+    return "\\" .. x
+  end)
 end
 
 function M.ctag_to_magic(str)


### PR DESCRIPTION
## Problem

Whenever my `grep` search contained a `@`, I got spammed with a bunch of warning messages on each keystroke. Upon some investigation, I found that a `vim.regex` call made to get the highlight for the current matched line was failing since `@` is a special character for `vim.regex`.

## Solution

Escape the `@` characters with a `\` before it. This removes the warning messages and adds the highlight matching the query. I tried to limit this to the `vim.regex` call since I noticed there's some custom logic for `--fixed-strings` that is for escaping regex characters to match them explicitly.
