### PR TITLE
fix(complete): fallback to user provided `opts.cwd`

### DIFF
--- a/lua/fzf-lua/complete.lua
+++ b/lua/fzf-lua/complete.lua
@@ -18,7 +18,7 @@ local function find_toplevel_cwd(maybe_cwd, postfix, orig_cwd)
   -- E5108: Error executing lua Vim:E220: Missing }.
   local ok, _ = pcall(libuv.expand, maybe_cwd)
   if not maybe_cwd or #maybe_cwd == 0 or not ok then
-    return nil, uv.cwd(), nil
+    return nil, nil, nil
   end
   if not orig_cwd then
     orig_cwd = maybe_cwd
@@ -58,12 +58,10 @@ local set_cmp_opts_path = function(opts)
     col = col + 1
     after = line:sub(col):match(match) or ""
   end
-  opts._cwd, opts.cwd, opts.query = find_toplevel_cwd(before .. after, nil, nil)
-  opts.prompt = opts._cwd
-  if not opts.prompt then
-    opts.prompt = "."
-  end
-  opts.prompt = path.add_trailing(opts.prompt)
+  local cwd
+  opts._cwd, cwd, opts.query = find_toplevel_cwd(before .. after, nil, nil)
+  opts.prompt = path.add_trailing(opts._cwd or ".")
+  opts.cwd = cwd or opts.cwd or uv.cwd()
   -- completion function rebuilds the line with the full path
   opts.complete = function(selected, o, l, _)
     -- query fuzzy matching is empty


### PR DESCRIPTION
Problem: `require("fzf-lua").complete_file { cwd = vim.fs.root(0, ".git") }` don't work.

Solution: Allow fallback to user passed `opts.cwd`, (higher priority than `uv.cwd()`)
