### PR TITLE
fix: correctly handle URIs without `//` after scheme

### DIFF
--- a/lua/fzf-lua/providers/lsp.lua
+++ b/lua/fzf-lua/providers/lsp.lua
@@ -93,7 +93,7 @@ local function location_handler(opts, cb, _, result, ctx, _)
   -- HACK: make sure target URI is valid for buggy LSPs (#1317)
   for i, x in ipairs(result) do
     for _, k in ipairs({ "uri", "targetUri" }) do
-      if type(x[k]) == "string" and not x[k]:match("://") then
+      if type(x[k]) == "string" and not x[k]:match("^([a-zA-Z]+[a-zA-Z0-9.+-]*):.*") then
         result[i][k] = "file://" .. result[i][k]
       end
     end


### PR DESCRIPTION
Fixes #2278 