### PR TITLE
fix: index nil CTX error after d7497da36

### DIFF
--- a/lua/fzf-lua/ctx.lua
+++ b/lua/fzf-lua/ctx.lua
@@ -2,8 +2,8 @@
 
 local M = {}
 
----@type fzf-lua.Ctx?
-local ctx
+---@type fzf-lua.Ctx|{}
+local ctx = {}
 
 ---@class fzf-lua.Ctx
 ---@field mode string
@@ -21,10 +21,10 @@ local ctx
 ---@field buflist? integer[]
 
 -- IMPORTANT: use the `__CTX` version that doesn't trigger a new context
----@return fzf-lua.Ctx?
+---@return fzf-lua.Ctx|{}
 M.get = function() return ctx end
 
-M.reset = function() ctx = nil end
+M.reset = function() ctx = {} end
 
 ---conditionally update the context if fzf-lua
 ---interface isn't open

--- a/lua/fzf-lua/utils.lua
+++ b/lua/fzf-lua/utils.lua
@@ -891,7 +891,7 @@ function M.CTX(opts)
   return require("fzf-lua.ctx").refresh(opts)
 end
 
----@return fzf-lua.Ctx?
+---@return fzf-lua.Ctx|{}
 function M.__CTX()
   return require("fzf-lua.ctx").get()
 end


### PR DESCRIPTION

```
E5108: Lua: **/fzf-lua/lua/fzf-lua/win.lua:1316: attempt to index a nil value
stack traceback:
**/fzf-lua/lua/fzf-lua/win.lua:1316: in function 'close'
**/fzf-lua/lua/fzf-lua/win.lua:1332: in function 'win_leave'
**/fzf-lua/lua/fzf-lua/utils.lua:881: in function 'fzf_exit'
**/fzf-lua/lua/fzf-lua/providers/lsp.lua:58: in function
'jump_to_location'
**/fzf-lua/lua/fzf-lua/providers/lsp.lua:445: in function 'fn_contents'
**/fzf-lua/lua/fzf-lua/providers/lsp.lua:628: in function
'lsp_definitions'
```

create a picker, hide it, then use lsp trigger `jump1`
