### PR TITLE
fix(reflow): resume causing lines to shift

### DIFF
--- a/lua/fzf-lua/win.lua
+++ b/lua/fzf-lua/win.lua
@@ -776,6 +776,7 @@ function FzfWin:set_backdrop()
     -- NOTE: backdrop shoulnd't be hidden with winopts.hide
     -- hide = self.winopts.hide,
   })
+  utils.wo[self.backdrop_win].eventignorewin = "FileType"
   utils.wo[self.backdrop_win].winhl = "Normal:" .. self.hls.backdrop
   utils.wo[self.backdrop_win].winblend = utils.tointeger(self.winopts.backdrop)
   vim.bo[self.backdrop_buf].buftype = "nofile"


### PR DESCRIPTION
## Details

This change disables `FileType` events from triggering on the backdrop buffer. Why exactly this causes issues in the terminal buffer, I'm not sure. My best guess is that having a variety of plugins running autocommands for the backdrop causes some timing issue, maybe in the redraw cycle. I believe this solves my issue and potentially others:

- https://github.com/ibhagwan/fzf-lua/issues/2025
- https://github.com/ibhagwan/fzf-lua/discussions/2457