### PR TITLE
fix(highlights): parse highlight group in action

### DIFF
--- a/lua/fzf-lua/actions.lua
+++ b/lua/fzf-lua/actions.lua
@@ -530,7 +530,8 @@ end
 
 M.hi = function(selected)
   if #selected == 0 then return end
-  vim.cmd("hi " .. selected[1])
+  local hl = selected[1]:match("^[^%s]+")
+  vim.cmd("hi " .. hl)
   vim.cmd("echo")
 end
 


### PR DESCRIPTION
Since https://github.com/ibhagwan/fzf-lua/commit/d7f9cf4f4b849c7b70eb415271aa3905dc9e3aef selecting an item from the highlights picker results in:
```
vim.schedule callback: ...ano/.local/share/nvim/lazy/fzf-lua/lua/fzf-lua/shell.lua:430: vim/_editor.lua:0: nvim_exec2(), line 1: Vim(highlight):E416: Missing equal sign: xxx guifg=#3b4048
stack traceback:
	[C]: in function 'nvim_exec2'
	vim/_editor.lua: in function 'cmd'
	...o/.local/share/nvim/lazy/fzf-lua/lua/fzf-lua/actions.lua:533: in function 'fn'
	...al/share/nvim/lazy/fzf-lua/lua/fzf-lua/profiles/hide.lua:69: in function 'fn'
	...ano/.local/share/nvim/lazy/fzf-lua/lua/fzf-lua/shell.lua:463: in function 'contents'
	...ano/.local/share/nvim/lazy/fzf-lua/lua/fzf-lua/shell.lua:425: in function <...ano/.local/share/nvim/lazy/fzf-lua/lua/fzf-lua/shell.lua:420>
	[C]: in function 'xpcall'
	...ano/.local/share/nvim/lazy/fzf-lua/lua/fzf-lua/shell.lua:420: in function 'fn'
	...ano/.local/share/nvim/lazy/fzf-lua/lua/fzf-lua/shell.lua:143: in function <...ano/.local/share/nvim/lazy/fzf-lua/lua/fzf-lua/shell.lua:142>
stack traceback:
	[C]: in function 'error'
	...ano/.local/share/nvim/lazy/fzf-lua/lua/fzf-lua/shell.lua:430: in function 'fn'
	...ano/.local/share/nvim/lazy/fzf-lua/lua/fzf-lua/shell.lua:143: in function <...ano/.local/share/nvim/lazy/fzf-lua/lua/fzf-lua/shell.lua:142>
```

