### PR TITLE
fix(previewer): handle empty or invalid entries

### DIFF
--- a/lua/fzf-lua/previewer/fzf.lua
+++ b/lua/fzf-lua/previewer/fzf.lua
@@ -195,6 +195,14 @@ local grep_tag = function(file, tag)
 end
 
 function Previewer.cmd_async:parse_entry_and_verify(entrystr)
+  -- Handle empty or invalid entries (common on Windows with live_grep)
+  if not entrystr or #entrystr == 0 or entrystr == "." or entrystr == ".." then
+    local errmsg = entrystr and #entrystr > 0
+        and string.format("'%s': Invalid entry", entrystr)
+        or "No entry selected"
+    return "", {}, "echo " .. libuv.shellescape(errmsg)
+  end
+  
   local entry = path.entry_to_file(entrystr, self.opts)
   -- make relative for bat's header display
   local filepath = path.relative_to(entry.bufname or entry.path or "", uv.cwd())


### PR DESCRIPTION
- add validation for empty and invalid paths (".", "..")
- return error message instead of parsing with `entry_to_file`
- fixes crashes on Windows with live_grep

Before:

<img width="3072" height="1761" alt="image" src="https://github.com/user-attachments/assets/319007bb-359b-4ce4-81d2-fe61e523b152" />

Now:

<img width="3072" height="1761" alt="image" src="https://github.com/user-attachments/assets/2a088800-6b08-407e-8d9a-a02a6de5c3e0" />