### PR TITLE
fix(call_hierarchy): Don't open fzf window with 1 result and `opts.jump1`

### DIFF
--- a/lua/fzf-lua/providers/lsp.lua
+++ b/lua/fzf-lua/providers/lsp.lua
@@ -171,12 +171,9 @@ local function call_hierarchy_handler(opts, cb, _, result, ctx, _)
         lnum = range.start.line + 1,
         col = range.start.character + 1,
       }
-      if opts.jump1 and #result == 1 then
-        jump_to_location(opts, location, encoding)
-      end
       local entry = make_entry.lcol(location, opts)
       entry = make_entry.file(entry, opts)
-      if entry then cb(entry) end
+      if entry then cb(entry, { result = location, encoding = encoding }) end
     end
   end
 end


### PR DESCRIPTION
With 1 result, the cursor will jump to the location but the fzf window also opens

Avoid opening the window by relying on the jump1 logic inside gen_lsp_contents()