### PR TITLE
fix(git_branch_del): update regex to reflect new git branch entries

### DIFF
--- a/lua/fzf-lua/actions.lua
+++ b/lua/fzf-lua/actions.lua
@@ -879,7 +879,7 @@ M.git_branch_del = function(selected, opts)
   if #selected == 0 then return end
   local cmd_del_branch = path.git_cwd(opts.cmd_del, opts)
   local cmd_cur_branch = path.git_cwd({ "git", "rev-parse", "--abbrev-ref", "HEAD" }, opts)
-  local branch = selected[1]:match("[^%s%*]+")
+  local branch = selected[1]:match("^[%*+]*[%s]*[(]?([^%s)]+)")
   local cur_branch = utils.io_systemlist(cmd_cur_branch)[1]
   if branch == cur_branch then
     utils.warn("Cannot delete active branch '%s'", branch)


### PR DESCRIPTION
The current regex is wrong now that #2389 is merged. This updates the regex to be the same as that used in the function `branches` in `git.lua`, so that the correct part of the picker menu entry (the branch name) is matched by the regex.

Really these two regexes should be unified so there are not two locations to maintain...