### PR TITLE
feat(actions): alt-d to delete command/search history

### DIFF
--- a/lua/fzf-lua/actions.lua
+++ b/lua/fzf-lua/actions.lua
@@ -588,6 +588,31 @@ M.search_cr = function(selected, opts)
   utils.feed_keys_termcodes("<CR>")
 end
 
+---@param kind ":"|"/"
+---@param selected string[]
+---@param opts fzf-lua.config.CommandHistory|{}
+local hist_del = function(kind, selected, opts)
+  if not vim.iter then return end
+  local iter = opts.reverse_list and vim.iter(selected) or vim.iter(selected):rev()
+  iter:each(function(e)
+    local idx = assert(utils.tointeger(opts.reverse_list and e or -e - 1))
+    local entry = vim.fn.histget(":", idx) -- get before deleted
+    local res = vim.fn.histdel(kind, idx)
+    local info = res == 1 and "deleted" or "fail to delete"
+    local notify = res == 1 and utils.info or utils.warn
+    notify("%s: %s", info, entry)
+  end)
+  vim.cmd("wshada!")
+end
+
+M.ex_del = function(...)
+  hist_del(":", ...)
+end
+
+M.search_del = function(...)
+  hist_del("/", ...)
+end
+
 M.goto_mark = function(selected)
   if not selected[1] then return end
   local mark = selected[1]

--- a/lua/fzf-lua/core.lua
+++ b/lua/fzf-lua/core.lua
@@ -86,8 +86,10 @@ M.ACTION_DEFINITIONS = {
   [actions.git_worktree_del]  = { "delete worktree" },
   [actions.ex_run]            = { "edit" },
   [actions.ex_run_cr]         = { "execute" },
+  [actions.ex_del]            = { "delete" },
   [actions.search]            = { "edit" },
   [actions.search_cr]         = { "search" },
+  [actions.search_del]        = { "delete" },
 }
 
 -- converts contents array sent to `fzf_exec` into a single contents

--- a/lua/fzf-lua/defaults.lua
+++ b/lua/fzf-lua/defaults.lua
@@ -1544,25 +1544,31 @@ M.defaults.undotree              = {
 }
 
 ---@class fzf-lua.config.CommandHistory: fzf-lua.config.Base
+---@field reverse_list? boolean
 M.defaults.command_history       = {
   fzf_opts    = { ["--tiebreak"] = "index", ["--no-multi"] = true },
+  render_crlf = true,
   _treesitter = function(line) return "foo.vim", nil, line end,
   fzf_colors  = { ["hl"] = "-1:reverse", ["hl+"] = "-1:reverse" },
   actions     = {
     ["enter"]  = actions.ex_run_cr,
     ["ctrl-e"] = actions.ex_run,
+    ["ctrl-x"]  = { fn = actions.ex_del, field_index = "{+n}", reload = true }
   },
   _headers    = { "actions" },
 }
 
 ---@class fzf-lua.config.SearchHistory : fzf-lua.config.CommandHistory
+---@field reverse_search? boolean
 M.defaults.search_history        = {
   fzf_opts    = { ["--tiebreak"] = "index", ["--no-multi"] = true },
+  render_crlf = true,
   _treesitter = function(line) return "", nil, line, "regex" end,
   fzf_colors  = { ["hl"] = "-1:reverse", ["hl+"] = "-1:reverse" },
   actions     = {
     ["enter"]  = actions.search_cr,
     ["ctrl-e"] = actions.search,
+    ["ctrl-x"]  = { fn = actions.search_del, field_index = "{+n}", reload = true }
   },
   _headers    = { "actions" },
 }

--- a/lua/fzf-lua/providers/nvim.lua
+++ b/lua/fzf-lua/providers/nvim.lua
@@ -109,7 +109,7 @@ M.commands = function(opts)
   return core.fzf_exec(entries, opts)
 end
 
----@param opts table
+---@param opts fzf-lua.config.CommandHistory
 ---@param str ":"|"/"
 local history = function(opts, str)
   local histnr          = vim.fn.histnr(str)

--- a/lua/fzf-lua/types.lua
+++ b/lua/fzf-lua/types.lua
@@ -146,6 +146,7 @@ local FzfLua = require("fzf-lua")
 ---@field cmd? string
 ---@field debug? boolean|integer|'v'|'verbose'
 ---@field preview_offset? string
+---@field render_crlf? boolean
 ---@field _fzf_cli_args? string[]
 ---@field __INFO fzf-lua.Info
 ---@field __CTX fzf-lua.Ctx


### PR DESCRIPTION
`render_crlf=true` to avoid mess up the index.
A history entry can be multi-line.
