### PR TITLE
fix: nvim_open_win from ctx win

### DIFF
--- a/lua/fzf-lua/previewer/builtin.lua
+++ b/lua/fzf-lua/previewer/builtin.lua
@@ -94,10 +94,12 @@ function TSContext.update(winid, bufnr, opts)
   else
     assert(context_lines)
     local function open()
-      if vim.api.nvim_buf_is_valid(bufnr) and vim.api.nvim_win_is_valid(winid) then
-        require("treesitter-context.render").open(bufnr, winid, context_ranges, context_lines)
-        TSContext._winids[tostring(winid)] = bufnr
-      end
+      api.nvim_win_call(utils.CTX().winid, function()
+        if vim.api.nvim_buf_is_valid(bufnr) and vim.api.nvim_win_is_valid(winid) then
+          require("treesitter-context.render").open(bufnr, winid, context_ranges, context_lines)
+          TSContext._winids[tostring(winid)] = bufnr
+        end
+      end)
     end
     -- NOTE: no longer required since adding `eventignore` to `FzfWin:set_winopts`
     -- if TSContext.is_attached(winid) == bufnr then

--- a/lua/fzf-lua/utils.lua
+++ b/lua/fzf-lua/utils.lua
@@ -1058,6 +1058,12 @@ function M.nvim_open_win(bufnr, enter, config)
   return winid
 end
 
+function M.nvim_open_win0(bufnr, enter, config)
+  return vim.api.nvim_win_call(M.CTX().winid, function()
+    return vim.api.nvim_open_win(bufnr, enter, config)
+  end)
+end
+
 -- Close a window without triggering an autocmd
 function M.nvim_win_close(win, opts)
   local save_ei = vim.o.eventignore

--- a/lua/fzf-lua/win.lua
+++ b/lua/fzf-lua/win.lua
@@ -580,7 +580,7 @@ function FzfWin:set_backdrop()
 
   -- Code from lazy.nvim (#1344)
   self.backdrop_buf = vim.api.nvim_create_buf(false, true)
-  self.backdrop_win = vim.api.nvim_open_win(self.backdrop_buf, false, {
+  self.backdrop_win = utils.nvim_open_win0(self.backdrop_buf, false, {
     relative = "editor",
     width = vim.o.columns,
     height = vim.o.lines,
@@ -590,7 +590,7 @@ function FzfWin:set_backdrop()
     focusable = false,
     -- -2 as preview border is -1
     zindex = self.winopts.zindex - 2,
-    border = 'none',
+    border = "none",
   })
   utils.wo(self.backdrop_win, "winhighlight", "Normal:" .. self.hls.backdrop)
   utils.wo(self.backdrop_win, "winblend", self.winopts.backdrop)
@@ -1312,7 +1312,7 @@ function FzfWin:update_preview_scrollbar()
     else
       empty.noautocmd = true
       self._sbuf1 = ensure_tmp_buf(self._sbuf1)
-      self._swin1 = vim.api.nvim_open_win(self._sbuf1, false, empty)
+      self._swin1 = utils.nvim_open_win0(self._sbuf1, false, empty)
       local hl = self.hls.scrollfloat_e or "PmenuSbar"
       vim.wo[self._swin1].winhighlight =
           ("Normal:%s,NormalNC:%s,NormalFloat:%s,EndOfBuffer:%s"):format(hl, hl, hl, hl)
@@ -1323,7 +1323,7 @@ function FzfWin:update_preview_scrollbar()
   else
     full.noautocmd = true
     self._sbuf2 = ensure_tmp_buf(self._sbuf2)
-    self._swin2 = vim.api.nvim_open_win(self._sbuf2, false, full)
+    self._swin2 = utils.nvim_open_win0(self._sbuf2, false, full)
     local hl = self.hls.scrollfloat_f or "PmenuThumb"
     vim.wo[self._swin2].winhighlight =
         ("Normal:%s,NormalNC:%s,NormalFloat:%s,EndOfBuffer:%s"):format(hl, hl, hl, hl)


### PR DESCRIPTION
See https://github.com/neovim/neovim/issues/33133#issuecomment-2763104765.

Temporally fix https://github.com/ibhagwan/fzf-lua/issues/1929.

*EDIT*: But it didn't handle float win not created by fzf...
* e.g. treesitter.context's win on ctx buffer
* e.g. lsp fidget's spinner win?

Although If you want, you can always override `api.nvim_win_open`,. I think it's usually harmless...