### PR TITLE
fix(actions): `:hi` executed twice

### DIFF
--- a/lua/fzf-lua/actions.lua
+++ b/lua/fzf-lua/actions.lua
@@ -488,7 +488,7 @@ end
 M.hi = function(selected)
   if #selected == 0 then return end
   vim.cmd("hi " .. selected[1])
-  vim.api.nvim_exec2("hi " .. selected[1], {})
+  vim.cmd("echo")
 end
 
 M.run_builtin = function(selected)


### PR DESCRIPTION
Anyway I want to avoid show twice when enable `vim._extui`
