### PR TITLE
fix: #2209 and improve builtin previewer scrolling

### DIFF
--- a/lua/fzf-lua/defaults.lua
+++ b/lua/fzf-lua/defaults.lua
@@ -84,8 +84,7 @@ M.defaults                      = {
         list           = false,
         foldenable     = false,
         foldmethod     = "manual",
-        -- >0 to prevent scrolling issues (#500)
-        scrolloff      = 1,
+        scrolloff      = 0,
       },
     },
     -- on_create  = function(_)

--- a/lua/fzf-lua/previewer/builtin.lua
+++ b/lua/fzf-lua/previewer/builtin.lua
@@ -509,16 +509,9 @@ function Previewer.base:scroll(direction)
     ["half-page-down"] = ("%c"):format(0x04), -- [[]]
     ["page-up"]        = ("%c"):format(0x02), -- [[]]
     ["page-down"]      = ("%c"):format(0x06), -- [[]]
-    -- ^Y/^E doesn't seem to work, "Mgk" also doesn't (#2111)
-    -- TODO: Can't scroll above line 2?
-    ["line-up"]        = (function()
-      local wi = utils.getwininfo(preview_winid)
-      return wi.topline <= 2 and "gg" or function()
-        api.nvim_win_set_cursor(0, { wi.topline, 1 })
-        vim.cmd("norm! gk")
-      end
-    end)(),
-    ["line-down"]      = "Mgj",
+    -- ^Y/^E doesn't seem to work
+    ["line-up"]        = "Hgk",
+    ["line-down"]      = "Lgj",
     ["reset"]          = true, -- dummy for exit condition
   })[direction]
 
@@ -536,11 +529,7 @@ function Previewer.base:scroll(direction)
     end)
   else
     pcall(vim.api.nvim_win_call, preview_winid, function()
-      if type(input) == "function" then
-        input()
-      else
-        vim.cmd([[norm! ]] .. input)
-      end
+      vim.cmd([[norm! ]] .. input)
       -- `zb` at bottom?
       local wi = utils.getwininfo(preview_winid)
       if wi.height > (wi.botline - wi.topline) then


### PR DESCRIPTION
fix #2209. I couldn't reproduce #500 as ` vim.api.nvim_win_set_cursor(preview_winid, self.orig_pos)` is no longer run when scrolling, but only when `direction` is `"reset"`. also why not just use `Hgk` and `Lgj` for `line-up` and `line-down`? it works fine for what I tested.