### PR TITLE
fix(config): pass `silent` to lsp provider

### DIFF
--- a/lua/fzf-lua/providers/lsp.lua
+++ b/lua/fzf-lua/providers/lsp.lua
@@ -895,7 +895,7 @@ local function wrap_fn(key, fn)
     opts.lsp_handler.capability = opts.lsp_handler.server_capability
 
     -- check_capabilities will print the appropriate warning
-    if not check_capabilities(opts.lsp_handler) then
+    if not check_capabilities(opts.lsp_handler, opts.silent) then
       return
     end
 


### PR DESCRIPTION
for `Global` picker:

i want to write like:
```lua
pickers = {
    { "frecency", desc = "Files" },
    { "buffers", desc = "Bufs", prefix = "$" },
    { "lsp_document_symbols", desc = "Symbols (buf)", prefix = "@", { silent = true } },
    { "lsp_workspace_symbols", desc = "Symbols (project)", prefix = "#", { silent = true } },
},
```
but `silent` peremeter seems useless when i passing, so i passed here.

i don't know if this "not pass `opts.silent`" is designed.