### PR TITLE
ci: fix flaky test by adding wait time

### DIFF
--- a/tests/file/ui_spec.lua
+++ b/tests/file/ui_spec.lua
@@ -162,6 +162,7 @@ T["files()"]["executable"] = new_set({ parametrize = { { "fd" }, { "rg" }, { "fi
     child.wait_until(function()
       return child.lua_get([[_G._fzf_load_called]]) == true
     end)
+    sleep(100)
     child.expect_screen_lines(screen_opts)
     child.type_keys("<c-c>")
     child.wait_until(function()


### PR DESCRIPTION
This attempts to fix a test failure that's happening in the [Nixpkgs](https://github.com/NixOS/nixpkgs) build.

- [Build log](https://cache.nixos.org/log/62gmgc5p9n1pflivl0k5xnwdj7fb65nr-lua5.4-fzf-lua-0.0.1783-1.drv)
- [Archived build log](https://web.archive.org/web/20250322234335/https://cache.nixos.org/log/62gmgc5p9n1pflivl0k5xnwdj7fb65nr-lua5.4-fzf-lua-0.0.1783-1.drv)

I also encountered the same error on my own GitHub Actions workflow, and was able to resolve it by applying this fix.

- [Failing commit](https://github.com/midchildan/dotfiles/commit/3f82a4e82bbfd9d1471ba40863d19ed24cb949ee)
- [Fixed commit](https://github.com/midchildan/dotfiles/commit/dcf915a4af10b18d7c8972cfb97e86f833fdb1b0)

I'll make this a draft PR for now, because it's untested on the Nixpkgs build servers.
