### PR TITLE
fix: missing M for alt in conv_map

### DIFF
--- a/lua/fzf-lua/utils.lua
+++ b/lua/fzf-lua/utils.lua
@@ -1326,6 +1326,7 @@ end
 function M.neovim_bind_to_fzf(key)
   local conv_map = {
     ["a"] = "alt",
+    ["m"] = "alt",
     ["c"] = "ctrl",
     ["s"] = "shift",
   }


### PR DESCRIPTION
Many people use `<M-` in Neovim instead of `<A-`, and this PR ads support for that, solving [this issue](https://github.com/ibhagwan/fzf-lua/discussions/2290#discussioncomment-14264048).