### PR TITLE
feat: allow register_ui_select via setup options

### DIFF
--- a/OPTIONS.md
+++ b/OPTIONS.md
@@ -137,6 +137,14 @@ Example, opening a floating help window at the top of screen with single border:
     })
 ```
 
+#### setup.register_ui_select
+
+Type: `boolean|table|function`, Default: `false`
+
+Register fzf-lua as the UI interface for `vim.ui.select` during `setup`.
+
+When set to a table or function, the value is passed to `register_ui_select`.
+
 ---
 
 ## Global Options

--- a/doc/fzf-lua-opts.txt
+++ b/doc/fzf-lua-opts.txt
@@ -175,6 +175,15 @@ border:
         })
 <
 
+                                                                              
+setup.register_ui_select               *fzf-lua-opts-setup.register_ui_select*
+
+Type: `boolean|table|function`, Default: `false`
+
+Register fzf-lua as the UI interface for `vim.ui.select` during `setup`.
+
+When set to a table or function, the value is passed to `register_ui_select`.
+
 ------------------------------------------------------------------------------
 GLOBAL OPTIONS                                   *fzf-lua-opts-global-options*
 

--- a/lua/fzf-lua/init.lua
+++ b/lua/fzf-lua/init.lua
@@ -232,6 +232,14 @@ function M.setup(opts, do_not_reset_defaults)
   config.setup_opts = opts
   -- setup highlights
   M.setup_highlights()
+  -- opt-in register ui.select via setup
+  if opts.register_ui_select then
+    local reg_opts = opts.register_ui_select
+    if type(reg_opts) ~= "table" and type(reg_opts) ~= "function" then
+      reg_opts = nil
+    end
+    M.register_ui_select(reg_opts, true)
+  end
 end
 
 M.redraw = function()


### PR DESCRIPTION
This allows configuration in e.g. lazy.nvim to simply be:
```
opts = {
    register_ui_select = true,
},
```
instead of needing to override the setup() call.
