### PR TITLE
fix(image): respect snacks image doc enabled property for inline render

### DIFF
--- a/lua/fzf-lua/previewer/builtin.lua
+++ b/lua/fzf-lua/previewer/builtin.lua
@@ -1014,7 +1014,7 @@ function Previewer.base:attach_snacks_image_inline()
   if not simg
       or not self.snacks_image.enabled
       or not simg.supports_terminal()
-      or not (simg.config.doc.inline and simg.terminal.env().placeholders)
+      or not (simg.config.doc.enabled and simg.config.doc.inline and simg.terminal.env().placeholders)
       or vim.b[bufnr].snacks_image_attached then
     return
   end


### PR DESCRIPTION
According to the Snacks Image documentation, the `enabled` property under `doc` enables/disables the rendering of images in document files, even if `inline` or `float` are set to `true`.

```lua
  doc = {
    -- enable image viewer for documents
    -- a treesitter parser must be available for the enabled languages.
    enabled = true,
    -- render the image inline in the buffer
    -- if your env doesn't support unicode placeholders, this will be disabled
    -- takes precedence over `opts.float` on supported terminals
    inline = true,
    -- render the image in a floating window
    -- only used if `opts.inline` is disabled
    float = true,
    max_width = 80,
    max_height = 40,
    -- Set to `true`, to conceal the image text when rendering inline.
    -- (experimental)
    ---@param lang string tree-sitter language
    ---@param type snacks.image.Type image type
    conceal = function(lang, type)
      -- only conceal math expressions
      return type == "math"
    end,
  },
```

After taking a look at the code here:
https://github.com/folke/snacks.nvim/blob/bc0630e43be5699bb94dadc302c0d21615421d93/lua/snacks/image/init.lua#L277

Snacks first checks if `doc` has `enabled` set to `true` and then proceeds to enable the document image rendering depending on the preference of `inline` or `float`.

I'm adding the condition in this PR to enable/disable the image image render in document files taking into consideration the config from Snacks.