### PR TITLE
fix(health): not ok when `cmd --version` fail

### DIFF
--- a/lua/fzf-lua/_health.lua
+++ b/lua/fzf-lua/_health.lua
@@ -19,7 +19,8 @@ function M.check()
     else
       local version = vim.fn.system(tool .. " --version") or ""
       version = vim.trim(vim.split(version, "\n")[1])
-      ok("'" .. tool .. "' `" .. version .. "`")
+      local is_ok = vim.v.shell_error == 0
+      (is_ok and ok or error)("'" .. tool .. "' `" .. version .. "`")
       return true
     end
   end
@@ -106,7 +107,7 @@ function M.check()
   if vim.env.FZF_DEFAULT_OPTS_FILE == nil then
     ok("`FZF_DEFAULT_OPTS_FILE` is not set")
   else
-    ok("`FZF_DEFAULT_OPTS_FILE` is set to `" .. vim.env.FZF_DEFAULT_OPTS_FILE .. "`")
+    ok("`$FZF_DEFAULT_OPTS_FILE` is set to `" .. vim.env.FZF_DEFAULT_OPTS_FILE .. "`")
   end
 end
 


### PR DESCRIPTION
Before
```
fzf-lua [optional:media] ~
- ✅ OK 'viu' `viu 1.5.1`
- ✅ OK 'chafa' `Chafa version 1.14.5`
- ✅ OK 'ueberzugpp' `ueberzugpp: error while loading shared libraries: libopencv_videoio.so.410: cannot open shared object file: No such file or directory`
```

After
```
fzf-lua [optional:media] ~
- ✅ OK 'viu' `viu 1.5.1`
- ✅ OK 'chafa' `Chafa version 1.14.5`
- ❌ ERROR 'ueberzugpp' `ueberzugpp: error while loading shared libraries: libopencv_videoio.so.410: cannot open shared object file: No such file or directory`
```
