### PR TITLE
fix: ts-context nvim_win_call on invalid win

### DIFF
--- a/lua/fzf-lua/previewer/builtin.lua
+++ b/lua/fzf-lua/previewer/builtin.lua
@@ -96,12 +96,12 @@ function TSContext.update(winid, bufnr, opts)
   else
     assert(context_lines)
     local function open()
-      api.nvim_win_call(utils.CTX().winid, function()
-        if vim.api.nvim_buf_is_valid(bufnr) and vim.api.nvim_win_is_valid(winid) then
+      if vim.api.nvim_buf_is_valid(bufnr) and vim.api.nvim_win_is_valid(winid) then
+        api.nvim_win_call(winid, function()
           require("treesitter-context.render").open(bufnr, winid, context_ranges, context_lines)
-          TSContext._winids[tostring(winid)] = bufnr
-        end
-      end)
+        end)
+        TSContext._winids[tostring(winid)] = bufnr
+      end
     end
     -- NOTE: no longer required since adding `eventignore` to `FzfWin:set_winopts`
     -- if TSContext.is_attached(winid) == bufnr then


### PR DESCRIPTION
```
Error executing vim.schedule lua callback: **/fzf-lua/lua/fzf-lua/previewer/builtin.lua:99: Invalid window id: 1016
stack traceback:
        [C]: in function 'nvim_win_call'
        **/fzf-lua/lua/fzf-lua/previewer/builtin.lua:99: in function 'open'
        **/fzf-lua/lua/fzf-lua/previewer/builtin.lua:108: in function 'update'
        **/fzf-lua/lua/fzf-lua/previewer/builtin.lua:900: in function 'fn'
        **/neovim/runtime/lua/vim/_editor.lua:617: in function 'fn'
        **/neovim/runtime/lua/vim/_editor.lua:366: in function <**/neovim/runtime/lua/vim/_editor.lua:365>
```
