### PR TITLE
fix(rpc): use `nvim -l` to get argv easilier (also less side effects)

### DIFF
--- a/.github/workflows/vimdoc.yaml
+++ b/.github/workflows/vimdoc.yaml
@@ -14,7 +14,7 @@ jobs:
       - uses: rhysd/action-setup-vim@v1
         with:
           neovim: true
-          version: v0.10.3
+          version: v0.10.4
       - name: Setup treesitter
         run: |
           mkdir -p ~/.local/share/nvim/site/pack/vendor/start
@@ -28,7 +28,7 @@ jobs:
         run: |
           export PATH="${PWD}/build/:${PATH}"
           export PACKPATH=$HOME/.local/share/nvim/site
-          nvim --headless -u ~/.local/share/nvim/site/pack/vendor/start/ts-vimdoc.nvim/scripts/init.lua  -c "lua require('ts-vimdoc').docgen({input_file='README.md', output_file='doc/fzf-lua.txt', project_name='fzf-lua', version='For Neovim >= 0.7.0'})" -c "qa"
+          nvim --headless -u ~/.local/share/nvim/site/pack/vendor/start/ts-vimdoc.nvim/scripts/init.lua  -c "lua require('ts-vimdoc').docgen({input_file='README.md', output_file='doc/fzf-lua.txt', project_name='fzf-lua', version='For Neovim >= 0.9.0'})" -c "qa"
       - name: Commit changes
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # fzf :heart: lua
 
