### PR TITLE
fix: don't send ambiguous empty string when no selected/matched

### DIFF
--- a/lua/fzf-lua/previewer/codeaction.lua
+++ b/lua/fzf-lua/previewer/codeaction.lua
@@ -245,10 +245,6 @@ end
 
 function M.builtin:populate_preview_buf(entry_str)
   if not self.win or not self.win:validate_preview() then return end
-  if entry_str == "" then
-    self:clear_preview_buf(true)
-    return
-  end
   local idx = tonumber(entry_str:match("^%s*(%d+)%."))
   assert(type(idx) == "number")
   local lines = self:preview_action_tuple(idx,


### PR DESCRIPTION
When trigger actions with no selected entry in hide profile, `selected` always will be `{ "" }`
To reproduce this with `mini.sh`:
* `require('fzf-lua').setup { "hide" }` (or just use `exec_silent = true` actions without this)
* `:FzfLua files cwd=/tmp` 
* typing random thing (ensure no entry selected)
* press enter, then `/tmp` opened in netrw

The root cause is that when use `{q} {+}`, `{+}` is expanded to an empty string if there's no selected entry.

We can use `{n}` to determine if it's really a no-selected case, and then send `{}` to actions rather than `{""}`.
