### PR TITLE
fix(manpages): warn when man executable or mandb cache is missing

### DIFF
--- a/lua/fzf-lua/providers/manpages.lua
+++ b/lua/fzf-lua/providers/manpages.lua
@@ -39,6 +39,17 @@ M.manpages = function(opts)
     return
   end
 
+  if vim.fn.executable("man") ~= 1 then
+    utils.warn("'man' executable not found.")
+    return
+  end
+
+  local out = vim.fn.system(opts.cmd)
+  if vim.v.shell_error ~= 0 or vim.trim(out) == "" then
+    utils.warn("'man -k' returned no results, try running 'sudo mandb' to populate the cache.")
+    return
+  end
+
   opts.fn_transform = function(x)
     -- split by first occurrence of ' - ' (spaced hyphen)
     local man, desc = x:match("^(.-) %- (.*)$")


### PR DESCRIPTION
basically i realized that `man -k .` was not working on nixos (the command for `:FzfLua man_pages` and that i was missing mandb.

So, thought it would be nice to make sure that this doesn't happen to anyone else by warning in the picker :D