### PR TITLE
fix(files): use POSIX compliant options for find_opts

### DIFF
--- a/README.md
+++ b/README.md
@@ -782,7 +782,7 @@ previewers = {
     -- otherwise auto-detect prioritizes `fd`:`rg`:`find`
     -- default options are controlled by 'fd|rg|find|_opts'
     -- cmd            = "rg --files",
-    find_opts         = [[-type f -not -path '*/\.git/*']],
+    find_opts         = [[-type f \! -path '*/.git/*']],
     rg_opts           = [[--color=never --hidden --files -g "!.git"]],
     fd_opts           = [[--color=never --hidden --type f --type l --exclude .git]],
     dir_opts          = [[/s/b/a:-d]],

--- a/doc/fzf-lua.txt
+++ b/doc/fzf-lua.txt
@@ -752,7 +752,7 @@ CUSTOMIZATION                                          *fzf-lua-customization*
         -- otherwise auto-detect prioritizes `fd`:`rg`:`find`
         -- default options are controlled by 'fd|rg|find|_opts'
         -- cmd            = "rg --files",
-        find_opts         = [[-type f -not -path '*/\.git/*']],
+        find_opts         = [[-type f \! -path '*/.git/*']],
         rg_opts           = [[--color=never --hidden --files -g "!.git"]],
         fd_opts           = [[--color=never --hidden --type f --type l --exclude .git]],
         dir_opts          = [[/s/b/a:-d]],

--- a/lua/fzf-lua/defaults.lua
+++ b/lua/fzf-lua/defaults.lua
@@ -346,7 +346,7 @@ M.defaults.files                = {
   _fzf_nth_devicons      = true,
   git_status_cmd         = {
     "git", "-c", "color.status=false", "--no-optional-locks", "status", "--porcelain=v1" },
-  find_opts              = [[-type f -not -path '*/\.git/*']],
+  find_opts              = [[-type f \! -path '*/.git/*']],
   rg_opts                = [[--color=never --files -g "!.git"]],
   fd_opts                = [[--color=never --type f --type l --exclude .git]],
   dir_opts               = [[/s/b/a:-d]],

--- a/lua/fzf-lua/providers/files.lua
+++ b/lua/fzf-lua/providers/files.lua
@@ -60,7 +60,7 @@ local get_files_cmd = function(opts)
         if k == "hidden" then
           is_find = true
           toggle = not opts[k]
-          v = [[-not -path '*/\.*']]
+          v = [[\! -path '*/.*']]
         end
       end
       command = utils.toggle_cmd_flag(command, v, toggle, is_find)

--- a/tests/file/ui_spec.lua
+++ b/tests/file/ui_spec.lua
@@ -131,7 +131,7 @@ T["files()"]["executable"] = new_set({ parametrize = { { "fd" }, { "rg" }, { "fi
     else
       exclude = [[{ "fd", "fdfind", "rg" }]]
       opts = [==[
-        find_opts = [[-type f -not -path '*/\.git/*' -not -path '*/doc/tags' -not -path '*/deps/*' | sort]],
+        find_opts = [[-type f \! -path '*/.git/*' \! -path '*/doc/tags' \! -path '*/deps/*' | sort]],
         dir_opts = [[/s/b/a:-d | findstr -v "\.git\\" | findstr -v "doc\\tags" | findstr -v "deps" | sort]],
         strip_cwd_prefix = true,
       ]==]


### PR DESCRIPTION
See `find(1)` man page for more details. The `!` character is escaped here to avoid it being interpreted weirdly by the shell (.e.g in bash's conditional clauses). I also remove the escaped dot character in -path argument. `find` doesn't treat `/` and `.` differently.