### PR TITLE
fix: reload before unhide buffers/tabs pickers

### DIFF
--- a/lua/fzf-lua/core.lua
+++ b/lua/fzf-lua/core.lua
@@ -299,7 +299,7 @@ M.CTX = function(opts)
   -- perhaps a min impact optimization but since only
   -- buffers/tabs use these we only include the current
   -- list of buffers when requested
-  if opts.includeBuflist and not M.__CTX.buflist then
+  if opts.force or opts.includeBuflist and not M.__CTX.buflist then
     -- also add a map for faster lookups than `utils.tbl_contains`
     -- TODO: is it really faster since we must use string keys?
     M.__CTX.bufmap = {}

--- a/lua/fzf-lua/defaults.lua
+++ b/lua/fzf-lua/defaults.lua
@@ -601,29 +601,35 @@ M.defaults.buffers              = {
   _actions              = function()
     return M.globals.actions.buffers or M.globals.actions.files
   end,
-  actions               = { ["ctrl-x"] = { fn = actions.buf_del, reload = true } },
+  actions               = {
+    ["ctrl-x"] = { fn = actions.buf_del, reload = true },
+    ["f11"] = { fn = actions.dummy_abort, reload = true },
+  },
+  _reload_bind          = "<F11>",
   _cached_hls           = { "buf_nr", "buf_flag_cur", "buf_flag_alt", "path_linenr" },
 }
 
 M.defaults.tabs                 = {
-  previewer   = M._default_previewer_fn,
-  tab_title   = "Tab",
-  tab_marker  = "<<",
-  file_icons  = 1,
-  color_icons = true,
-  _actions    = function()
+  previewer    = M._default_previewer_fn,
+  tab_title    = "Tab",
+  tab_marker   = "<<",
+  file_icons   = 1,
+  color_icons  = true,
+  _actions     = function()
     return M.globals.actions.buffers or M.globals.actions.files
   end,
-  actions     = {
+  actions      = {
     ["enter"]  = actions.buf_switch,
     ["ctrl-x"] = { fn = actions.buf_del, reload = true },
+    ["f11"]    = { fn = actions.dummy_abort, reload = true },
   },
-  fzf_opts    = {
+  _reload_bind = "<F11>",
+  fzf_opts     = {
     ["--multi"]     = true,
     ["--delimiter"] = "[\\):]",
     ["--with-nth"]  = "5..",
   },
-  _cached_hls = { "buf_nr", "buf_flag_cur", "buf_flag_alt", "tab_title", "tab_marker", "path_linenr" },
+  _cached_hls  = { "buf_nr", "buf_flag_cur", "buf_flag_alt", "tab_title", "tab_marker", "path_linenr" },
 }
 
 M.defaults.lines                = {

--- a/lua/fzf-lua/utils.lua
+++ b/lua/fzf-lua/utils.lua
@@ -797,8 +797,8 @@ function M.fzf_winobj()
   return loadstring("return require'fzf-lua'.win.__SELF()")()
 end
 
-function M.CTX()
-  return loadstring("return require'fzf-lua'.core.CTX()")()
+function M.CTX(...)
+  return loadstring("return require'fzf-lua'.core.CTX(...)")(...)
 end
 
 function M.__CTX()

--- a/lua/fzf-lua/win.lua
+++ b/lua/fzf-lua/win.lua
@@ -1210,7 +1210,11 @@ end
 function FzfWin.unhide()
   local self = _self
   if not self or not self:hidden() then return end
-  self._o.__CTX = utils.CTX()
+  self._o.__CTX = utils.CTX({ force = true })
+  -- reload list for buffers/tabs
+  if self._o._reload_bind then
+    utils.feed_keys_termcodes(self._o._reload_bind)
+  end
   vim.bo[self._hidden_fzf_bufnr].bufhidden = "wipe"
   self.fzf_bufnr = self._hidden_fzf_bufnr
   self._hidden_fzf_bufnr = nil


### PR DESCRIPTION
After ~https://github.com/ibhagwan/fzf-lua/commit/da9a0898541b34b95361e4223df17a7f680be070~ https://github.com/ibhagwan/fzf-lua/commit/480e29c20cb324bb9bf3d6f7d8e5505bcb49d555
Actions like `ctrl-x` may throw an error since CTX updated.


This PR
* reload all CTX include `buflist` for buffers
* force a reload by a dummy reload bind when unhide
