### PR TITLE
feat(image): add option to control image inline render

### DIFF
--- a/README.md
+++ b/README.md
@@ -744,7 +744,7 @@ previewers = {
       -- render_markdown.nvim integration, enabled by default for markdown
       render_markdown = { enabled = true, filetypes = { ["markdown"] = true } },
       -- snacks.images integration, enabled by default
-      snacks_image = { enabled = true },
+      snacks_image = { enabled = true, render_inline = true },
     },
     -- Code Action previewers, default is "codeaction" (set via `lsp.code_actions.previewer`)
     -- "codeaction_native" uses fzf's native previewer, recommended when combined with git-delta

--- a/lua/fzf-lua/defaults.lua
+++ b/lua/fzf-lua/defaults.lua
@@ -218,7 +218,7 @@ M.defaults                      = {
       ueberzug_scaler   = "cover",
       title_fnamemodify = function(s) return path.tail(s) end,
       render_markdown   = { enabled = true, filetypes = { ["markdown"] = true } },
-      snacks_image      = { enabled = true },
+      snacks_image      = { enabled = true, render_inline = true },
       _ctor             = previewers.builtin.buffer_or_file,
     },
     codeaction = {

--- a/lua/fzf-lua/previewer/builtin.lua
+++ b/lua/fzf-lua/previewer/builtin.lua
@@ -1013,8 +1013,9 @@ function Previewer.base:attach_snacks_image_inline()
   local bufnr, preview_winid = self.preview_bufnr, self.win.preview_winid
   if not simg
       or not self.snacks_image.enabled
+      or not self.snacks_image.render_inline
       or not simg.supports_terminal()
-      or not (simg.config.doc.enabled and simg.config.doc.inline and simg.terminal.env().placeholders)
+      or not simg.terminal.env().placeholders
       or vim.b[bufnr].snacks_image_attached then
     return
   end


### PR DESCRIPTION
- Adds `render_inline` prop to control whether to do image inline render in fzf-lua builtin previewer or not.
- This options is added because as explained in https://github.com/ibhagwan/fzf-lua/issues/2064 if inline render is enabled in Snacks, fzf-lua is detecting this option and applying it to the previewer as well.
- Enables the user to control better customization having a separate option for the previewer.