### PR TITLE
fix(previewer): re-detect filetype on poor filetype

### DIFF
--- a/lua/fzf-lua/types.lua
+++ b/lua/fzf-lua/types.lua
@@ -67,6 +67,7 @@ _G.FzfLua = require("fzf-lua")
 ---@field no_syntax boolean?
 ---@field cached fzf-lua.buffer_or_file.Bcache?
 ---@field content string[]?
+---@field filetype string?
 
 ---@class fzf-lua.keymap.Entry
 ---@field vmap string?


### PR DESCRIPTION
Example: `/path/to/xx.txt` with modeline in it saying it's `cmake`.
