### PR TITLE
feat: add use_absolute_paths to files picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -833,6 +833,7 @@ previewers = {
     hidden             = true,          -- enable hidden files by default
     follow             = false,         -- do not follow symlinks by default
     no_ignore          = false,         -- respect ".gitignore"  by default
+    absolute_path      = false,         -- display absolute paths
     actions = {
       -- inherits from 'actions.files', here we can override
       -- or set bind to 'false' to disable a default action

--- a/lua/fzf-lua/make_entry.lua
+++ b/lua/fzf-lua/make_entry.lua
@@ -580,20 +580,27 @@ M.file = function(x, opts)
   if opts.render_crlf then
     filepath = path.render_crlf(filepath)
   end
-  -- make path relative
-  if opts.cwd and #opts.cwd > 0 then
-    filepath = path.relative_to(filepath, opts.cwd)
+  if opts.absolute_path then
+    -- make path absolute
+    if not path.is_absolute(filepath) then
+      filepath = path.join({ opts.cwd or uv.cwd(), filepath })
+    end
+  else
+    -- make path relative
+    filepath = path.relative_to(filepath, opts.cwd or uv.cwd())
   end
   if path.is_absolute(filepath) then
     -- filter for cwd only
     if opts.cwd_only then
-      local cwd = opts.cwd or uv.cwd()
-      if not path.is_relative_to(filepath, cwd) then
+      if not path.is_relative_to(filepath, opts.cwd or uv.cwd()) then
         return nil
       end
     end
-    -- replace $HOME with ~
-    filepath = path.HOME_to_tilde(filepath)
+
+    if not opts.absolute_path then
+      -- replace $HOME with ~
+      filepath = path.HOME_to_tilde(filepath)
+    end
   end
   -- only check for ignored patterns after './' was
   -- stripped and path was transformed to relative

--- a/lua/fzf-lua/shell.lua
+++ b/lua/fzf-lua/shell.lua
@@ -213,6 +213,7 @@ M.stringify_mt = function(contents, opts)
       "file_icons",
       "color_icons",
       "path_shorten",
+      "absolute_path",
       "strip_cwd_prefix",
       "render_crlf",
       "exec_empty_query",


### PR DESCRIPTION
Hi!

I think this improvement could be quite useful for some users. The file picker is extended with a new property, `use_absolute_paths`, which simply disables the `$HOME` replacement with `~` when displaying paths.

I’ve been using this feature for a year already, and it has helped me a lot in scenarios where I have an absolute file path (e.g., generated by a script, linter, or any other external source) and want to open it using the file picker. By default, since all paths start with `~`, the results window remains empty even if the file actually exists.

Here’s the current behavior:

1. I have an absolute file path.
2. I try to find this file using the file picker.
3. The result is empty if I search directly.

<img width="2039" height="1078" alt="image" src="https://github.com/user-attachments/assets/e679c6c6-384b-431e-b967-886e5f773c7a" />

because all the paths start with `~`:

<img width="2040" height="1075" alt="image" src="https://github.com/user-attachments/assets/91f76b01-9a51-4d3e-8bc6-4433ef67eeb0" />

The main issue is that I can’t locate a file using the path I’ve copied from a linter output in another terminal. I either have to convert the path to a relative one or configure the linter (or another tool) to generate relative paths. This can also happen when someone shares an absolute path, and you want to open that file directly.

Here’s how it works when `use_absolute_paths` is passed to the file picker with a value of `true`:

```lua
require('fzf-lua').files({
        use_absolute_paths = true,
        cmd = get_fd_cmd(), -- fd should be called with --absolute-path . to display full paths
})
```

<img width="2043" height="1074" alt="image" src="https://github.com/user-attachments/assets/c2a85dd7-002e-42d0-934e-9bb59435183f" />

Let me know your thoughts. If any other picker could benefit from the same behavior, I’d be happy to update them as well. Personally, I only use the file picker, as this is the only scenario where the issue occurs.
