### PR TITLE
feat(commands): include subcommands

### DIFF
--- a/lua/fzf-lua/defaults.lua
+++ b/lua/fzf-lua/defaults.lua
@@ -1045,6 +1045,7 @@ M.defaults.tagstack             = {
 
 M.defaults.commands             = {
   actions         = { ["enter"] = actions.ex_run },
+  flatten         = {},
   include_builtin = true,
 }
 

--- a/lua/fzf-lua/providers/nvim.lua
+++ b/lua/fzf-lua/providers/nvim.lua
@@ -63,13 +63,26 @@ M.commands = function(opts)
     end
   end
 
+  opts.flatten = opts.flatten or {}
   for k, _ in pairs(global_commands) do
     table.insert(entries, utils.ansi_codes.blue(k))
+    local flattened = vim.is_callable(opts.flatten[k]) and opts.flatten[k](opts)
+        or opts.flatten[k] and vim.fn.getcompletion(k .. " ", "cmdline")
+        or {}
+    vim.list_extend(entries,
+      vim.tbl_map(function(cmd) return utils.ansi_codes.blue(k .. " " .. cmd) end,
+        flattened))
   end
 
   for k, v in pairs(buf_commands) do
     if type(v) == "table" then
       table.insert(entries, utils.ansi_codes.green(k))
+      local flattened = vim.is_callable(opts.flatten[k]) and opts.flatten[k](opts)
+          or opts.flatten[k] and vim.fn.getcompletion(k .. " ", "cmdline")
+          or {}
+      vim.list_extend(entries,
+        vim.tbl_map(function(cmd) return utils.ansi_codes.green(k .. " " .. cmd) end,
+          flattened))
     end
   end
 


### PR DESCRIPTION
```lua
-- Save one more type
require('fzf-lua').commands({ flatten = { Gitsigns = true } })

-- Discovery (all commands)
require('fzf-lua').commands({ flatten = vim.api.nvim_get_commands {} })

-- Customization
require('fzf-lua').commands({ flatten = { Foo = function(opts) return { 'Bar', 'Baz --abc' } end } })
```
![image](https://github.com/user-attachments/assets/59af9726-92ae-4054-899c-87a0a0401fe7)
