### PR TITLE
fix: `skim --tmux` didn't pass all environemnt variable

### DIFF
--- a/lua/fzf-lua/fzf.lua
+++ b/lua/fzf-lua/fzf.lua
@@ -280,6 +280,8 @@ function M.raw_fzf(contents, fzf_cli_args, opts)
       ["FZF_DEFAULT_COMMAND"] = FZF_DEFAULT_COMMAND,
       ["SKIM_DEFAULT_COMMAND"] = FZF_DEFAULT_COMMAND,
       ["FZF_LUA_SERVER"] = vim.g.fzf_lua_server,
+      -- sk --tmux didn't pass all environemnt variable (https://github.com/skim-rs/skim/issues/732)
+      ["SKIM_FZF_LUA_SERVER"] = vim.g.fzf_lua_server,
       ["VIMRUNTIME"] = vim.env.VIMRUNTIME,
       ["FZF_DEFAULT_OPTS"] = (function()
         -- Newer style `--preview-window` options in FZF_DEFAULT_OPTS such as:

--- a/lua/fzf-lua/shell_helper.lua
+++ b/lua/fzf-lua/shell_helper.lua
@@ -57,7 +57,7 @@ local rpc_nvim_exec_lua = function(opts)
     -- for skim compatibility
     local preview_lines = vim.env.FZF_PREVIEW_LINES or vim.env.LINES
     local preview_cols = vim.env.FZF_PREVIEW_COLUMNS or vim.env.COLUMNS
-    local chan_id = vim.fn.sockconnect("pipe", vim.env.FZF_LUA_SERVER or vim.env.NVIM, { rpc = true })
+    local chan_id = vim.fn.sockconnect("pipe", opts.fzf_lua_server, { rpc = true })
     vim.rpcrequest(chan_id, "nvim_exec_lua", [[
       local luaargs = {...}
       local function_id = luaargs[1]
@@ -103,6 +103,7 @@ args[0] = nil -- remove filename
 local opts = {
   fnc_id = tonumber(table.remove(args, 1)),
   debug = table.remove(args, 1) == "true",
-  fzf_selection = args
+  fzf_selection = args,
+  fzf_lua_server = vim.env.FZF_LUA_SERVER or vim.env.SKIM_FZF_LUA_SERVER or vim.env.NVIM,
 }
 rpc_nvim_exec_lua(opts)


### PR DESCRIPTION
~I search through skim docuemnt `$SKIM` seems for testing purpose only so we can use it.
Otherwise we need to pass `fzf_lua_server` in cli again...~ Ok, there's no $SKIM, it's $SKIM_xx

Since `SKIM_xx` is allowed we use `SKIM_FZF_LUA_SERVER`...

Fix https://github.com/ibhagwan/fzf-lua/pull/1974.

fzf wrap a proxy bash script with tons of lines of `export xx=xx` (`ps aux | rg fzf-temp | rg '\-\-tmux'`)...https://github.com/junegunn/fzf/blob/aefb9a5bc41f92227e4bffa050caca0270b450ba/src/proxy.go#L63.
But this `--proxy-script` is an undocumented option (at least currently)
