### PR TITLE
fix: allow TermOpen to detect fzf filetype

### DIFF
--- a/lua/fzf-lua/fzf.lua
+++ b/lua/fzf-lua/fzf.lua
@@ -62,6 +62,8 @@ function M.raw_fzf(contents, fzf_cli_args, opts)
   table.insert(cmd, libuv.shellescape(outputtmpname))
 
   if not opts.is_fzf_tmux then
+    utils.eventignore(function() vim.bo.filetype = "fzf" end)
+
     -- A pesky bug I fixed upstream and was merged in 0.11/0.10.2:
     -- <C-c> in term buffers was making neovim freeze, as a workaround in older
     -- versions (not perfect could still hang) we map <C-c> to <Esc> locally


### PR DESCRIPTION
fzf.vim also defer filetype
https://github.com/junegunn/fzf/blob/821b8e70a80e3ea96772a4dda36311b19b7171b4/plugin/fzf.vim#L976

But maybe no reason we cannot set filetype before jobstart

https://github.com/ibhagwan/fzf-lua/discussions/2532#discussioncomment-15595064
