### PR TITLE
fix(actions): switch to correct buffer window on special set buf autocmd

### DIFF
--- a/lua/fzf-lua/actions.lua
+++ b/lua/fzf-lua/actions.lua
@@ -215,10 +215,10 @@ M.vimcmd_entry = function(_vimcmd, selected, opts)
             then
               vim.bo.bufhidden = "wipe"
             end
-            -- NOTE: nvim_win_set_buf will load the buffer if needed
+            -- NOTE: nvim_set_current_buf will load the buffer if needed
             -- calling bufload will mess up `BufReadPost` autocmds
             -- vim.fn.bufload(bufnr)
-            local ok, _ = pcall(vim.api.nvim_win_set_buf, 0, bufnr)
+            local ok, _ = pcall(vim.api.nvim_set_current_buf, bufnr)
             -- When `:set nohidden && set confirm`, neovim will invoke the save dialog
             -- and confirm with the user when trying to switch from a dirty buffer, if
             -- user cancelles the save dialog pcall will fail with:


### PR DESCRIPTION
Hi @ibhagwan,

I encountered an edge case where if vim.api.nvim_win_set_buf results in autocmd that eventually decides to open the buffer elsewhere, the current window is switched back to the place where it was, I don't know if that's a neovim bug or something that is by design, here is my attempt to fix this by checking whether the current window contains the buffer, and if not - switch to the window where the buffer is.

The use case for such autocmd to decide to open the buffer elsewhere is for example if the buffer is about to open in like a file explorer or something. The winfixbuf doesnt resolve this nicely, this is what I am doing:

https://github.com/eyalz800/nvim.lua/blob/main/lua/plugins/pin.lua

What happens is that nvim_win_set_buf triggers my open_in_best_win function which opens the buffer in a different window and sets as current window, but somehow nvim_win_set_buf by fzf-lua returns with the current window being the previous window.

I hope you can review and accept/suggest a different fix.

Thank you for this awesome plugin!
