### PR TITLE
fix: selected is nil if its number is padded

### DIFF
--- a/lua/fzf-lua/providers/ui_select.lua
+++ b/lua/fzf-lua/providers/ui_select.lua
@@ -48,7 +48,7 @@ end
 
 M.accept_item = function(selected, o)
   if #selected == 0 then return end
-  local idx = selected and tonumber(selected[1]:match("^(%d+)%.")) or nil
+  local idx = selected and tonumber(selected[1]:match("^%s*(%d+)%.")) or nil
   o._on_choice(idx and o._items[idx] or nil, idx)
   o._on_choice_called = true
 end


### PR DESCRIPTION
Selected is nil if the number is padded in the ui-select function.

To reproduce: run `:so` in the test file:

```lua
require('fzf-lua.providers.ui_select').register()
vim.ui.select({
  'Acai',
  'Apple',
  'Apricot',
  'Asian Pear',
  'Avocado',
  'Banana',
  'Blackberry',
  'Blood Orange',
  'Blueberry',
  'Boysenberry',
  'Breadfruit',
  'Cactus Pear',
  'Cantaloupe',
  'Carambola',
  'Cherimoya',
  'Cherry',
  'Clementine',
  'Coconut',
  'Cranberry',
  'Custard Apple',
  'Date',
  'Dragonfruit',
  'Durian',
  'Elderberry',
  'Fig',
  'Gooseberry',
  'Grapefruit',
  'Grapes',
  'Guava',
  'Honeydew',
  'Jackfruit',
  'Jujube',
  'Kiwi',
  'Kumquat',
  'Lemon',
  'Lime',
  'Lingonberry',
  'Loquat',
  'Longan',
  'Lychee',
  'Mandarin',
  'Mango',
  'Mangosteen',
  'Marionberry',
  'Mulberry',
  'Nectarine',
  'Olive',
  'Orange',
  'Papaya',
  'Passion Fruit',
  'Peach',
  'Pear',
  'Persimmon',
  'Pineapple',
  'Plantain',
  'Plum',
  'Pomegranate',
  'Pomelo',
  'Prickly Pear',
  'Prune',
  'Quince',
  'Raisin',
  'Rambutan',
  'Raspberry',
  'Red Banana',
  'Red Currant',
  'Sapodilla',
  'Sapote',
  'Soursop',
  'Star Apple',
  'Star Fruit',
  'Strawberry',
  'Sugar Apple',
  'Tamarind',
  'Tangerine',
  'Tomato',
  'Ugli Fruit',
  'Watermelon',
  'White Currant',
  'White Sapote',
  'Yellow Passion Fruit',
  'Yuzu',
  'Acerola',
  'Ackee',
  'African Cherry Orange',
  'Ambarella',
  'Araza',
  'Babaco',
  'Bael',
  'Barbados Cherry',
  'Barberry',
  'Bearberry',
  'Bilberry',
  'Black Sapote',
  'Black Mulberry',
  'Brazilian Guava',
  "Buddha's Hand",
  'Calamansi',
  'Canistel',
  'Cape Gooseberry',
  'Capulin Cherry',
  'Cassabanana',
  'Ceylon Gooseberry',
  'Chayote',
  'Cloudberry',
  'Cocona',
}, { prompt = "I'd like to eat:" }, function(choice)
  print(choice)
end)
```

choose a option with number < 100 and see if the choice is printed out (it is not).