### PR TITLE
fix: close pipe when actions error

### DIFF
--- a/lua/fzf-lua/shell.lua
+++ b/lua/fzf-lua/shell.lua
@@ -113,7 +113,7 @@ end
 
 function M.raw_action(fn, fzf_field_expression, debug)
   local receiving_function = function(pipe, ...)
-    local ret = fn(...)
+    local ok, ret = pcall(fn, ...)
 
     local on_complete = function(_)
       -- We are NOT asserting, in case fzf closes
@@ -121,6 +121,9 @@ function M.raw_action(fn, fzf_field_expression, debug)
       -- assert(not err)
       uv.close(pipe)
     end
+
+    -- pipe must be closed, otherwise terminal will freeze
+    if not ok then on_complete() end
 
     if type(ret) == "string" then
       uv.write(pipe, ret, on_complete)


### PR DESCRIPTION
Fix https://github.com/ibhagwan/fzf-lua/discussions/1901#discussioncomment-12588036.

If pipe is not closed, terminal won't response and refresh unless we
press a ctrl-c.

This can happened when:
```
actions["ctrl-g"].fn = function() error('xxx') end
```