### PR TITLE
traceback

### DIFF
--- a/lua/fzf-lua/providers/grep.lua
+++ b/lua/fzf-lua/providers/grep.lua
@@ -309,10 +309,14 @@ M.live_grep = function(opts)
     local query = s[1] or ""
     opts.no_esc = nil
     local cmd0 = get_grep_cmd(opts, query, true)
-    return core.can_transform(opts) and
-        ("reload:" .. (
-          not opts.exec_empty_query and #query == 0 and FzfLua.utils.shell_nop() or cmd0))
-        or cmd0
+    if not core.can_transform(opts) then return cmd0 end
+    -- "reload:cmd"
+    if not opts.exec_empty_query and #query == 0 then
+      cmd0 = FzfLua.utils.shell_nop()
+    elseif opts.silent_fail ~= false then
+      cmd0 = cmd0 .. " || " .. FzfLua.utils.shell_nop()
+    end
+    return "reload:" .. cmd0
   end, opts)
 end
 

--- a/lua/fzf-lua/shell.lua
+++ b/lua/fzf-lua/shell.lua
@@ -428,14 +428,14 @@ M.stringify = function(contents, opts, fzf_field_index)
         return on_write(data, cb)
       end
 
-      local ok, err = pcall(function()
+      local ok, err = xpcall(function()
         if type(contents) == "table" then
           vim.tbl_map(function(x) on_write_nl(x) end, contents)
           on_finish()
         elseif type(contents) == "function" then
           contents(on_write_nl, on_write, unpack(args))
         end
-      end)
+      end, debug.traceback)
       if not ok and err then
         on_finish()
         error(err)

--- a/lua/fzf-lua/types.lua
+++ b/lua/fzf-lua/types.lua
@@ -164,6 +164,7 @@ _G.FzfLua = require("fzf-lua")
 ---@field no_resume boolean?
 ---@field profile string|table?
 ---@field fn_reload boolean? is "live" picker
+---@field silent_fail boolean?
 ---set_headers
 ---@field _headers string[]?
 ---@field headers string[]?


### PR DESCRIPTION
- **fix(live_grep_st): slient_fail need to be apply again if we transform the cmd**
- **fix: reuse xpcall to get full traceback**


Now I know why it used to be xpcall, since pcall truncated traceback...
https://www.lua.org/pil/8.5.html
