### PR TITLE
tabs.locate positions cursor at current window

### DIFF
--- a/README.md
+++ b/README.md
@@ -1057,6 +1057,7 @@ previewers = {
     prompt            = 'Tabs❯ ',
     tab_title         = "Tab",
     tab_marker        = "<<",
+    locate            = true,         -- position cursor at current window
     file_icons        = true,         -- show file icons (true|"devicons"|"mini")?
     color_icons       = true,         -- colorize file|git icons
     actions = {

--- a/doc/fzf-lua.txt
+++ b/doc/fzf-lua.txt
@@ -1028,6 +1028,7 @@ CUSTOMIZATION                                          *fzf-lua-customization*
         prompt            = 'Tabs❯ ',
         tab_title         = "Tab",
         tab_marker        = "<<",
+        locate            = true,         -- position cursor at current window
         file_icons        = true,         -- show file icons (true|"devicons"|"mini")?
         color_icons       = true,         -- colorize file|git icons
         actions = {

--- a/lua/fzf-lua/core.lua
+++ b/lua/fzf-lua/core.lua
@@ -701,6 +701,9 @@ M.build_fzf_cli = function(opts, fzf_win)
     end
   end
   opts.fzf_opts["--bind"] = M.create_fzf_binds(opts)
+  if opts.__load_pos and type(opts.__load_pos) == "number" then
+    table.insert(opts.fzf_opts["--bind"], string.format("load:pos(%d)", opts.__load_pos))
+  end
   opts.fzf_opts["--color"] = M.create_fzf_colors(opts)
   do
     -- `actions.expect` parses the actions table and returns a list of

--- a/lua/fzf-lua/defaults.lua
+++ b/lua/fzf-lua/defaults.lua
@@ -637,6 +637,7 @@ M.defaults.tabs                 = {
   previewer   = M._default_previewer_fn,
   tab_title   = "Tab",
   tab_marker  = "<<",
+  locate      = true,
   file_icons  = 1,
   color_icons = true,
   _actions    = function()

--- a/lua/fzf-lua/providers/buffers.lua
+++ b/lua/fzf-lua/providers/buffers.lua
@@ -379,6 +379,23 @@ M.tabs = function(opts)
     return msg, hl
   end
 
+  opts.fn_pre_fzf = opts.locate and function(opts)
+    local counter = 0
+    for tabnr, tabh in ipairs(vim.api.nvim_list_tabpages()) do
+      counter = counter + 1
+      for _, w in ipairs(vim.api.nvim_tabpage_list_wins(tabh)) do
+        local b = filter_buffers(opts, { vim.api.nvim_win_get_buf(w) })[1]
+        if b then
+          counter = counter + 1
+          if tabnr == core.CTX().tabnr and w == core.CTX().winid then
+            opts.__load_pos = counter
+            return
+          end
+        end
+      end
+    end
+  end
+
   opts.__fn_reload = opts.__fn_reload or function(_)
     -- we do not return the populate function with cb directly to avoid
     -- E5560: nvim_exec must not be called in a lua loop callback


### PR DESCRIPTION
Hey, @ibhagwan , can we add the ability to position the cursor at the current window to the tabs provider?

Use fn_pre_fzf to set opts.__load_pos, and core.build_fzf_cli adds the action to fzf_opts["--bind"].
