### PR TITLE
fix(marks): Use correct condition for marks filter

### DIFF
--- a/lua/fzf-lua/providers/nvim.lua
+++ b/lua/fzf-lua/providers/nvim.lua
@@ -254,7 +254,7 @@ M.marks = function(opts)
     local buf = utils.CTX().bufnr
     local entries = {}
     local function add_mark(mark, line, col, text)
-      if opts.marks and string.match(mark, opts.marks) then return end
+      if opts.marks and not string.match(mark, opts.marks) then return end
       table.insert(entries, string.format("%s  %s  %s %s",
         utils.ansi_codes[opts.hls.buf_nr](string.format("%4s", mark)),
         utils.ansi_codes[opts.hls.path_linenr](string.format("%4s", tostring(line))),


### PR DESCRIPTION
Commit 4cb7d7c614a55d55dcc175c2457b7be0cbbdecec inverted the behavior of `marks.marks` filtering.