### PR TITLE
perf: improve startup time by deferring config defaults

### DIFF
--- a/lua/fzf-lua/defaults.lua
+++ b/lua/fzf-lua/defaults.lua
@@ -190,11 +190,11 @@ M.defaults                      = {
     },
     man = {
       _ctor = previewers.builtin.man_pages,
-      cmd = M._man_cmd_fn(),
+      cmd = function() return M._man_cmd_fn() end,
     },
     man_native = {
       _ctor = previewers.fzf.man_pages,
-      cmd = M._man_cmd_fn(true),
+      cmd = function() return M._man_cmd_fn(true) end,
     },
     help_tags = {
       _ctor = previewers.builtin.help_tags,


### PR DESCRIPTION
This change wraps the function `_man_cmd_fn` which checks the system to find which man previewer is installed. This system check is expensive and does not need to be called until it is actually required. This reduces the startup time of fzf-lua. An example of the difference via [vim-startuptime](https://github.com/dstein64/vim-startuptime):

### Before:
```
event                  time percent
fzf-lua               41.34   42.38
fzf-lua.config        37.96   38.91
fzf-lua.defaults      37.57   38.51
```

### After:
```
event                  time percent
fzf-lua                3.29    5.66
fzf-lua.config         0.98    1.69
fzf-lua.path           0.67    1.15
fzf-lua.defaults       0.53    0.91
```

Relates: #970 