### PR TITLE
Add action that avoids splitting when opening help

### DIFF
--- a/lua/fzf-lua/actions.lua
+++ b/lua/fzf-lua/actions.lua
@@ -758,6 +758,29 @@ M.help = function(selected, opts)
   vim.cmd("help " .. helptags(selected, opts)[1])
 end
 
+M.help_curwin = function(selected, opts)
+  if #selected == 0 then return end
+  local helpcmd
+  local is_shown = false
+  local current_win_number = 1
+  local last_win_number = vim.fn.winnr("$")
+  while current_win_number <= last_win_number do
+    local buffer = vim.api.nvim_win_get_buf(vim.fn.win_getid(current_win_number))
+    local type = vim.api.nvim_get_option_value("buftype", { buf = buffer })
+    if type == "help" then
+      is_shown = true
+      break
+    end
+    current_win_number = current_win_number + 1
+  end
+  if is_shown then
+    helpcmd = "help "
+  else
+    helpcmd = "enew | setlocal bufhidden=wipe | setlocal buftype=help | keepjumps help "
+  end
+  vim.cmd(helpcmd .. helptags(selected, opts)[1])
+end
+
 M.help_vert = function(selected, opts)
   if #selected == 0 then return end
   vim.cmd("vert help " .. helptags(selected, opts)[1])

--- a/lua/fzf-lua/config.lua
+++ b/lua/fzf-lua/config.lua
@@ -1072,6 +1072,7 @@ M._action_to_helpstr = {
   [actions.help]                 = "help-open",
   [actions.help_vert]            = "help-vertical",
   [actions.help_tab]             = "help-tab",
+  [actions.help_curwin]          = "help-open-curwin",
   [actions.man]                  = "man-open",
   [actions.man_vert]             = "man-vertical",
   [actions.man_tab]              = "man-tab",


### PR DESCRIPTION
I've been using this patch for a while, and as suggested [here](https://github.com/ibhagwan/fzf-lua/discussions/1268) created a new action, so the default behaviour is not changed