### PR TITLE
fix(actions): make `:tabnew | h xx | only` work with &splitkeep

### DIFF
--- a/lua/fzf-lua/actions.lua
+++ b/lua/fzf-lua/actions.lua
@@ -702,7 +702,9 @@ end
 M.help_tab = function(selected, opts)
   if #selected == 0 then return end
   -- vim.cmd("tab help " .. helptags(selected, opts)[1])
-  vim.cmd("tabnew | setlocal bufhidden=wipe | help " .. helptags(selected, opts)[1] .. " | only")
+  utils.with({ go = { splitkeep = "cursor" } }, function()
+    vim.cmd("tabnew | setlocal bufhidden=wipe | help " .. helptags(selected, opts)[1] .. " | only")
+  end)
 end
 
 local function mantags(s)
@@ -721,8 +723,9 @@ end
 
 M.man_tab = function(selected)
   if #selected == 0 then return end
-  -- vim.cmd("tab Man " .. mantags(selected)[1])
-  vim.cmd("tabnew | setlocal bufhidden=wipe | Man " .. mantags(selected)[1] .. " | only")
+  utils.with({ go = { splitkeep = "cursor" } }, function()
+    vim.cmd("tabnew | setlocal bufhidden=wipe | Man " .. mantags(selected)[1] .. " | only")
+  end)
 end
 
 M.git_switch = function(selected, opts)

--- a/lua/fzf-lua/utils.lua
+++ b/lua/fzf-lua/utils.lua
@@ -1073,6 +1073,14 @@ function M.zz()
   end
 end
 
+---@param context vim.context.mods
+function M.with(context, func)
+  if vim._with then
+    return vim._with(context, func)
+  end
+  return func()
+end
+
 ---@param func function
 ---@param scope string?
 ---@param win integer


### PR DESCRIPTION
`nvim --clean -u repro.lua`:
```lua
vim.o.scrolloff = math.ceil(vim.o.lines / 2)
vim.o.splitkeep = 'topline'
vim.cmd [[tabnew | help shada | only]]
```

Cursor won't focus on tags.

For fzf-lua not sure if this problem exist for old version.. since there's another bug [6a71239cd5ea2a8e993bddd8e7765d1afe3e79e4](https://github.com/phanen/neovim/commit/6a71239cd5ea2a8e993bddd8e7765d1afe3e79e4). And this just fix on 0.11 (which has `vim._with`) only.