### PR TITLE
Load content from dap server

### DIFF
--- a/lua/fzf-lua/previewer/builtin.lua
+++ b/lua/fzf-lua/previewer/builtin.lua
@@ -891,6 +891,8 @@ function Previewer.buffer_or_file:populate_preview_buf(entry_str)
       local lines = nil
       if entry.path:match("^%[DEBUG]") then
         lines = { tostring(entry.path:gsub("^%[DEBUG]", "")) }
+      elseif entry.content then
+        lines = entry.content
       else
         -- make sure the file is readable (or bad entry.path)
         local fs_stat = entry.fs_stat or uv.fs_stat(entry.path)

--- a/lua/fzf-lua/types.lua
+++ b/lua/fzf-lua/types.lua
@@ -47,6 +47,7 @@
 ---@field fs_stat uv.fs_stat.result?
 ---@field no_syntax boolean?
 ---@field cached fzf-lua.buffer_or_file.Bcache?
+---@field content string[]?
 
 ---@class fzf-lua.buffer_or_file.Bcache
 ---@field bufnr integer


### PR DESCRIPTION
# Context: 

Some debuggers are _asynchronous_. It means that the debugging and the code execution doesn't happen at the same time. An example of this is [coredumpy](https://github.com/gaogaotiantian/coredumpy). In their implementation, the source code that triggered the error is saved in a dump file, which can be loaded later. This can even be loaded on a different machine/system. In this case, the files on the local filesystem are often ignored because they're not guaranteed to be the same as the source code which caused the error (or simply don't exist at all).

# What this PR does

This PR attempts to load the source code saved in the dump file (provided by the dap server). This enables frame previewing when working with a dump file from [coredumpy](https://github.com/gaogaotiantian/coredumpy) using [coredumpy.nvim](https://github.com/Davidyz/coredumpy.nvim).

Before:
![image](https://github.com/user-attachments/assets/b717bcf0-10f3-420a-a0fb-83bec34f4035)


After:
![image](https://github.com/user-attachments/assets/ec56c1a3-48e0-4947-9112-981702ae011c)

[This](https://microsoft.github.io/debug-adapter-protocol//specification.html#Requests_Source) is the dap `source` request used to fetch the source code from supported server.