### PR TITLE
fix(lsp): change error to warn on lsp error message (#2547)

### DIFF
--- a/lua/fzf-lua/providers/lsp.lua
+++ b/lua/fzf-lua/providers/lsp.lua
@@ -485,7 +485,8 @@ local function gen_lsp_contents(opts)
           local context = { client_id = client_id }
           lsp_handler.handler(opts, cb, lsp_handler.method, response.result, context, nil)
         elseif response.error then
-          utils.error("Error executing '%s': %s", lsp_handler.method, response.error.message)
+          local name = assert(vim.lsp.get_client_by_id(client_id)).name
+          utils.warn("%s[%s]: %s", tostring(name), lsp_handler.method, response.error.message)
         end
       end
       if utils.tbl_isempty(results) then


### PR DESCRIPTION
see https://github.com/ibhagwan/fzf-lua/issues/2547#issuecomment-3840420481

Builtin lsp warn on hierarchy request:
https://github.com/neovim/neovim/blob/0501c5fd0959895b18d8166c6c034cdf1832edf3/runtime/lua/vim/lsp/buf.lua#L1275
Also other "content" request don't throw error message.

So I think we can change error to warn.

Fix https://github.com/ibhagwan/fzf-lua/issues/2547.
