### PR TITLE
docs: fix title_fnamemodify example

### DIFF
--- a/README.md
+++ b/README.md
@@ -721,7 +721,7 @@ previewers = {
       -- from being modified when toggling the preview.
       toggle_behavior = "default",
       -- Title transform function, by default only displays the tail
-      -- title_fnamemodify = function(s) vim.fn.fnamemodify(s, ":t") end,
+      -- title_fnamemodify = function(s) return vim.fn.fnamemodify(s, ":t") end,
       -- preview extensions using a custom shell command:
       -- for example, use `viu` for image previews
       -- will do nothing if `viu` isn't executable

--- a/doc/fzf-lua.txt
+++ b/doc/fzf-lua.txt
@@ -698,7 +698,7 @@ CUSTOMIZATION                                          *fzf-lua-customization*
           -- from being modified when toggling the preview.
           toggle_behavior = "default",
           -- Title transform function, by default only displays the tail
-          -- title_fnamemodify = function(s) vim.fn.fnamemodify(s, ":t") end,
+          -- title_fnamemodify = function(s) return vim.fn.fnamemodify(s, ":t") end,
           -- preview extensions using a custom shell command:
           -- for example, use `viu` for image previews
           -- will do nothing if `viu` isn't executable


### PR DESCRIPTION
Adds missing `return` statement in docs for the `title_fnamemodify` example.
While testing I kept getting and error regarding a `nil` value so I noticed the `return` statement was missing.

Error without the `return` statement:
![image](https://github.com/user-attachments/assets/024b4916-d860-479e-a739-02f4626c78af)
