### PR TITLE
fix: update CTX when `unhide`

### DIFF
--- a/lua/fzf-lua/win.lua
+++ b/lua/fzf-lua/win.lua
@@ -1210,6 +1210,7 @@ end
 function FzfWin.unhide()
   local self = _self
   if not self or not self:hidden() then return end
+  self._o.__CTX = utils.CTX()
   vim.bo[self._hidden_fzf_bufnr].bufhidden = "wipe"
   self.fzf_bufnr = self._hidden_fzf_bufnr
   self._hidden_fzf_bufnr = nil


### PR DESCRIPTION
If something in `CTX` changed after picker launched and before picker died (`accept`/or pkilled), then any action may not work as expected.

In "hide" profile, a picker only die when you launch a new picker.

Reproduce with `mini.sh`:
* `:e Makefile`
* `:e README.md`
* open picker (`:FzfLua files`)
* `hide()` then `<c-^>` (or any other way make you navigate to another file, without killing the picker)
* `unhide()` and try to use picker to navigate to `README.md`. But cannot.