### PR TITLE
fix: force `border = "none"` for scrollbar to ignore `&winborder`

### DIFF
--- a/lua/fzf-lua/win.lua
+++ b/lua/fzf-lua/win.lua
@@ -1296,7 +1296,8 @@ function FzfWin:update_preview_scrollbar()
     height = o.wininfo.height,
     zindex = self.winopts.zindex + 1,
     row = 0,
-    col = o.wininfo.width + scrolloff
+    col = o.wininfo.width + scrolloff,
+    border = "none",
   }
   local full = vim.tbl_extend("keep", {
     zindex = empty.zindex + 1,


### PR DESCRIPTION
Fix https://github.com/ibhagwan/fzf-lua/issues/1907.
