### PR TITLE
fix(zoxide): sort by score

### DIFF
--- a/lua/fzf-lua/defaults.lua
+++ b/lua/fzf-lua/defaults.lua
@@ -1174,6 +1174,7 @@ M.defaults.zoxide               = {
     ["--tabstop"]   = "4",
     ["--tiebreak"]  = "end,index",
     ["--nth"]       = "2..",
+    ["--no-sort"]   = true, -- sort by score
   },
   actions      = { enter = actions.cd }
 }


### PR DESCRIPTION
Fix https://github.com/ibhagwan/fzf-lua/discussions/1928.

Side note:
So the way to implement a `frecency` fzf-lua plugin is `cmd | frecency-sort | fzf --no-sort`

Edit:
That's not very good though... since fzf have to wait frecency-sort finish all sort job... 

thing would be much more easier as long as fzf can give a sort rank on something like prefix score number. then also we can just use spawn.lua to prepend a score retrieval from whatever db while processing the stream.