### PR TITLE
fix(codeaction): consider whitespace when getting index

### DIFF
--- a/lua/fzf-lua/previewer/codeaction.lua
+++ b/lua/fzf-lua/previewer/codeaction.lua
@@ -285,7 +285,7 @@ end
 function M.native:cmdline(o)
   o = o or {}
   local act = shell.raw_action(function(entries, _, _)
-    local idx = tonumber(entries[1]:match("^%d+%."))
+    local idx = tonumber(entries[1]:match("^%s*%d+%."))
     assert(type(idx) == "number")
     local lines = self:preview_action_tuple(idx)
     return table.concat(lines, "\r\n")


### PR DESCRIPTION
With `jdtls` there's a space before the code action index, causing the `assert` in the following line to fail.