### PR TITLE
(garbage draft) add nested picker with

### DIFF
--- a/lua/fzf-lua/defaults.lua
+++ b/lua/fzf-lua/defaults.lua
@@ -1236,7 +1236,10 @@ M.defaults.tagstack              = {
 }
 
 M.defaults.commands              = {
-  actions         = { ["enter"] = actions.ex_run },
+  actions         = {
+    ["enter"]  = actions.ex_run,
+    ["ctrl-s"] = actions.ex_run_nested,
+  },
   flatten         = {},
   include_builtin = true,
   _cached_hls     = { "cmd_ex", "cmd_buf", "cmd_global" },


### PR DESCRIPTION
***This pr is utter garbage as it stands but works as described below. I figured you would have better intuition about how to integrate this feature into a picker (obviously) so put this pr up if you'd like to take it as a starting point***

Adds ability to nest command pickers when a command has completions. Press ctrl-s on a command to open a nested picker with its subcommands.

Missing features:
- explicit keybinds to populate the command/run the cmd
- docs
