### PR TITLE
feat(diagnostics): add options to color headings and show diag code

### DIFF
--- a/README.md
+++ b/README.md
@@ -1274,12 +1274,14 @@ previewers = {
   diagnostics ={
     prompt            = 'Diagnostics❯ ',
     cwd_only          = false,
-    file_icons        = true,
+    file_icons        = false,
     git_icons         = false,
-    diag_icons        = true,
+    color_headings    = true,   -- use diag highlights to color source & filepath
+    diag_icons        = true,   -- display icons from diag sign definitions
     diag_source       = true,   -- display diag source (e.g. [pycodestyle])
+    diag_code         = true,   -- display diag code (e.g. [undefined])
     icon_padding      = '',     -- add padding for wide diagnostics signs
-    multiline         = true,   -- concatenate multi-line diags into a single line
+    multiline         = 2,      -- split heading and diag to separate lines
     -- severity_only:   keep any matching exact severity
     -- severity_limit:  keep any equal or more severe (lower)
     -- severity_bound:  keep any equal or less severe (higher)

--- a/doc/fzf-lua.txt
+++ b/doc/fzf-lua.txt
@@ -1244,11 +1244,13 @@ CUSTOMIZATION                                          *fzf-lua-customization*
       },
       diagnostics ={
         prompt            = 'Diagnostics❯ ',
+        color_headings    = false,  -- display filename and source in diag color (e.g. orange for warnings)
         cwd_only          = false,
         file_icons        = true,
         git_icons         = false,
         diag_icons        = true,
-        diag_source       = true,   -- display diag source (e.g. [pycodestyle])
+        diag_source       = false,  -- display diag source (e.g. [pycodestyle])
+        diag_code         = false,  -- display diag code (e.g. [E011])
         icon_padding      = '',     -- add padding for wide diagnostics signs
         multiline         = true,   -- concatenate multi-line diags into a single line
         -- severity_only:   keep any matching exact severity

--- a/lua/fzf-lua/defaults.lua
+++ b/lua/fzf-lua/defaults.lua
@@ -970,19 +970,21 @@ M.defaults.lsp.code_actions     = {
 }
 
 M.defaults.diagnostics          = {
-  previewer   = M._default_previewer_fn,
-  file_icons  = 1,
-  color_icons = true,
-  git_icons   = false,
-  diag_icons  = true,
-  diag_source = false,
-  multiline   = 2,
-  fzf_opts    = {
+  previewer      = M._default_previewer_fn,
+  file_icons     = 1,
+  color_icons    = true,
+  color_headings = false,
+  git_icons      = false,
+  diag_icons     = true,
+  diag_source    = false,
+  diag_code      = false,
+  multiline      = 2,
+  fzf_opts       = {
     ["--multi"] = true,
     ["--wrap"]  = true,
   },
-  _actions    = function() return M.globals.actions.files end,
-  _cached_hls = { "path_colnr", "path_linenr" },
+  _actions       = function() return M.globals.actions.files end,
+  _cached_hls    = { "path_colnr", "path_linenr" },
   -- signs = {
   --   ["Error"] = { text = "e", texthl = "DiagnosticError" },
   --   ["Warn"]  = { text = "w", texthl = "DiagnosticWarn" },

--- a/lua/fzf-lua/defaults.lua
+++ b/lua/fzf-lua/defaults.lua
@@ -971,13 +971,13 @@ M.defaults.lsp.code_actions     = {
 
 M.defaults.diagnostics          = {
   previewer      = M._default_previewer_fn,
-  file_icons     = 1,
+  file_icons     = false,
   color_icons    = true,
-  color_headings = false,
+  color_headings = true,
   git_icons      = false,
   diag_icons     = true,
-  diag_source    = false,
-  diag_code      = false,
+  diag_source    = true,
+  diag_code      = true,
   multiline      = 2,
   fzf_opts       = {
     ["--multi"] = true,

--- a/lua/fzf-lua/providers/diagnostic.lua
+++ b/lua/fzf-lua/providers/diagnostic.lua
@@ -194,6 +194,13 @@ M.diagnostics = function(opts)
                 coroutine.resume(co)
                 return
               end
+
+              local sign_def = opts.__signs[diag.severity]
+
+              if opts.color_headings then
+                diag_entry.filename = utils.ansi_from_hl(sign_def.texthl, diag_entry.filename)
+              end
+
               local entry = make_entry.lcol(diag_entry, opts)
               entry = make_entry.file(entry, opts)
               if not entry then
@@ -201,22 +208,27 @@ M.diagnostics = function(opts)
                 coroutine.resume(co)
               else
                 local icon = nil
-                if opts.__signs[diag.severity] then
-                  local sign_def = opts.__signs[diag.severity]
+                if sign_def then
                   icon = sign_def.text
                   if opts.color_icons then
                     icon = utils.ansi_from_hl(sign_def.texthl, icon)
                   end
                 end
+
+                if opts.diag_code and diag.code then
+                  entry = entry .. utils.ansi_from_hl('Comment', ' [' .. diag.code .. ']')
+                end
+
                 entry = string.format("%s%s%s",
                   icon and string.format("%s%s%s", icon, opts.icon_padding or "", utils.nbsp)
                   or "",
-                  opts.diag_source and string.format(
-                    "%s%s%s%s",
-                    "[", --utils.ansi_codes.bold("["),
-                    diag.source,
-                    "]", --utils.ansi_codes.bold("]"),
-                    utils.nbsp)
+                  opts.diag_source and utils.ansi_from_hl(
+                    opts.color_headings and sign_def.texthl, string.format(
+                      "%s%s%s%s",
+                      "[", --utils.ansi_codes.bold("["),
+                      diag.source,
+                      "]", --utils.ansi_codes.bold("]"),
+                      utils.nbsp))
                   or "",
                   entry)
                 fzf_cb(entry, function() coroutine.resume(co) end)

--- a/lua/fzf-lua/providers/diagnostic.lua
+++ b/lua/fzf-lua/providers/diagnostic.lua
@@ -216,7 +216,7 @@ M.diagnostics = function(opts)
                 end
 
                 if opts.diag_code and diag.code then
-                  entry = entry .. utils.ansi_from_hl('Comment', ' [' .. diag.code .. ']')
+                  entry = entry .. utils.ansi_from_hl("Comment", " [" .. diag.code .. "]")
                 end
 
                 entry = string.format("%s%s%s",


### PR DESCRIPTION
This implements the changes discussed in https://github.com/ibhagwan/fzf-lua/issues/2067:

- Highlight the file headers with the diagnostic color (warnings = orange etc.)
- Append the diagnostic code to the message if present

Both are disabled by default and can be enabled with the `color_headings` and `diag_code` options.