### PR TITLE
fix(previewer): Apply fn_transform_cmd to regex query parsing

### DIFF
--- a/lua/fzf-lua/previewer/builtin.lua
+++ b/lua/fzf-lua/previewer/builtin.lua
@@ -1040,7 +1040,10 @@ function Previewer.buffer_or_file:set_cursor_hl(entry)
   local mgrep, glob_args = require("fzf-lua.providers.grep"), nil
   local regex = self.opts.__ACT_TO == mgrep.grep and self.opts._last_query
       or self.opts.__ACT_TO == mgrep.live_grep and self.opts.search or nil
-  if regex and self.opts.rg_glob and self.opts.glob_separator then
+  if regex and self.opts.fn_transform_cmd then
+    local _, query = self.opts.fn_transform_cmd(regex, self.opts.cmd, self.opts)
+    regex = query or regex
+  elseif regex and self.opts.rg_glob and self.opts.glob_separator then
     regex, glob_args = require("fzf-lua.make_entry").glob_parse(regex, self.opts)
   end
   if regex then


### PR DESCRIPTION
This PR addresses an issue where the `fn_transform_cmd` wasn't being applied to the regex query when parsing.
Now, before parsing the regex query, the `fn_transform_cmd` is checked and applied if it exists.
This allows the query to be retrieved and transformed based on user configuration.

Please review and let me know if anything needs adjustment. Thank you!

Fixes #1927