### PR TITLE
feature(git_diff): add ability to diff between two specific commits

### DIFF
--- a/lua/fzf-lua/defaults.lua
+++ b/lua/fzf-lua/defaults.lua
@@ -597,9 +597,10 @@ M.defaults.git                   = {
   },
   ---@class fzf-lua.config.GitDiff: fzf-lua.config.GitBase
   diff = {
-    cmd               = "git --no-pager diff --name-only {ref}",
+    cmd               = "git --no-pager diff --name-only {compare_against} {ref}",
     ref               = "HEAD",
-    preview           = "git diff {ref} {file}",
+    compare_against   = "",
+    preview           = "git diff {compare_against} {ref} {file}",
     preview_pager     = M._preview_pager_fn,
     multiprocess      = 1, ---@type integer|boolean
     _type             = "file",


### PR DESCRIPTION
An additional field is added to `git_diff()`: `compare_against` (string). If it is not provided, behaviour is also changed to diff against the provided `ref` and its direct parent commit, showing what changes the `ref` commit introduced. When `compare_against` is given, the difference between commits `compare_against` and `ref` is shown. The `git_preview()` function is modified to operate from the nearest Git repository up the `cwd` path, so that the preview for `git_diff()` works.