### PR TITLE
Revert "fix: set TMPDIR for child to avoid lots of logging"

### DIFF
--- a/lua/fzf-lua/libuv.lua
+++ b/lua/fzf-lua/libuv.lua
@@ -666,9 +666,6 @@ M.expand = function(s)
   return vim.fn.expand(s)
 end
 
-
-local TMPDIR = vim.fn.fnamemodify(vim.fn.tempname(), ":h:h:h")
-
 ---@param opts string
 ---@param fn_transform string?
 ---@param fn_preprocess string?
@@ -683,17 +680,12 @@ M.wrap_spawn_stdio = function(opts, fn_transform, fn_preprocess, fn_postprocess)
         _is_win and [[set VIMRUNTIME=%s& ]] or "VIMRUNTIME=%s ",
         _is_win and vim.fs.normalize(vim.env.VIMRUNTIME) or M.shellescape(vim.env.VIMRUNTIME)
       )
-  local tmp_dir = os.getenv("TMPDIR") and "" or string.format(
-    _is_win and [[set TMPDIR=%s& ]] or "TMPDIR=%s ",
-    _is_win and vim.fs.normalize(TMPDIR) or M.shellescape(TMPDIR))
-
   local lua_cmd = ("lua %sloadfile([[%s]])().spawn_stdio(%s,%s,%s,%s)"):format(
     _has_nvim_010 and "vim.g.did_load_filetypes=1; " or "",
     vim.fn.fnamemodify(_is_win and vim.fs.normalize(__FILE__) or __FILE__, ":h") .. "/spawn.lua",
     opts, fn_transform, fn_preprocess, fn_postprocess
   )
-  local cmd_str = ("%s%s%s -n --headless -u NONE -i NONE --cmd %s"):format(
-    tmp_dir,
+  local cmd_str = ("%s%s -n --headless -u NONE -i NONE --cmd %s"):format(
     nvim_runtime,
     M.shellescape(_is_win and vim.fs.normalize(nvim_bin) or nvim_bin),
     M.shellescape(lua_cmd)

--- a/lua/fzf-lua/shell.lua
+++ b/lua/fzf-lua/shell.lua
@@ -46,8 +46,6 @@ end
 -- NOT USED ANYMORE, we use `vim.g.fzf_lua_server` instead
 -- local action_server_address = nil
 
-local TMPDIR = vim.fn.fnamemodify(vim.fn.tempname(), ":h:h:h")
-
 function M.raw_async_action(fn, fzf_field_expression, debug)
   if not fzf_field_expression then
     fzf_field_expression = "{+}"
@@ -92,10 +90,6 @@ function M.raw_async_action(fn, fzf_field_expression, debug)
     utils._if_win(path.normalize(vim.env.VIMRUNTIME),
       libuv.shellescape(vim.env.VIMRUNTIME)))
 
-  local tmp_dir = os.getenv("TMPDIR") and "" or string.format(
-    utils._if_win([[set TMPDIR=%s& ]], "TMPDIR=%s "),
-    utils._if_win(path.normalize(TMPDIR), libuv.shellescape(TMPDIR)))
-
   local call_args = ("fzf_lua_server=[[%s]], fnc_id=%d %s"):format(
     vim.g.fzf_lua_server, id, debug and ", debug=true" or "")
 
@@ -104,8 +98,7 @@ function M.raw_async_action(fn, fzf_field_expression, debug)
   -- special shell chars ('+', '-', etc), examples where this can
   -- happen are the `git status` command and git branches from diff
   -- worktrees (#600)
-  local action_cmd = ("%s%s%s -n --headless -u NONE -i NONE --cmd %s -- %s"):format(
-    tmp_dir,
+  local action_cmd = ("%s%s -n --headless -u NONE -i NONE --cmd %s -- %s"):format(
     nvim_runtime,
     libuv.shellescape(path.normalize(nvim_bin)),
     libuv.shellescape(("lua %sloadfile([[%s]])().rpc_nvim_exec_lua({%s})"):format(


### PR DESCRIPTION
Revert https://github.com/ibhagwan/fzf-lua/pull/1743 for two reason:
* This is no longer a problem for nightly (after https://github.com/mrowegawd/neovim/commit/3768fabed0155a04be2937a5f8996c338aedc37b). And this won't happened on any stable nvim.
* 922eff893faf3b32a055298a452eeb08a8a5be00 cause a new issue, it can spam log in another way:
```
ERR 2025-02-08T19:14:51.741 nvim.69567.0/c vim_gettempdir:3494: tempdir disappeared (antivirus or broken cleanup job?): /tmp/nvim.phan/vGwvP7/
ERR 2025-02-08T19:14:51.918 nvim.69567.0/c vim_gettempdir:3494: tempdir disappeared (antivirus or broken cleanup job?): /tmp/nvim.phan/ECnFme/
ERR 2025-02-08T19:14:52.068 nvim.69567.0/c vim_gettempdir:3494: tempdir disappeared (antivirus or broken cleanup job?): /tmp/nvim.phan/D59oYM/
```

Reproduce by
* `tail -f .local/state/nvim/log`
* then `./scripts/mini.sh`, `:FzfLua live_grep multiprocess=true`, then type some chars:

Sorry I didn't spot this before because I only tested with `live_grep_native` at that time.
