### PR TITLE
fix: `utils.setup_highlights` to not always override colorscheme hl groups

### DIFF
--- a/lua/fzf-lua/utils.lua
+++ b/lua/fzf-lua/utils.lua
@@ -858,8 +858,9 @@ M.resume_set = function(what, val, opts)
   return require("fzf-lua").config.resume_set(what, val, opts)
 end
 
+---@param override? boolean
 function M.setup_highlights(override)
-  pcall(require("fzf-lua").setup_highlights, override and "true" or "")
+  pcall(require("fzf-lua").setup_highlights, override)
 end
 
 ---@param fname string


### PR DESCRIPTION
Fixing https://github.com/ibhagwan/fzf-lua/issues/2196 bug introduced in https://github.com/ibhagwan/fzf-lua/commit/a9803618d77bd024d97de75cf5878819d4d6a2d0#diff-6610b6cdb84f62055c6687508d2346e099b304fe0095ff33b8fed55474cd77aaR848