### PR TITLE
feat: allow keymap to focus preview window

### DIFF
--- a/lua/fzf-lua/win.lua
+++ b/lua/fzf-lua/win.lua
@@ -119,6 +119,7 @@ local _preview_keymaps = {
   ["preview-reset"]          = { module = "win", fnc = "preview_scroll('reset')" },
   ["preview-top"]            = { module = "win", fnc = "preview_scroll('top')" },
   ["preview-bottom"]         = { module = "win", fnc = "preview_scroll('bottom')" },
+  ['focus-preview']          = { module = "win", fnc = "focus_preview()" },
 }
 
 function FzfWin:setup_keybinds()
@@ -1385,6 +1386,13 @@ function FzfWin.toggle_fullscreen()
   local self = _self
   self.fullscreen = not self.fullscreen
   self:redraw()
+end
+
+function FzfWin.focus_preview()
+  vim.brint('focus preview')
+  if not _self then return end
+  local self = _self
+  vim.api.nvim_set_current_win(self.preview_winid)
 end
 
 function FzfWin.toggle_preview()


### PR DESCRIPTION
Allow focusing the preview window, since there's already a keymap to focus the fzf input from the preview window.