-![Neovim version](https://img.shields.io/badge/Neovim-0.7-57A143?style=flat-square&logo=neovim)
+![Neovim version](https://img.shields.io/badge/Neovim-0.9-57A143?style=flat-square&logo=neovim)
 
 [Quickstart](#quickstart) • [Installation](#installation) • [Usage](#usage) • [Commands](#commands) • [Customization](#customization) • [Wiki](https://github.com/ibhagwan/fzf-lua/wiki)
 
@@ -55,7 +55,7 @@ Using [lazy.nvim](https://github.com/folke/lazy.nvim)
 
 ### Dependencies
 
-- [`neovim`](https://github.com/neovim/neovim/releases) version > `0.7.0`
+- [`neovim`](https://github.com/neovim/neovim/releases) version >= `0.9`
 - [`fzf`](https://github.com/junegunn/fzf) version > `0.25`
   or [`skim`](https://github.com/skim-rs/skim) binary installed
 - [nvim-web-devicons](https://github.com/nvim-tree/nvim-web-devicons)

--- a/lua/fzf-lua/devicons.lua
+++ b/lua/fzf-lua/devicons.lua
@@ -45,8 +45,6 @@ function NvimWebDevicons:new()
 end
 
 function NvimWebDevicons:load(do_not_lazy_load)
-  -- limit devicons support to nvim >=0.8, although official support is >=0.7
-  -- running setup on 0.7 errs with "W18: Invalid character in group name"
   if not self._package_loaded
       -- do not trigger lazy loading
       and (not do_not_lazy_load or package.loaded[self._package_name])
@@ -180,7 +178,7 @@ function MiniIcons:new()
 end
 
 function MiniIcons:load(do_not_lazy_load)
-  if not self._package_loaded and utils.__HAS_NVIM_08
+  if not self._package_loaded
       -- do not trigger lazy loading
       and (not do_not_lazy_load or package.loaded[self._package_name])
   then

--- a/lua/fzf-lua/fzf.lua
+++ b/lua/fzf-lua/fzf.lua
@@ -279,6 +279,8 @@ function M.raw_fzf(contents, fzf_cli_args, opts)
       ["SHELL"] = shell_cmd[1],
       ["FZF_DEFAULT_COMMAND"] = FZF_DEFAULT_COMMAND,
       ["SKIM_DEFAULT_COMMAND"] = FZF_DEFAULT_COMMAND,
+      ["FZF_LUA_SERVER"] = vim.g.fzf_lua_server,
+      ["VIMRUNTIME"] = vim.env.VIMRUNTIME,
       ["FZF_DEFAULT_OPTS"] = (function()
         -- Newer style `--preview-window` options in FZF_DEFAULT_OPTS such as:
         --   --preview-window "right,50%,hidden,<60(up,70%,hidden)"

--- a/lua/fzf-lua/init.lua
+++ b/lua/fzf-lua/init.lua
@@ -84,12 +84,7 @@ function M.setup_highlights(override)
     { "FzfLuaScrollFloatFull",   "scrollfloat_f",  { default = default, link = "PmenuThumb" } },
     { "FzfLuaDirIcon",           "dir_icon",       { default = default, link = "Directory" } },
     { "FzfLuaDirPart",           "dir_part",       { default = default, link = "Comment" } },
-    { "FzfLuaFilePart", "file_part",
-      {
-        default = default,
-        link = utils.__HAS_NVIM_08 and "@none" or "Normal",
-      }
-    },
+    { "FzfLuaFilePart",          "file_part",      { default = default, link = "@none" } },
     -- Fzf terminal hls, colors from `vim.api.nvim_get_color_map()`
     { "FzfLuaHeaderBind", "header_bind",
       { default = default, fg = is_light and "MediumSpringGreen" or "BlanchedAlmond" } },
@@ -144,20 +139,6 @@ function M.setup_highlights(override)
       end
     end
     vim.api.nvim_set_hl(0, hl_name, hl_def)
-  end
-
-  -- linking to a cleared hl is bugged in neovim 0.8.x
-  -- resulting in a pink background for hls linked to `Normal`
-  if not utils.__HAS_NVIM_09 and utils.__HAS_NVIM_08 then
-    for _, a in ipairs(highlights) do
-      local hl_name, opt_name = a[1], a[2]
-      if utils.is_hl_cleared(hl_name) then
-        -- reset any invalid hl, this will cause our 'winhighlight'
-        -- string to look something akin to `Normal:,FloatBorder:`
-        -- which uses terminal fg|bg colors instead
-        utils.map_set(config.setup_opts, "__HLS." .. opt_name, "")
-      end
-    end
   end
 
   -- Init the colormap singleton

--- a/lua/fzf-lua/libuv.lua
+++ b/lua/fzf-lua/libuv.lua
@@ -51,6 +51,8 @@ end
 ---@param opts {cwd: string, cmd: string|table, env: table?, cb_finish: function, cb_write: function, cb_err: function, cb_pid: function, fn_transform: function?, EOL: string?, process1: boolean?, profile: boolean?}
 ---@param fn_transform function?
 ---@param fn_done function?
+---@return uv.uv_process_t proc
+---@return integer         pid
 M.spawn = function(opts, fn_transform, fn_done)
   local EOL = opts.EOL or "\n"
   local output_pipe = uv.new_pipe(false)
@@ -233,6 +235,7 @@ M.spawn = function(opts, fn_transform, fn_done)
     output_pipe:read_start(read_cb)
     error_pipe:read_start(err_cb)
   end
+  return handle, pid
 end
 
 M.async_spawn = coroutinify(M.spawn)
@@ -690,14 +693,10 @@ M.wrap_spawn_stdio = function(opts, fn_transform, fn_preprocess, fn_postprocess)
   assert(opts and type(opts) == "string")
   assert(not fn_transform or type(fn_transform) == "string")
   local nvim_bin = os.getenv("FZF_LUA_NVIM_BIN") or vim.v.progpath
-  local lua_cmd = ("lua %sloadfile([[%s]])().spawn_stdio(%s,%s,%s,%s)"):format(
-    _has_nvim_010 and "vim.g.did_load_filetypes=1; " or "",
-    vim.fn.fnamemodify(_is_win and vim.fs.normalize(__FILE__) or __FILE__, ":h") .. "/spawn.lua",
-    opts, fn_transform, fn_preprocess, fn_postprocess
-  )
-  local cmd_str = ("%s -n --headless -u NONE -i NONE --cmd %s"):format(
+  local cmd_str = ("%s -u NONE -l %s %s"):format(
     M.shellescape(_is_win and vim.fs.normalize(nvim_bin) or nvim_bin),
-    M.shellescape(lua_cmd)
+    vim.fn.fnamemodify(_is_win and vim.fs.normalize(__FILE__) or __FILE__, ":h") .. "/spawn.lua",
+    M.shellescape(("return %s,%s,%s,%s"):format(opts, fn_transform, fn_preprocess, fn_postprocess))
   )
   return cmd_str
 end

--- a/lua/fzf-lua/profiles/default.lua
+++ b/lua/fzf-lua/profiles/default.lua
@@ -1,5 +1,4 @@
 return {
   desc = "fzf-lua default options",
-  -- Defaults to picker info in win title if neovim version >= 0.9, prompt otherwise
-  require("fzf-lua").utils.__HAS_NVIM_09 and "default-title" or "default-prompt"
+  "default-title",
 }

--- a/lua/fzf-lua/shell.lua
+++ b/lua/fzf-lua/shell.lua
@@ -90,22 +90,18 @@ function M.raw_async_action(fn, fzf_field_expression, debug)
     utils._if_win(path.normalize(vim.env.VIMRUNTIME),
       libuv.shellescape(vim.env.VIMRUNTIME)))
 
-  local call_args = ("fzf_lua_server=[[%s]], fnc_id=%d %s"):format(
-    vim.g.fzf_lua_server, id, debug and ", debug=true" or "")
 
   -- we need to add '--' to mark the end of command options otherwise
   -- our preview command will fail when the selected items contain
   -- special shell chars ('+', '-', etc), examples where this can
   -- happen are the `git status` command and git branches from diff
   -- worktrees (#600)
-  local action_cmd = ("%s%s -n --headless -u NONE -i NONE --cmd %s -- %s"):format(
+  local action_cmd = ("%s%s -u NONE -l %s -- %s %s %s"):format(
     nvim_runtime,
     libuv.shellescape(path.normalize(nvim_bin)),
-    libuv.shellescape(("lua %sloadfile([[%s]])().rpc_nvim_exec_lua({%s})"):format(
-      utils.__HAS_NVIM_010 and "vim.g.did_load_filetypes=1; " or "",
-      path.join { vim.g.fzf_lua_directory, "shell_helper.lua" },
-      call_args
-    )),
+    libuv.shellescape(path.normalize(path.join { vim.g.fzf_lua_directory, "shell_helper.lua" })),
+    id,
+    debug,
     fzf_field_expression)
 
   return action_cmd, id

--- a/lua/fzf-lua/shell.lua
+++ b/lua/fzf-lua/shell.lua
@@ -85,19 +85,9 @@ function M.raw_async_action(fn, fzf_field_expression, debug)
   -- this is for windows WSL and AppImage users, their nvim path isn't just
   -- 'nvim', it can be something else
   local nvim_bin = os.getenv("FZF_LUA_NVIM_BIN") or vim.v.progpath
-  local nvim_runtime = os.getenv("FZF_LUA_NVIM_BIN") and "" or string.format(
-    utils._if_win([[set VIMRUNTIME=%s& ]], "VIMRUNTIME=%s "),
-    utils._if_win(path.normalize(vim.env.VIMRUNTIME),
-      libuv.shellescape(vim.env.VIMRUNTIME)))
 
-
-  -- we need to add '--' to mark the end of command options otherwise
-  -- our preview command will fail when the selected items contain
-  -- special shell chars ('+', '-', etc), examples where this can
-  -- happen are the `git status` command and git branches from diff
-  -- worktrees (#600)
-  local action_cmd = ("%s%s -u NONE -l %s -- %s %s %s"):format(
-    nvim_runtime,
+  -- all args after `-l` will be in `_G.args`
+  local action_cmd = ("%s -u NONE -l %s %s %s %s"):format(
     libuv.shellescape(path.normalize(nvim_bin)),
     libuv.shellescape(path.normalize(path.join { vim.g.fzf_lua_directory, "shell_helper.lua" })),
     id,

--- a/lua/fzf-lua/spawn.lua
+++ b/lua/fzf-lua/spawn.lua
@@ -1,4 +1,5 @@
 -- This file should only be loaded from the headless instance
+local uv = vim.uv or vim.loop
 assert(#vim.api.nvim_list_uis() == 0)
 
 -- path to this file
@@ -31,5 +32,8 @@ end
 
 -- global var indicating a headless instance
 _G._fzf_lua_is_headless = true
-
-return { spawn_stdio = require("fzf-lua.libuv").spawn_stdio }
+local _, pid = require("fzf-lua.libuv").spawn_stdio(loadstring(_G.arg[1])())
+-- while vim.uv.run() do end -- os.exit in spawn_stdio
+while uv.os_getpriority(pid) do
+  vim.wait(100, function() return uv.os_getpriority(pid) == nil end)
+end

--- a/lua/fzf-lua/spawn.lua
+++ b/lua/fzf-lua/spawn.lua
@@ -1,17 +1,6 @@
 -- This file should only be loaded from the headless instance
 assert(#vim.api.nvim_list_uis() == 0)
 
--- When running CI tests there's a bug on Windows which adds a space after the runtime
--- path, this will subsequently cause `vim.filetype.match` to fail  when it attempts to
---`require("vim.filetype.detect")` which will fail our custom `path.ft_match`. This will
--- fail mini.icons UI tests as any icon that requires the use of `vim.filetype.match`
--- will return a default icon
-local VIMRUNTIME = os.getenv("VIMRUNTIME")
-if VIMRUNTIME and VIMRUNTIME:match("%s$") then
-  vim.opt.runtimepath:prepend(vim.trim(VIMRUNTIME))
-  -- package.path = ("%s/lua/?.lua;"):format(vim.trim(VIMRUNTIME)) .. package.path
-end
-
 -- path to this file
 local __FILE__ = debug.getinfo(1, "S").source:gsub("^@", "")
 

--- a/lua/fzf-lua/test/helpers.lua
+++ b/lua/fzf-lua/test/helpers.lua
@@ -136,6 +136,7 @@ M.new_child_neovim = function()
           on_close = function()
             _G._fzf_lua_on_create = nil
             _G._fzf_postprocess_called = nil
+            _G._fzf_load_called = nil
           end,
         },
         keymap = { fzf = {
@@ -265,13 +266,14 @@ M.new_child_neovim = function()
     MiniTest.expect.reference_screenshot(child.get_buf_lines(buf, screenshot_opts), path, opts)
   end
 
+  local wait_timeout = (M.IS_WIN() and 5000 or 2000)
   --- waits until condition fn evals to true, checking every interval ms
   --- times out at timeout ms
   ---@param condition fun(): boolean
   ---@param timeout? integer, defaults to 2000
   ---@param interval? integer, defaults to 100
   child.wait_until = function(condition, timeout, interval)
-    local max = timeout or 2000
+    local max = timeout or wait_timeout
     local inc = interval or 100
     for _ = 0, max, inc do
       if condition() then

--- a/lua/fzf-lua/utils.lua
+++ b/lua/fzf-lua/utils.lua
@@ -10,8 +10,6 @@ local uv = vim.uv or vim.loop
 
 local M = {}
 
-M.__HAS_NVIM_08 = vim.fn.has("nvim-0.8") == 1
-M.__HAS_NVIM_09 = vim.fn.has("nvim-0.9") == 1
 M.__HAS_NVIM_010 = vim.fn.has("nvim-0.10") == 1
 M.__HAS_NVIM_0102 = vim.fn.has("nvim-0.10.2") == 1
 M.__HAS_NVIM_011 = vim.fn.has("nvim-0.11") == 1
@@ -587,21 +585,9 @@ end
 
 -- Helper func to test for invalid (cleared) highlights
 function M.is_hl_cleared(hl)
-  -- `vim.api.nvim_get_hl_by_name` is deprecated since v0.9.0
-  if vim.api.nvim_get_hl then
-    local ok, hl_def = pcall(vim.api.nvim_get_hl, 0, { name = hl, link = false })
-    if not ok or M.tbl_isempty(hl_def) then
-      return true
-    end
-  else
-    ---@diagnostic disable-next-line: deprecated
-    local ok, hl_def = pcall(vim.api.nvim_get_hl_by_name, hl, true)
-    -- Not sure if this is the right way but it seems that cleared
-    -- highlights return 'hl_def[true] == 6' (?) and 'hl_def[true]'
-    -- does not exist at all otherwise
-    if not ok or hl_def[true] then
-      return true
-    end
+  local ok, hl_def = pcall(vim.api.nvim_get_hl, 0, { name = hl, link = false })
+  if not ok or M.tbl_isempty(hl_def) then
+    return true
   end
 end
 
@@ -1009,14 +995,6 @@ function M.nvim_buf_get_name(bufnr, bufinfo)
   end
   assert(#bufname > 0)
   return bufname
-end
-
-function M.wo(win, k, v)
-  if M.__HAS_NVIM_08 then
-    vim.api.nvim_set_option_value(k, v, { scope = "local", win = win })
-  else
-    vim.wo[win][k] = v
-  end
 end
 
 function M.zz()

--- a/lua/fzf-lua/win.lua
+++ b/lua/fzf-lua/win.lua
@@ -1218,7 +1218,7 @@ function FzfWin.unhide()
   -- Send SIGWINCH to to trigger resize in the fzf process
   -- We will use the trigger to reload necessary buffer lists
   local pid = fn.jobpid(vim.bo[self._hidden_fzf_bufnr].channel)
-  vim.tbl_map(function(_pid) libuv.process_kill(_pid, 28) end, vim._os_proc_children(pid))
+  vim.tbl_map(function(_pid) libuv.process_kill(_pid, 28) end, api.nvim_get_proc_children(pid))
   vim.bo[self._hidden_fzf_bufnr].bufhidden = "wipe"
   self.fzf_bufnr = self._hidden_fzf_bufnr
   self._hidden_fzf_bufnr = nil

--- a/lua/fzf-lua/win.lua
+++ b/lua/fzf-lua/win.lua
@@ -592,8 +592,8 @@ function FzfWin:set_backdrop()
     zindex = self.winopts.zindex - 2,
     border = "none",
   })
-  utils.wo(self.backdrop_win, "winhighlight", "Normal:" .. self.hls.backdrop)
-  utils.wo(self.backdrop_win, "winblend", self.winopts.backdrop)
+  vim.wo[self.backdrop_win].winhighlight = "Normal:" .. self.hls.backdrop
+  vim.wo[self.backdrop_win].winblend = self.winopts.backdrop
   vim.bo[self.backdrop_buf].buftype = "nofile"
   vim.bo[self.backdrop_buf].filetype = "fzflua_backdrop"
 end
@@ -701,13 +701,7 @@ function FzfWin:set_winopts(win, opts, ignore_events)
   end
   for opt, value in pairs(opts) do
     if utils.nvim_has_option(opt) then
-      -- PROBABLY DOESN'T MATTER (WHO USES 0.5?) BUT WHY NOT LOL
-      -- minor backward compatibility fix, with neovim version < 0.7
-      -- nvim_win_get_option("scroloff") which should return -1
-      -- returns an invalid (really big number instead which panics
-      -- when called with nvim_win_set_option, wrapping in a pcall
-      -- ensures this plugin still works for neovim version as low as 0.5!
-      pcall(function() vim.wo[win][opt] = value end)
+      vim.wo[win][opt] = value
     end
   end
   if save_ei then
@@ -793,9 +787,7 @@ function FzfWin:redraw_main()
   self:generate_layout()
 
   local winopts = vim.tbl_extend("keep", (function()
-    if not utils.__HAS_NVIM_09 or
-        (type(self.winopts.title) ~= "string" and type(self.winopts.title) ~= "table")
-    then
+    if type(self.winopts.title) ~= "string" and type(self.winopts.title) ~= "table" then
       return {}
     end
     return {
@@ -857,7 +849,6 @@ function FzfWin:treesitter_detach(buf)
 end
 
 function FzfWin:treesitter_attach()
-  if not utils.__HAS_NVIM_09 then return end
   if not self._o.winopts.treesitter then return end
   -- local utf8 = require("fzf-lua.lib.utf8")
   local function trim(s) return (string.gsub(s, "^%s*(.-)%s*$", "%1")) end
@@ -1331,8 +1322,7 @@ function FzfWin:update_preview_scrollbar()
 end
 
 function FzfWin.update_win_title(winid, winopts, o)
-  -- neovim >= 0.9 added window title
-  if not utils.__HAS_NVIM_09 or (type(o.title) ~= "string" and type(o.title) ~= "table") then
+  if type(o.title) ~= "string" and type(o.title) ~= "table" then
     return
   end
   vim.api.nvim_win_set_config(winid,
@@ -1359,8 +1349,7 @@ function FzfWin:update_main_title(title)
 end
 
 function FzfWin:update_preview_title(title)
-  -- neovim >= 0.9 added window title
-  if not utils.__HAS_NVIM_09 or (type(title) ~= "string" and type(title) ~= "table") then
+  if type(title) ~= "string" and type(title) ~= "table" then
     return
   end
   -- since `nvim_win_set_config` removes all styling, save backup

--- a/plugin/fzf-lua.lua
+++ b/plugin/fzf-lua.lua
@@ -1,10 +1,8 @@
 if vim.g.loaded_fzf_lua == 1 then return end
 vim.g.loaded_fzf_lua = 1
 
--- Should never be called, below nvim 0.7 "plugin/fzf-lua.vim"
--- sets `vim.g.loaded_fzf_lua=1`
-if vim.fn.has("nvim-0.7") ~= 1 then
-  vim.api.nvim_err_writeln("Fzf-lua minimum requirement is Neovim versions 0.7")
+if vim.fn.has("nvim-0.9") ~= 1 then
+  vim.notify("Fzf-lua requires neovim >= v0.9", vim.log.levels.ERROR, { title = "fzf-lua" })
   return
 end
 

--- a/scripts/headless_fd.sh
+++ b/scripts/headless_fd.sh
@@ -130,8 +130,7 @@ if [ $# -gt 0 ]; then
 fi
 
 VIMRUNTIME=/usr/share/nvim/runtime \
-/usr/bin/nvim -n --headless -u NONE -i NONE --cmd "lua vim.g.did_load_filetypes=1; loadfile(
-  [[${BASEDIR}/../lua/fzf-lua/spawn.lua]])().spawn_stdio(
+/usr/bin/nvim -u NONE -l ${BASEDIR}/../lua/fzf-lua/spawn.lua "return
   -- opts
   {
     g = {
@@ -155,4 +154,4 @@ VIMRUNTIME=/usr/share/nvim/runtime \
   [==[
     return require(\"fzf-lua.make_entry\").preprocess
   ]==]
-)"
+"


### PR DESCRIPTION
1. `nvim -l` still quit immediately even with `coroutine.yield`...
```
local co = coroutine.create(function()
  coroutine.yield()
  os.exit(0)
end)

vim.defer_fn(function()
  print('defer done')
  coroutine.resume(co)
end, 1000)

coroutine.resume(co)
```

2. `vim.wait` don't work on windows?