### PR TITLE
fix(typo): replace `darcula` with `dracula`

### DIFF
--- a/lua/fzf-lua/data/colorschemes.json
+++ b/lua/fzf-lua/data/colorschemes.json
@@ -190,7 +190,7 @@
     "url": "Mofiqul/vscode.nvim",
     "colorschemes": ["vscode"]
   },
-  "darcula.nvim": {
+  "dracula.nvim": {
     "disp_name": "Dracula",
     "url": "Mofiqul/dracula.nvim",
     "colorschemes": ["dracula"]
@@ -464,11 +464,11 @@
         "lua": "require('starry').setup({style={name='moonlight'}}); vim.cmd.colorscheme('starry')"
       },
       {
-        "disp_name": "Starry Darcula",
+        "disp_name": "Starry Dracula",
         "lua": "require('starry').setup({style={name='dracula'}}); vim.cmd.colorscheme('starry')"
       },
       {
-        "disp_name": "Starry Darcula Blood",
+        "disp_name": "Starry Dracula Blood",
         "lua": "require('starry').setup({style={name='dracula_blood'}}); vim.cmd.colorscheme('starry')"
       },
       {


### PR DESCRIPTION
Was looking through the `colorschemes.json` file and noticed these instances of `darcula`. I'm assuming this is just a typo.
So I just did a simple find and replace.