### PR TITLE
fix: git_bcommits silently fails if file name matches tag

### DIFF
--- a/lua/fzf-lua/defaults.lua
+++ b/lua/fzf-lua/defaults.lua
@@ -505,7 +505,7 @@ M.defaults.git                   = {
   },
   bcommits = {
     cmd           = [[git log --color --pretty=format:"%C(yellow)%h%Creset ]]
-        .. [[%Cgreen(%><(12)%cr%><|(12))%Creset %s %C(blue)<%an>%Creset" {file}]],
+        .. [[%Cgreen(%><(12)%cr%><|(12))%Creset %s %C(blue)<%an>%Creset" -- {file}]],
     preview       = "git show --color {1} -- {file}",
     preview_pager = M._preview_pager_fn,
     actions       = {


### PR DESCRIPTION
Hello, 

In my repository I have some git tags that are matching filenames from the same repo, e.g.

I have file `docs/my.txt` and a tag `docs/my.txt`.

When running `:FzfLua git_bcommits` with `docs/my.txt` opened - the picker window has no content and no warning is shown.

It's happening because git log fails with a following error

```sh
git log docs/my.txt
fatal: ambiguous argument 'docs/my.txt': both revision and filename
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
```

Adding `--` before filename, as suggested, solves the issue.

PS: currently I've fixed this by fixing `cmd` in plugin config, but I believe generic fix would be beneficial for plugin's users.