### PR TITLE
feat(defaults): make delta switch dark/light

### DIFF
--- a/lua/fzf-lua/defaults.lua
+++ b/lua/fzf-lua/defaults.lua
@@ -21,7 +21,8 @@ function M._default_previewer_fn()
 end
 
 function M._preview_pager_fn()
-  return vim.fn.executable("delta") == 1 and "delta --width=$COLUMNS" or nil
+  return vim.fn.executable("delta") == 1 and ("delta --width=$COLUMNS --%s"):format(vim.o.bg) or
+      nil
 end
 
 function M._man_cmd_fn(bat_pager)


### PR DESCRIPTION
`delta` have [osc 10/11 support] support, so it can detect light/dark in
terminal like [kitty,
neovim](https://github.com/bash/terminal-colorsaurus/blob/main/doc/terminal-survey.md),
but sadly not in fzf previewer.

But we can pass a flag to delta using neovim's `&bg` (neovim caculate a
luminance to know if the terminal is dark/light
https://github.com/neovim/neovim/blob/0d5a93be22d27dd095ecbc02775de1f3f4b8d3c9/runtime/lua/vim/_defaults.lua#L776).
