### PR TITLE
feat: Replace local buf global mark output with highlighted text

### DIFF
--- a/lua/fzf-lua/providers/nvim.lua
+++ b/lua/fzf-lua/providers/nvim.lua
@@ -271,12 +271,17 @@ M.marks = function(opts)
 
     -- global marks
     for _, m in ipairs(vim.fn.getmarklist()) do
-      local mark, lnum, col, file = m.mark:sub(2, 2), m.pos[2], m.pos[3], m.file
+      local mark, bufnr, lnum, col, file = m.mark:sub(2, 2), m.pos[1], m.pos[2], m.pos[3], m.file
       file = path.relative_to(file, uv.cwd())
       if path.is_absolute(file) then
         file = path.HOME_to_tilde(file)
       end
-      add_mark(mark, lnum, col, file or "-invalid-")
+      if bufnr == utils.CTX().bufnr then
+        local text = vim.api.nvim_buf_get_lines(bufnr, lnum - 1, lnum, false)[1]
+        add_mark(mark, lnum, col, utils.ansi_from_hl("Directory", text or "-invalid-"))
+      else
+        add_mark(mark, lnum, col, file or "-invalid-")
+      end
     end
 
     if opts.sort then


### PR DESCRIPTION
Commit 4cb7d7c614a55d55dcc175c2457b7be0cbbdecec didn't fully address the github issue

Addresses #2353

It looks like this now:
<img width="876" height="317" alt="Screenshot From 2025-09-23 20-10-29" src="https://github.com/user-attachments/assets/599e27cd-2fe6-4101-b48b-2648c4b65781" />
