### PR TITLE
feat: path_shorten using extmarks

### DIFF
--- a/lua/fzf-lua/defaults.lua
+++ b/lua/fzf-lua/defaults.lua
@@ -72,6 +72,8 @@ end
 ---@field fullscreen? boolean
 ---Use treesitter highlighting in fzf's main window. NOTE: Only works for file-like entries where treesitter parser exists and is loaded for the filetype.
 ---@field treesitter? fzf-lua.config.TreesitterWinopts|boolean
+---Use extmarks with conceal to visually shorten paths while keeping full paths for actions/preview. Set to `true` for 1 char, or a number for custom length. NOTE: Unlike the picker `path_shorten` option, this doesn't modify the actual entry text, making it compatible with `combine()`. NOTE: This option has no effect when using `fzf-tmux` as the fzf window runs in a tmux popup outside of Neovim where extmarks are not available.
+---@field path_shorten? boolean|integer
 ---Callback after the creation of the fzf-lua main terminal window.
 ---@field on_create? fun(e: { winid?: integer, bufnr?: integer })
 ---Callback after closing the fzf-lua window.

--- a/lua/fzf-lua/path.lua
+++ b/lua/fzf-lua/path.lua
@@ -273,7 +273,7 @@ end
 ---@param str string
 ---@param start_idx integer
 ---@return integer?
-local function find_next_separator(str, start_idx)
+function M.find_next_separator(str, start_idx)
   local SEPARATOR_BYTES = utils._if_win(
     { M.fslash_byte, M.bslash_byte }, { M.fslash_byte })
   for i = start_idx or 1, #str do
@@ -288,7 +288,7 @@ end
 ---@param s string
 ---@param i? integer
 ---@return integer?
-local function utf8_char_len(s, i)
+function M.utf8_char_len(s, i)
   -- Get byte count of unicode character (RFC 3629)
   local c = string_byte(s, i or 1)
   if not c then
@@ -321,7 +321,7 @@ local function utf8_sub(s, from, to)
   local byte_i, utf8_i = from, from
   -- Concat utf8 chars until "to" or end of string
   while byte_i <= #s and (not to or utf8_i <= to) do
-    local c_len = utf8_char_len(s, byte_i) ---@cast c_len-?
+    local c_len = M.utf8_char_len(s, byte_i) ---@cast c_len-?
     local c = string_sub(s, byte_i, byte_i + c_len - 1)
     ret = ret .. c
     byte_i = byte_i + c_len
@@ -343,7 +343,7 @@ function M.shorten(path, max_len, sep)
     start_idx = 4
   end
   repeat
-    local i = find_next_separator(path, start_idx)
+    local i = M.find_next_separator(path, start_idx)
     local end_idx = i and start_idx + math.min(i - start_idx, max_len) - 1 or nil
     local part = utf8_sub(path, start_idx, end_idx) ---@cast i-?
     if end_idx and part == "." and i - start_idx > 1 then


### PR DESCRIPTION
I'm quite mind blown, this PR was one shot from a single prompt in opencode using subagents, the prompt:
```
  ┃  Can you take a look at issue #2517 in fzf-lua github repo and read the linked comment from discussion
  ┃  #2516 and see if you can come up with a PR to enable path_shorten using neovim extmarks?
```

I haven't reviewed the code yet, but my agents (3 different models) did and this is what they found:
<img width="994" height="1391" alt="image" src="https://github.com/user-attachments/assets/068c9320-348d-4b06-87d9-62d3ce025f6b" />

Note it chose to use a different option as it affects the main fzf window only within neovim and can't be used in fzf-tmux so to use this you need to use `winopts.path_shorten`:
```lua
:FzfLua files winopts.path_shorten=true
```

<img width="1002" height="348" alt="image" src="https://github.com/user-attachments/assets/da37f0ed-8961-4b93-994f-daefd9f00688" />


Honestly, this is quite shocking, the level of understanding of a very intricate problem and solution from a two-liner prompt...

The review seems to be on-point too (which I'll soon push it's changes too).