### PR TITLE
fix(test): `setmetatable__gc` on windows

### DIFF
--- a/tests/utils_spec.lua
+++ b/tests/utils_spec.lua
@@ -80,4 +80,13 @@ describe("Testing utils module", function()
     assert.are.same(utils.has({ __FZF_VERSION = { 2, 5, 5 } }, "fzf", "2.5.5"), true)
     assert.are.same(utils.has({ __FZF_VERSION = { 2, 5, 5 } }, "fzf", "2.5.6"), false)
   end)
+
+  it("setmetatable__gc", function()
+    local gc_called = nil
+    local _obj = utils.setmetatable__gc({}, { __gc = function() gc_called = true end })
+    assert.are.same(gc_called, nil)
+    _obj = nil
+    collectgarbage("collect")
+    assert.are.same(gc_called, true)
+  end)
 end)


### PR DESCRIPTION
## Problem
It seems a upstream bug: https://github.com/neovim/neovim/issues/12974.

Since job is not cleaned (as the result of `nvim_list_chans()`: https://github.com/ibhagwan/fzf-lua/actions/runs/14485522236/job/40630260016?pr=1967). So the coroutine here https://github.com/ibhagwan/fzf-lua/blob/ba5ba606f11967e08165aeeb9d7abe04d0835f58/lua/fzf-lua/fzf.lua#L329 is always alive: `job.on_exit` -> `co` -> ... -> `win._self` (by upvalues maybe).

You can use a weak table to point to the win instance, then the weak table entry is cleaned only if the coroutine cleaned, ...and only if the job cleaned.).

## Solution
Send `<c-c>` to fzf stdin to stop it rather than use signal/jobstop/chanclose/bwipeout! (all of them cannot stop/clean the job...).

I cannot reproduce this when interactively use fzf-lua in win10 qemu so just add it to test... If any user report this as a bug we can do `chan_send` on `hidden_buffer.channel` before new `jobstart`.