### PR TITLE
fix: nil check for `haystack`

### DIFF
--- a/lua/fzf-lua/path.lua
+++ b/lua/fzf-lua/path.lua
@@ -361,7 +361,7 @@ function M.lengthen(path)
 end
 
 local function lastIndexOf(haystack, needle)
-  local i = haystack:match(".*" .. needle .. "()")
+  local i = haystack and haystack:match(".*" .. needle .. "()")
   if i == nil then return nil else return i - 1 end
 end
 


### PR DESCRIPTION
I have the following error occasionally when I return from the path picker:

```
[Fzf-lua] fn_selected threw an error: .../.local/share/nvim/packages/fzf-lua/lua/fzf-lua/path.lua:364: attempt to index local 'haystack' (a nil value)
stack traceback:
        .../.local/share/nvim/packages/fzf-lua/lua/fzf-lua/core.lua:255: in function '__index'
        .../.local/share/nvim/packages/fzf-lua/lua/fzf-lua/path.lua:364: in function 'lastIndexOf'
        .../.local/share/nvim/packages/fzf-lua/lua/fzf-lua/path.lua:369: in function 'stripBeforeLastOccurrenceOf'
        .../.local/share/nvim/packages/fzf-lua/lua/fzf-lua/path.lua:423: in function 'entry_to_file'
        /home/zeng/.config/nvim/lua/configs/fzf-lua.lua:128: in function 'action'
        ...ocal/share/nvim/packages/fzf-lua/lua/fzf-lua/actions.lua:122: in function 'act'
        .../.local/share/nvim/packages/fzf-lua/lua/fzf-lua/core.lua:161: in function 'fn_selected'
        .../.local/share/nvim/packages/fzf-lua/lua/fzf-lua/core.lua:248: in function <.../.local/share/nvim/packages/fzf-lua/lua/fzf-lua/core.lua:247>
        [C]: in function 'xpcall'
        .../.local/share/nvim/packages/fzf-lua/lua/fzf-lua/core.lua:247: in function <.../.local/share/nvim/packages/fzf-lua/lua/fzf-lua/core.lua:239>
```

Checking if `haystack` is nil before indexing it should fix this error.