### PR TITLE
fix(picker): file picker not respecting .gitignore

### DIFF
--- a/lua/fzf-lua/defaults.lua
+++ b/lua/fzf-lua/defaults.lua
@@ -349,7 +349,7 @@ M.defaults.files                = {
     "git", "-c", "color.status=false", "--no-optional-locks", "status", "--porcelain=v1" },
   find_opts              = [[-type f \! -path '*/.git/*']],
   rg_opts                = [[--color=never --files -g "!.git"]],
-  fd_opts                = [[--color=never --type f --type l --exclude .git]],
+  fd_opts                = [[--color=never --type f --type l --exclude .git --no-require-git]],
   dir_opts               = [[/s/b/a:-d]],
   hidden                 = true,
   toggle_ignore_flag     = "--no-ignore",


### PR DESCRIPTION
By default `fd` only respects global or local gitignore rules if searching inside a git repository. However in certain scenarios, e.g. when using [jujutsu](https://github.com/jj-vcs/jj) instead of git, this approach never takes effect since it can't find a .git directory in cwd.

The proposed `--no-require-git` flag allows `fd` to respect all git related ignore rules, regardless of whether it's searching inside a git repo or not.

I think it's safe to include this flag in default cmd.