### PR TITLE
fix(lsp): jump1 should just hide window rather than kill session

### DIFF
--- a/lua/fzf-lua/providers/lsp.lua
+++ b/lua/fzf-lua/providers/lsp.lua
@@ -60,10 +60,6 @@ local function locations_to_entries(locations, enc)
 end
 
 local jump_to_location = function(opts, result, enc)
-  -- exits the fzf window when use with async
-  -- safe to call even if the interface is closed
-  utils.fzf_exit()
-
   local action = opts.jump1_action
   if action then
     local entries = locations_to_entries({ result }, enc)


### PR DESCRIPTION
git blame tell me hide profile don't exist at that time?
I think it's ok to just hide the window.

So we can still unhide the window after gotodef trigger jump1.
