### PR TITLE
fix bug when close_buf called with nil fzf_bufnr

### DIFF
--- a/lua/fzf-lua/win.lua
+++ b/lua/fzf-lua/win.lua
@@ -1000,7 +1000,9 @@ function FzfWin:close(fzf_bufnr, hide)
       pcall(api.nvim_win_close, self.fzf_winid, true)
     end
   end
-  if not hide then self:close_buf(self.fzf_bufnr) end
+  if not hide and self.fzf_bufnr then
+    self:close_buf(self.fzf_bufnr)
+  end
   for k, _ in pairs(self.on_closes) do
     self.on_closes[k](hide)
     self.on_closes[k] = nil


### PR DESCRIPTION
Fixes a regression caused by 18837e2 merged in #2512. When using the `fzf-tmux` profile, fzf runs in a tmux popup not a nvim terminal buffer so passing nil to close_buf will throw.

Fixes #2578