### PR TITLE
fix(ui_select): fix E5101 if invoked through v:lua

### DIFF
--- a/lua/fzf-lua/providers/ui_select.lua
+++ b/lua/fzf-lua/providers/ui_select.lua
@@ -212,7 +212,7 @@ M.ui_select = function(items, ui_opts, on_choice)
   -- casues issues with abort as on_choice(nil) won't be called (#2439)
   opts.no_hide = opts.no_hide == nil and true or opts.no_hide
 
-  return core.fzf_exec(entries, opts)
+  core.fzf_exec(entries, opts)
 end
 
 return M


### PR DESCRIPTION
This fixes "E5101: Cannot convert given Lua type" when invoking vim.ui.select through v:lua-call, e.g.:

    :call v:lua.vim.ui.select(["foo", "bar"], {}, luaeval('function(x) print(x) end'))

core.fzf_exec returns a tuple, the first element of which is an object of type "thread", which can't be converted to a vimscript value. But vim.ui.select isn't meant to return anything, so the fix is to just drop the return — which was presumably added by accident (ui_select isn't really a provider like the others, and isn't meant to be combined, so doesn't need to return anything).

Fixes: 594b4f7e8fa6 ("feat: combine pickers (#1879)")
