### PR TITLE
refactor: always setlocal on window options

### DIFF
--- a/lua/fzf-lua/actions.lua
+++ b/lua/fzf-lua/actions.lua
@@ -201,9 +201,7 @@ M.vimcmd_entry = function(_vimcmd, selected, opts, pcall_vimcmd)
           return
         end
       end
-      if will_replace_curbuf
-          and vim.fn.exists("&winfixbuf") == 1
-          and vim.wo.winfixbuf
+      if will_replace_curbuf and utils.wo.winfixbuf
       then
         utils.warn("'winfixbuf' is set for current window, will open in a split.")
         vimcmd = "split | " .. vimcmd

--- a/lua/fzf-lua/previewer/builtin.lua
+++ b/lua/fzf-lua/previewer/builtin.lua
@@ -107,9 +107,7 @@ function TSContext.update(winid, bufnr, opts)
           if win and api.nvim_win_is_valid(win) and api.nvim_win_get_config(win).zindex ~= zindex then
             api.nvim_win_set_config(win, { zindex = zindex })
             -- noautocmd don't ignore WinResized/WinScrolled
-            if fn.exists("+eventignorewin") == 1 and vim.wo[win][0].eventignorewin == "" then
-              vim.wo[win][0].eventignorewin = "WinResized"
-            end
+            utils.wo[win].eventignorewin = "WinResized"
           end
         end
         api.nvim_win_call(winid, function()
@@ -1053,11 +1051,11 @@ function Previewer.base:attach_snacks_image_inline()
   if not ft then return end
   _G._fzf_lua_snacks_langs = _G._fzf_lua_snacks_langs or simg.langs()
   if not vim.tbl_contains(_G._fzf_lua_snacks_langs, vim.treesitter.language.get_lang(ft)) then
-    vim.wo[preview_winid].winblend = self.winblend
+    utils.wo[preview_winid].winblend = self.winblend
     return
   end
 
-  vim.wo[preview_winid].winblend = 0 -- https://github.com/folke/snacks.nvim/pull/1615
+  utils.wo[preview_winid].winblend = 0 -- https://github.com/folke/snacks.nvim/pull/1615
   vim.b[bufnr].snacks_image_attached = simg.inline.new(bufnr)
   vim.defer_fn(function()
     self.win:update_preview_scrollbar()
@@ -1121,7 +1119,7 @@ function Previewer.buffer_or_file:do_syntax(entry)
     -- nvim_buf_call has less side-effects than window switch
     -- doautocmd filetypedetect BufRead (vim.filetype.match + ftdetect) + do_modeline
     local ok, _ = pcall(api.nvim_buf_call, bufnr, function()
-      utils.eventignore(function() vim.cmd("filetype detect") end, preview_winid, "FileType")
+      utils.eventignore(function() vim.cmd("filetype detect") end, "FileType")
     end)
     if not ok then
       utils.warn(("':filetype detect' failed for '%s'"):format(entry.path or "<null>"))
@@ -1172,9 +1170,7 @@ function Previewer.base:maybe_set_cursorline(win, pos)
     vim.api.nvim_win_set_cursor(win, pos)
     cursorline = self.winopts.cursorline
   end
-  if cursorline ~= vim.wo[win].cursorline then
-    vim.wo[win].cursorline = cursorline
-  end
+  utils.wo[win].cursorline = cursorline
 end
 
 function Previewer.buffer_or_file:set_cursor_hl(entry)
@@ -1211,7 +1207,7 @@ function Previewer.buffer_or_file:set_cursor_hl(entry)
     local lnum, col = tonumber(entry.line), tonumber(entry.col) or 0
     if not lnum or lnum < 1 then
       -- set win option is slow with bigfile
-      if vim.wo.cursorline then vim.wo.cursorline = false end
+      utils.wo.cursorline = false
       self.orig_pos = { 1, 0 }
       api.nvim_win_set_cursor(self.win.preview_winid, cached_pos or self.orig_pos)
       return

--- a/lua/fzf-lua/providers/nvim.lua
+++ b/lua/fzf-lua/providers/nvim.lua
@@ -529,7 +529,6 @@ M.nvim_options = function(opts)
 end
 
 M.spell_suggest = function(opts)
-  -- if not vim.wo.spell then return false end
   ---@type fzf-lua.config.SpellSuggest
   opts = config.normalize_opts(opts, "spell_suggest")
   if not opts then return end

--- a/lua/fzf-lua/types.lua
+++ b/lua/fzf-lua/types.lua
@@ -279,8 +279,8 @@ _G.FzfLua = require("fzf-lua")
 ---@field scrolloff? integer
 
 ---@class fzf-lua.config.Keymap
----@field builtin table<string, string>
----@field fzf table<string, string>
+---@field builtin? table<string, string>
+---@field fzf? table<string, string>
 
 ---@class fzf-lua.config.Previewer
 ---@field cmd string|fun():string?

--- a/lua/fzf-lua/win.lua
+++ b/lua/fzf-lua/win.lua
@@ -519,13 +519,16 @@ end
 function FzfWin:reset_win_highlights(win)
   -- derive the highlights from the window type
   local key = "main"
+  local hl
   if win == self.preview_winid then
     key = "prev"
+    hl = self._previewer:gen_winopts().winhl
   end
-  local hl
-  for _, h in ipairs(self.winopts.__winhls[key]) do
-    if h[2] then
-      hl = string.format("%s%s:%s", hl and hl .. "," or "", h[1], h[2])
+  if not hl then
+    for _, h in ipairs(self.winopts.__winhls[key]) do
+      if h[2] then
+        hl = string.format("%s%s:%s", hl and hl .. "," or "", h[1], h[2])
+      end
     end
   end
   utils.wo[win].winhl = hl

--- a/tests/utils_spec.lua
+++ b/tests/utils_spec.lua
@@ -89,4 +89,16 @@ describe("Testing utils module", function()
     collectgarbage("collect")
     assert.are.same(gc_called, true)
   end)
+
+  it("wo", function()
+    utils.wo.nonexist = "this is nop"
+    assert.are.same(nil, utils.wo.nonexist)
+    vim.wo[0][0].nu = true -- setlocal
+    vim.wo[0].rnu = true   -- setglobal
+    assert.are.same(vim.wo[0][0].nu, vim.wo.nu)
+    assert.are.same(vim.wo[0][0].rnu, vim.wo.rnu)
+    vim.cmd.new()
+    assert.are.same(vim.wo[0][0].nu, vim.wo.nu)
+    assert.are.same(vim.wo[0][0].rnu, vim.wo.rnu)
+  end)
 end)


### PR DESCRIPTION
- **refactor: always setlocal on window options**
  * chore: remove useless autocmd
  * refactor: move logic to win:resized, win:save_size
  * refactor: simplify utils.eventignore
- **fix(previewer): prefer winopts.winhl (useful with non-float window as previewer)**
