### PR TITLE
fix: `:quit` on other window should not kill fzf job

### DIFF
--- a/lua/fzf-lua/init.lua
+++ b/lua/fzf-lua/init.lua
@@ -42,7 +42,7 @@ do
 
   -- Workaround for using `:wqa` with "hide"
   -- https://github.com/neovim/neovim/issues/14061
-  vim.api.nvim_create_autocmd("QuitPre", {
+  vim.api.nvim_create_autocmd("ExitPre", {
     group = vim.api.nvim_create_augroup("FzfLuaNvimQuit", { clear = true }),
     callback = function()
       local win = utils.fzf_winobj()

--- a/lua/fzf-lua/test/helpers.lua
+++ b/lua/fzf-lua/test/helpers.lua
@@ -338,13 +338,13 @@ M.new_set_with_child = function(child, opts, setup_opts)
         if opts.hooks.post_case then
           opts.hooks.post_case()
         end
-        child.unload()
+        pcall(child.unload) -- job may already die
       end,
       post_once = function()
         if opts.hooks.post_once then
           opts.hooks.post_once()
         end
-        child.stop()
+        pcall(child.stop) -- job may already die
       end,
     },
     -- n_retry = helpers.get_n_retry(2),

--- a/tests/win_spec.lua
+++ b/tests/win_spec.lua
@@ -96,6 +96,27 @@ T["win"]["hide"]["can resume after close CTX win (#1936)"] = function()
   end)
   child.type_keys("<c-j>")
   child.type_keys("<c-j>")
+
+  -- `:quit` on other window should not kill fzf job #2011
+  child.lua([[FzfLua.hide()]])
+  child.wait_until(function()
+    return child.lua_get([[_G._fzf_lua_on_create]]) == vim.NIL
+  end)
+  child.cmd([[new]])
+  child.cmd([[quit]])
+  child.lua([[FzfLua.unhide()]])
+  child.wait_until(function()
+    return child.lua_get([[_G._fzf_lua_on_create]]) == true
+  end)
+  child.lua([[FzfLua.hide()]])
+  child.wait_until(function()
+    return child.lua_get([[_G._fzf_lua_on_create]]) == vim.NIL
+  end)
+
+  -- can :wqa when there're hide job #1817
+  pcall(child.cmd, [[wqa]])
+  -- child.is_running() didn't work as expected
+  eq(vim.fn.jobwait({ child.job.id }, 1000)[1], 0)
 end
 
 T["win"]["hide"]["actions on multi-select but zero-match #1961"] = function()


### PR DESCRIPTION
`FzfLua files` -> `<esc>` -> `new` -> `quit` -> `unhide` fail
