### PR TITLE
fix: prioritize opts.prompt if available

### DIFF
--- a/lua/fzf-lua/providers/ui_select.lua
+++ b/lua/fzf-lua/providers/ui_select.lua
@@ -98,7 +98,7 @@ M.ui_select = function(items, ui_opts, on_choice)
 
   -- Force override prompt or it stays cached (#786)
   local prompt = ui_opts.prompt or "Select one of:"
-  opts.prompt = prompt:gsub(":%s?$", "> ")
+  opts.prompt = opts.prompt or prompt:gsub(":%s?$", "> ")
 
   -- save items so we can access them from the action
   opts._items = items


### PR DESCRIPTION
The fix for issue #786 breaks setups where user wants a consistent prompt text for all vim.ui.select operations. Previously, this used to be provided in `opts` like below (for eg.):

```lua
    require("fzf-lua").register_ui_select(function(ui_opts, _)
      return {
        prompt = "❯ ",
        winopts = {
          title = ui_opts.prompt:gsub(":%s*$", ""),
          title_pos = "center",
          height = 0.33,
          width = 0.5
        }
      }
```
With the updated changes, the prompt provided above is not considered and one must change the provided `ui_opts.prompt` instead.

The changes proposed here prioritize `opts.prompt` if available. Fixes #1952 