### PR TITLE
fix: backdrop shouldn't use `&winborder` too

### DIFF
--- a/lua/fzf-lua/win.lua
+++ b/lua/fzf-lua/win.lua
@@ -590,6 +590,7 @@ function FzfWin:set_backdrop()
     focusable = false,
     -- -2 as preview border is -1
     zindex = self.winopts.zindex - 2,
+    border = 'none',
   })
   utils.wo(self.backdrop_win, "winhighlight", "Normal:" .. self.hls.backdrop)
   utils.wo(self.backdrop_win, "winblend", self.winopts.backdrop)


### PR DESCRIPTION
Fix https://github.com/ibhagwan/fzf-lua/issues/1907#issuecomment-2745107564.
