### PR TITLE
git branch: change default picker list

### DIFF
--- a/lua/fzf-lua/defaults.lua
+++ b/lua/fzf-lua/defaults.lua
@@ -536,7 +536,8 @@ M.defaults.git                   = {
     _treesitter   = function(line) return line:match("(%s+)(%d+)%)(.+)$") end,
   },
   branches = {
-    cmd        = "git branch --all --color",
+    cmd        = [[git branch --all --color -vv ]]
+        .. [[--sort=-'committerdate' --sort='refname:rstrip=-2' --sort=-'HEAD']],
     preview    = "git log --graph --pretty=oneline --abbrev-commit --color {1}",
     remotes    = "local",
     actions    = {

--- a/lua/fzf-lua/providers/git.lua
+++ b/lua/fzf-lua/providers/git.lua
@@ -184,12 +184,14 @@ M.branches = function(opts)
   if opts.preview then
     local preview = path.git_cwd(opts.preview, opts)
     opts.preview = shell.stringify_cmd(function(items)
-      -- all possible options:
+      -- The beginning of the selected line looks like the below,
+      -- but we only want the string containing the branch name,
+      -- so match the first sequence not including spaces:
       --   branch
       -- * branch
       --   remotes/origin/branch
       --   (HEAD detached at origin/branch)
-      local branch = items[1]:match("[^%s%*]*$"):gsub("%)$", "")
+      local branch = items[1]:match("^[%*+]*[%s]*[(]?([^%s)]+)")
       return (preview:gsub("{.*}", branch))
     end, opts, "{}")
   end


### PR DESCRIPTION
Hi!

Not sure if you'd be interested to change the default git branch picker list display format? I have changed my personal default and I prefer it. It's not enormously different from the current default but it might make the out-of-box behaviour a bit better?

This MR contains my current config, if you're interested I can tidy it up / change it for merging.

As it stands now, this would add a dependency on `column`, not sure if git can arrange the columns as nicely like `column` does, I think I could at least set unchanging column widths.

The picker list is organised by current branch first, then local branches ordered by most recently changed to least recently changed, then remote branches listed in the same order. And the relative date is also added in the list. I've added the commit hash too because without it fzf-lua's current parsing of the selected picker option doesn't work, so the preview for the git branch doesn't work. If this MR is accepted I can probably change fzf-lua's parsing of the list so the git commit hash isn't required.

**Before:**

<img src="https://github.com/user-attachments/assets/caff900a-d215-4796-9432-68c3a4d59dd3" />

**After:**

<img src="https://github.com/user-attachments/assets/f62d813b-676b-490d-9abc-770716c4b426" />

