### PR TITLE
refactor: rg_opts add default --trim

### DIFF
--- a/lua/fzf-lua/defaults.lua
+++ b/lua/fzf-lua/defaults.lua
@@ -605,7 +605,7 @@ M.defaults.grep                  = {
       .. "--extended-regexp -e"
       or "--binary-files=without-match --line-number --recursive --color=always "
       .. "--perl-regexp -e",
-  rg_opts        = "--column --line-number --no-heading --color=always --smart-case "
+  rg_opts        = "--trim --column --line-number --no-heading --color=always --smart-case "
       .. "--max-columns=4096 -e",
   rg_glob        = 1, -- do not display warning if using `grep`
   _actions       = function() return M.globals.actions.files end,


### PR DESCRIPTION
## Changes

Adding `--trim` option by default to the grep picker for `ripgrep`

## Why

This is a personal style change which I think would be a sane default, there was already an issue opened regarding this https://github.com/ibhagwan/fzf-lua/issues/971

Also, I don't see any negatives with having this option, the readability only improves as you can actually see what you matched in the fzf list, otherwise you can opt out with `--no-trim`

<details>
<summary>Before</summary>

<img width="1626" height="896" alt="image" src="https://github.com/user-attachments/assets/d38af7bd-2097-44c2-b04a-25465746a53b" />


</details>

<details>
<summary>After</summary>

<img width="1682" height="674" alt="image" src="https://github.com/user-attachments/assets/cae03dc6-2b4d-49ff-983e-37b8854e266c" />


</details>

But as this is a personal "feelings" change feel free to close the PR