### PR TITLE
feat(lsp_code_actions): Use `apply` based on fzf `--select-1`

### DIFF
--- a/lua/fzf-lua/providers/lsp.lua
+++ b/lua/fzf-lua/providers/lsp.lua
@@ -994,7 +994,11 @@ M.code_actions = function(opts)
   -- 3rd arg are "once" options to override
   -- existing "registered" ui_select options
   ui_select.register(opts, true, opts)
-  vim.lsp.buf.code_action({ context = opts.context, filter = opts.filter })
+  vim.lsp.buf.code_action({
+    apply = opts.fzf_opts['-1'] or opts.fzf_opts['--select-1'],
+    context = opts.context,
+    filter = opts.filter,
+  })
   -- vim.defer_fn(function()
   --   ui_select.deregister({}, true, true)
   -- end, 100)


### PR DESCRIPTION
This is an improvement on the default behavior of `--select-1` because it won't flash an fzf window momentarily before applying the code action when there is only one option.