### PR TITLE
feat(default): allow `lua$` to match lua buffer only in buffer picker

### DIFF
--- a/lua/fzf-lua/defaults.lua
+++ b/lua/fzf-lua/defaults.lua
@@ -1055,7 +1055,12 @@ M.defaults.buffers               = {
   no_action_set_cursor  = true,
   cwd_only              = false,
   cwd                   = nil,
-  fzf_opts              = { ["--tiebreak"] = "index", ["--multi"] = true },
+  fzf_opts              = {
+    ["--tiebreak"] = "index",
+    ["--multi"] = true,
+    ["--delimiter"] = ":",
+    ["--nth"] = "..-2",
+  },
   _actions              = function()
     return M.globals.actions.buffers or M.globals.actions.files
   end,


### PR DESCRIPTION
Maybe someone can have different muscle memory like `lua:` rather than `lua$`, I just always find I type something like `lua$` and found it don't work in buffer picker.