### PR TITLE
fix it's-its grammar mistakes

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 ## Quickstart
 
-To quickly test this plugin without changing your configuration run (will run in it's own sandbox
+To quickly test this plugin without changing your configuration run (will run in its own sandbox
 with the default keybinds below):
 > [!NOTE]
 > it's good practice to first

--- a/doc/fzf-lua.txt
+++ b/doc/fzf-lua.txt
@@ -60,7 +60,7 @@ QUICKSTART                                                *fzf-lua-quickstart*
 
 
 To quickly test this plugin without changing your configuration run (will run
-in it's own sandbox with the default keybinds below):
+in its own sandbox with the default keybinds below):
 
   [!NOTE] it's good practice to first read the script
   <https://github.com/ibhagwan/fzf-lua/blob/main/scripts/mini.sh> before running

--- a/lua/fzf-lua/providers/tags.lua
+++ b/lua/fzf-lua/providers/tags.lua
@@ -158,7 +158,7 @@ local function tags(opts)
     opts.filter = (opts.filter == nil) and filter or opts.filter
     -- rg globs are meaningless here since we are searching a single file
     opts.rg_glob = false
-    -- tags has it's own formatter
+    -- tags has its own formatter
     opts.formatter, opts._fmt = false, { _to = false, to = false, from = false }
     opts.filespec = libuv.shellescape(opts._ctags_file)
     if opts.multiprocess then
@@ -183,7 +183,7 @@ local function tags(opts)
     if opts.filter and #opts.filter > 0 then
       opts.raw_cmd = ("%s | %s"):format(opts.raw_cmd, opts.filter)
     end
-    -- tags has it's own formatter
+    -- tags has its own formatter
     opts.formatter, opts._fmt = false, { _to = false, to = false, from = false }
     return require "fzf-lua.providers.grep".grep(opts)
   end


### PR DESCRIPTION
it's = it is
its = possessive form of "it"