### PR TITLE
chore: remove stylua config

### DIFF
--- a/.stylua.toml
+++ b/.stylua.toml
@@ -1,7 +1,0 @@
-column_width = 100
-line_endings = "Unix"
-indent_type = "Spaces"
-indent_width = 2
-quote_style = "AutoPreferDouble"
-call_parentheses = "Always"
-collapse_simple_statement = "Never"


### PR DESCRIPTION
It's pretty confusing that we have a stylua config file when we don't use stylua for formatting at all. So removing it here.
