### PR TITLE
fix: handle paths containing spaces in `arg_exec`

### DIFF
--- a/lua/fzf-lua/actions.lua
+++ b/lua/fzf-lua/actions.lua
@@ -478,7 +478,7 @@ local function arg_exec(cmd, selected, opts)
       if path.is_absolute(relpath) then
         relpath = path.relative_to(relpath, vim.uv.cwd())
       end
-      vim.cmd(cmd .. " " .. relpath)
+      vim.cmd(cmd .. " " .. string.gsub(relpath, " ", [[\ ]]))
     end)()
   end
 end


### PR DESCRIPTION
Handle paths containing spaces in the actions using `arg_exec`:

* `fzf.actions.arg_add`
* `fzf.actions.arg_del`

Before:
<img width="1920" height="1066" alt="image" src="https://github.com/user-attachments/assets/340b8cb0-4c7e-44ee-9280-37a8ba908955" />
<img width="1920" height="1065" alt="image" src="https://github.com/user-attachments/assets/59845503-e217-4a18-8ec7-293235772c76" />

After:
<img width="1920" height="1061" alt="image" src="https://github.com/user-attachments/assets/ac7acc19-7e44-467c-8972-f15dad86ec2f" />
<img width="1919" height="1068" alt="image" src="https://github.com/user-attachments/assets/f46efe10-7064-4f14-8415-b101f0300b57" />

I've handled it as described in the `:help :argedit`:

> Spaces in filenames have to be escaped with "\". [count] is used like with |:argadd|.