### PR TITLE
Add `~` to the list of very magic special characters

### DIFF
--- a/lua/fzf-lua/utils.lua
+++ b/lua/fzf-lua/utils.lua
@@ -223,8 +223,8 @@ end
 
 function M.regex_to_magic(str)
   -- Convert regex to "very magic" pattern, basically a regex
-  -- with special meaning for "%=&<>", `:help /magic`
-  return [[\v]] .. str:gsub("[%%=&@<>]", function(x)
+  -- with special meaning for "%=&<>~", `:help /magic`
+  return [[\v]] .. str:gsub("[%%=&@<>~]", function(x)
     return "\\" .. x
   end)
 end


### PR DESCRIPTION
If you search for any pattern containing `~` then you get this error when using `live_grep`:
```
[Fzf-lua] Unable to init vim.regex with "\v~", couldn't parse regex: Vim:E867: (NFA) Unknown operator '\~. . Add 'silent=true' to hide this message.
```

This change adds `~` to the list of characters that need to be escaped when converting the regex back to a very magic vim regex.

Similar PR: https://github.com/ibhagwan/fzf-lua/pull/2270