### PR TITLE
chore: use render-markdown render API

### DIFF
--- a/lua/fzf-lua/previewer/builtin.lua
+++ b/lua/fzf-lua/previewer/builtin.lua
@@ -1032,7 +1032,7 @@ function Previewer.base:update_ts_context()
 end
 
 function Previewer.base:update_render_markdown()
-  local bufnr, winid = self.preview_bufnr, self.win.preview_winid
+  local bufnr = self.preview_bufnr
   local ft = vim.b[bufnr] and vim.b[bufnr]._ft
   if not ft
       or not self.render_markdown.enabled
@@ -1041,7 +1041,7 @@ function Previewer.base:update_render_markdown()
     return
   end
   if package.loaded["render-markdown"] then
-    require("render-markdown.core.ui").update(bufnr, winid, "FzfLua", true)
+    require("render-markdown").render({ buf = bufnr, event = "FzfLua" })
   elseif package.loaded["markview"] then
     --- Render strictly to save performance.
     ---


### PR DESCRIPTION
## Details

Previously the `update` method was used to update markdown rendering via the `render-markdown` plugin. This works, but the method was originally built to be used internally and as a result is rather limited.

Update to the new public `render` API added in: https://github.com/MeanderingProgrammer/render-markdown.nvim/commit/060c911c62f995a9db4467dde6fafd699cf94d55

This method allows custom configurations so be set, handles edge cases when attaching to buffers, and is generally built to be extended to serve more use cases for other plugins.

`snacks.nvim` recently updated to using this API to supply a custom configuration: https://github.com/folke/snacks.nvim/commit/717073df1a515a1564e855cc6ae8986025611e4b