### PR TITLE
feat: align numbers in ui-select function

### DIFF
--- a/lua/fzf-lua/providers/ui_select.lua
+++ b/lua/fzf-lua/providers/ui_select.lua
@@ -76,9 +76,11 @@ M.ui_select = function(items, ui_opts, on_choice)
     title = "Mark `mymainmenu` as defined global."
   } } ]]
   local entries = {}
+  local num_width = math.ceil(math.log10(#items))
+  local num_format_str = "%" .. num_width .. "d"
   for i, e in ipairs(items) do
     table.insert(entries,
-      ("%s. %s"):format(utils.ansi_codes.magenta(tostring(i)),
+      ("%s. %s"):format(utils.ansi_codes.magenta(num_format_str:format(i)),
         ui_opts.format_item and ui_opts.format_item(e) or tostring(e)))
   end
 


### PR DESCRIPTION
Align the numbers in the ui-select function for a cleaner visual effect.

Before:

![image](https://github.com/user-attachments/assets/042fda7c-651d-4f6e-9680-8256f22013a1)


After:

![image](https://github.com/user-attachments/assets/83add866-b08a-4768-9c68-f3149627bace)


Test file:

```lua
require('fzf-lua.providers.ui_select').register()
vim.ui.select(
  {
    'Acai',
    'Apple',
    'Apricot',
    'Asian Pear',
    'Avocado',
    'Banana',
    'Blackberry',
    'Blood Orange',
    'Blueberry',
    'Boysenberry',
    'Breadfruit',
    'Cactus Pear',
    'Cantaloupe',
    'Carambola',
    'Cherimoya',
    'Cherry',
    'Clementine',
    'Coconut',
    'Cranberry',
    'Custard Apple',
    'Date',
    'Dragonfruit',
    'Durian',
    'Elderberry',
    'Fig',
    'Gooseberry',
    'Grapefruit',
    'Grapes',
    'Guava',
    'Honeydew',
    'Jackfruit',
    'Jujube',
    'Kiwi',
    'Kumquat',
    'Lemon',
    'Lime',
    'Lingonberry',
    'Loquat',
    'Longan',
    'Lychee',
    'Mandarin',
    'Mango',
    'Mangosteen',
    'Marionberry',
    'Mulberry',
    'Nectarine',
    'Olive',
    'Orange',
    'Papaya',
    'Passion Fruit',
    'Peach',
    'Pear',
    'Persimmon',
    'Pineapple',
    'Plantain',
    'Plum',
    'Pomegranate',
    'Pomelo',
    'Prickly Pear',
    'Prune',
    'Quince',
    'Raisin',
    'Rambutan',
    'Raspberry',
    'Red Banana',
    'Red Currant',
    'Sapodilla',
    'Sapote',
    'Soursop',
    'Star Apple',
    'Star Fruit',
    'Strawberry',
    'Sugar Apple',
    'Tamarind',
    'Tangerine',
    'Tomato',
    'Ugli Fruit',
    'Watermelon',
    'White Currant',
    'White Sapote',
    'Yellow Passion Fruit',
    'Yuzu',
    'Acerola',
    'Ackee',
    'African Cherry Orange',
    'Ambarella',
    'Araza',
    'Babaco',
    'Bael',
    'Barbados Cherry',
    'Barberry',
    'Bearberry',
    'Bilberry',
    'Black Sapote',
    'Black Mulberry',
    'Brazilian Guava',
    "Buddha's Hand",
    'Calamansi',
    'Canistel',
    'Cape Gooseberry',
    'Capulin Cherry',
    'Cassabanana',
    'Ceylon Gooseberry',
    'Chayote',
    'Cloudberry',
    'Cocona',
  },
  { prompt = "I'd like to eat:" },
  function() end
)
```