### PR TITLE
fix: `ctrl-g` should not change layout when use `live_grep` with `winopts.split`

### DIFF
--- a/lua/fzf-lua/win.lua
+++ b/lua/fzf-lua/win.lua
@@ -1339,7 +1339,7 @@ end
 
 function FzfWin:update_main_title(title)
   -- Can be called from fzf-tmux on ctrl-g
-  if not self.layout then return end
+  if not self.layout or self.winopts.split then return end
   self.winopts.title = title
   self._o.winopts.title = title
   self.update_win_title(self.fzf_winid, self.layout.fzf, {


### PR DESCRIPTION
`ctrl-g` in `live_grep` picker should not change layout:
```lua
require('fzf-lua').setup { winopts = { split = 'botright new' } }
```

Did a bisect, this happened after https://github.com/ibhagwan/fzf-lua/commit/d932025a62bc6644cb531e74cf2f1ef35606fd2b..
