### PR TITLE
fix(preview): swallow warning for missing ts parsers

### DIFF
--- a/lua/fzf-lua/utils.lua
+++ b/lua/fzf-lua/utils.lua
@@ -1474,7 +1474,7 @@ function M.has_ts_parser(lang, query_name)
   -- ensure the language has a highlights parser or we get
   -- no highlights for langugaes like json/jsonc/toml/etc
   return (M.__HAS_NVIM_011 and vim.treesitter.language.add(lang)
-        or (pcall(vim.treesitter.language.add, lang)))
+        or (not M.__HAS_NVIM_011 and pcall(vim.treesitter.language.add, lang)))
       and #vim.treesitter.query.get_files(lang, query_name) > 0 or false
 end
 


### PR DESCRIPTION
This [commit](https://github.com/ibhagwan/fzf-lua/commit/464bab1fe59c4b92f3a19eda86b1d8536f40d8ad#diff-6610b6cdb84f62055c6687508d2346e099b304fe0095ff33b8fed55474cd77aaR1473) introduced a regression in nvim 0.11+. If a treesitter parser isn't installed, it shows a warning. The functionality before this commit, was to swallow the warning and highlight the buffer with whatever colors it could, if any at all.


This PR aims to restore the original functionality, without affecting older neovim versions.

An example of a warning is shown below:

<img width="855" height="1073" alt="image" src="https://github.com/user-attachments/assets/0bc183f1-1517-4b69-9d89-ae698d7602bd" />
