### PR TITLE
fix(previewer): `nvim_win_call` fail when `ctx.winid` is invalid

### DIFF
--- a/lua/fzf-lua/test/helpers.lua
+++ b/lua/fzf-lua/test/helpers.lua
@@ -151,7 +151,13 @@ M.new_child_neovim = function()
   child.unload = function()
     -- Unload Lua module
     child.lua([[_G.FzfLua = nil]])
-    child.lua([[package.loaded["fzf-lua"] = nil]])
+    child.lua([[
+      for k, v in pairs(package.loaded) do
+        if k:match("^fzf%-lua") then
+          package.loaded[k] = nil
+        end
+      end
+    ]])
 
     -- Remove global vars
     for _, var in ipairs({ "server", "directory", "root" }) do

--- a/lua/fzf-lua/utils.lua
+++ b/lua/fzf-lua/utils.lua
@@ -1059,7 +1059,11 @@ function M.nvim_open_win(bufnr, enter, config)
 end
 
 function M.nvim_open_win0(bufnr, enter, config)
-  return vim.api.nvim_win_call(M.CTX().winid, function()
+  local winid = M.CTX().winid
+  if not vim.api.nvim_win_is_valid(winid) then
+    return vim.api.nvim_open_win(bufnr, enter, config)
+  end
+  return vim.api.nvim_win_call(winid, function()
     return vim.api.nvim_open_win(bufnr, enter, config)
   end)
 end

--- a/scripts/minimal_init.lua
+++ b/scripts/minimal_init.lua
@@ -14,4 +14,7 @@ if #vim.api.nvim_list_uis() == 0 then
 end
 
 vim.env.FZF_DEFAULT_OPTS = nil
+vim.env.FZF_DEFAULT_OPTS_FILE = nil
+vim.env.FZF_DEFAULT_COMMAND = nil
+vim.env.FZF_API_KEY = nil
 vim.env.LC_ALL = "C"

--- a/tests/win_spec.lua
+++ b/tests/win_spec.lua
@@ -74,4 +74,31 @@ T["win"]["hide"]["buffer deleted after win hidden (#1783)"] = function()
   end)
 end
 
+T["win"]["hide"]["can resume after close CTX win (#1936)"] = function()
+  reload({ "hide" })
+  eq(child.lua_get([[_G._fzf_lua_on_create]]), vim.NIL)
+  child.cmd([[new]])
+  child.lua([[FzfLua.files()]])
+  child.wait_until(function()
+    return child.lua_get([[_G._fzf_lua_on_create]]) == true
+  end)
+  vim.uv.sleep(100)
+  child.type_keys([[<esc>]])
+  child.wait_until(function()
+    return child.lua_get([[_G._fzf_lua_on_create]]) == vim.NIL
+  end)
+  vim.uv.sleep(100)
+  child.cmd([[close]])
+  vim.uv.sleep(100)
+  child.lua([[FzfLua.resume()]])
+  -- child.lua([[FzfLua.unhide()]])
+  child.wait_until(function()
+    return child.lua_get([[_G._fzf_lua_on_create]]) == true
+  end)
+  vim.uv.sleep(100)
+  child.type_keys("<c-j>")
+  vim.uv.sleep(100)
+  child.type_keys("<c-j>")
+end
+
 return T

--- a/tests/win_spec.lua
+++ b/tests/win_spec.lua
@@ -75,7 +75,7 @@ T["win"]["hide"]["buffer deleted after win hidden (#1783)"] = function()
 end
 
 T["win"]["hide"]["can resume after close CTX win (#1936)"] = function()
-  reload({ "hide" })
+  -- reload({ "hide" })
   eq(child.lua_get([[_G._fzf_lua_on_create]]), vim.NIL)
   child.cmd([[new]])
   child.lua([[FzfLua.files()]])


### PR DESCRIPTION
In `hide` profile, `:new`, `:FzfLua files`, `<esc>`, `:FzfLua resume`
