### PR TITLE
refactor previewer

### DIFF
--- a/lua/fzf-lua/previewer/bcache.lua
+++ b/lua/fzf-lua/previewer/bcache.lua
@@ -1,0 +1,104 @@
+-- cache entry for preview buf
+
+---rename bufnr to buf?
+---@class fzf-lua.BcacheEntry
+---@field bufnr integer
+---@field tick? integer
+---@field min_winopts? boolean
+---@field pos? [integer, integer]|true cached cursor positions
+
+---@class fzf-lua.Bcache
+---@field private entries table<any, fzf-lua.BcacheEntry> cached preview entries
+---@field private buffers table<integer, fzf-lua.BcacheEntry> cached bufnrs
+---@field private bufdel fun(buf: integer) callback to delete a buffer when evicted from cache
+local M = {}
+M.__index = M
+
+---@param bufdel fun(buf: integer)
+---@return fzf-lua.Bcache
+function M.new(bufdel)
+  return setmetatable({ entries = {}, buffers = {}, bufdel = bufdel }, M)
+end
+
+---Prioritize entry.cache_key since override self:key_from_entry is not allowed now
+---@param entry fzf-lua.buffer_or_file.Entry
+---@return string?
+local key_from_entry = function(entry)
+  -- entry.do_not_cache -> entry.cache_key=false?
+  if entry.do_not_cache then return nil end
+  return entry.cache_key
+      or entry.bufnr and ("bufnr:%d"):format(entry.bufnr)
+      or entry.uri
+      or entry.path
+end
+
+---@param entry fzf-lua.buffer_or_file.Entry
+---@return fzf-lua.BcacheEntry?
+function M:get(entry)
+  return self.entries[key_from_entry(entry)]
+end
+
+---cache only buffer have key_from_entry
+---@param entry fzf-lua.buffer_or_file.Entry
+---@param buf integer buf should be valid
+---@param min_winopts boolean?
+function M:set(entry, buf, min_winopts)
+  local key = key_from_entry(entry)
+  if not key then return end
+  local cached = self.entries[key]
+  if cached and cached.bufnr == buf then
+    cached.tick = entry.tick
+    return
+  elseif cached then
+    self.bufdel(cached.bufnr)
+  end
+  ---@type fzf-lua.BcacheEntry
+  local newcache = {
+    bufnr = buf,
+    tick = entry.tick,
+    min_winopts = min_winopts,
+    pos = true, -- reset scroll position
+  }
+  self.entries[key] = newcache
+  self.buffers[buf] = newcache
+  -- remove buffer auto-delete since it's now cached
+  vim.bo[buf].bufhidden = "hide"
+end
+
+---@param entry fzf-lua.buffer_or_file.Entry
+---@return fzf-lua.BcacheEntry?, boolean? (true: stale, false: valid, nil: not cached)
+function M:check(entry)
+  local cached = self.entries[key_from_entry(entry)]
+  return cached, cached and entry.tick ~= cached.tick or nil
+end
+
+---nop if update on a un-managed buf
+---@param buf integer
+---@param pos [integer, integer]|true set/reset cursor position
+function M:update_pos(buf, pos)
+  local cached = self.buffers[buf]
+  if cached then cached.pos = pos end
+end
+
+---nop if update on a un-managed buf
+---@param buf integer
+function M:reset_pos(buf)
+  self:update_pos(buf, true)
+end
+
+---@param buf integer
+---@return [integer, integer]|true?
+function M:get_pos(buf)
+  local cached = self.buffers[buf]
+  return cached and cached.pos or nil
+end
+
+function M:clear()
+  for _, entry in pairs(self.entries) do
+    self.bufdel(entry.bufnr)
+  end
+  self.entries = {}
+  self.buffers = {}
+end
+
+return M

--- a/lua/fzf-lua/previewer/builtin.lua
+++ b/lua/fzf-lua/previewer/builtin.lua
@@ -574,9 +574,6 @@ function Previewer.buffer_or_file:parse_entry(entry_str, _cb)
       end)
     end
   end
-  if not entry.tick and entry.path then
-    entry.tick = vim.tbl_get(uv.fs_stat(entry.path) or {}, "mtime", "nsec")
-  end
   if entry.path and next(self.extensions) then
     local ext = path.extension(entry.path)
     local cmd = ext and self.extensions[ext:lower()] or nil
@@ -589,6 +586,24 @@ function Previewer.buffer_or_file:parse_entry(entry_str, _cb)
         entry.pty = true
       end
     end
+  end
+  local stat = entry.path and not entry.uri and uv.fs_stat(entry.path) or nil
+  entry.tick = entry.tick or vim.tbl_get(stat or {}, "mtime", "nsec")
+  if entry.debug then
+    entry.content = { { { entry.debug, "Error" } } }
+  elseif not stat then
+    entry.content = { { { "Unable to stat file: ", "Error" }, { entry.path or "nil", "DiagnosticInfo" } } }
+    -- TODO: https://github.com/EmmyLuaLs/emmylua-analyzer-rust/issues/1026
+  elseif stat and stat.type == "directory" then
+    entry.cmd = utils._if_win({ "cmd.exe", "/c", "dir", entry.path },
+      { "ls", "-la", entry.path })
+  elseif stat and stat.size > 0 and utils.perl_file_is_binary(entry.path) then
+    entry.content = { { "Preview is not supported for binary files.", "Error" } }
+  elseif stat and stat.size > self.limit_b then
+    entry.content = {
+      { { ("Preview file size limit (>%dMB) reached, file size %dMB.")
+          :format(self.limit_b / (1024 * 1024), stat.size / (1024 * 1024)), "ERROR" } }
+    }
   end
   return entry
 end
@@ -865,10 +880,9 @@ end
 
 ---@param tmpbuf integer
 ---@param entry fzf-lua.buffer_or_file.Entry
----@param lines (fzf-lua.line|string)[]
 ---@return nil
-function Previewer.buffer_or_file:_set_preview_lines(tmpbuf, entry, lines)
-  local textlines, extmarks = parse_rich(lines)
+function Previewer.buffer_or_file:_set_preview_lines(tmpbuf, entry)
+  local textlines, extmarks = parse_rich(entry.content or {})
   extmarks = entry.extmarks or extmarks
   pcall(api.nvim_buf_set_lines, tmpbuf, 0, -1, false, textlines)
   if extmarks and #extmarks > 0 then
@@ -937,57 +951,6 @@ function Previewer.buffer_or_file:_populate_file_preview(tmpbuf, entry)
   end))
 end
 
----@param tmpbuf integer
----@param entry fzf-lua.buffer_or_file.Entry
----@param entry_str string
----@return nil
-function Previewer.buffer_or_file:_populate_standard_preview(tmpbuf, entry, entry_str)
-  -- will return 'false' when cmd isn't executable.
-  -- If we get here it means preview was successful
-  -- it can still fail if using wrong command flags
-  -- but the user will be able to see the error in
-  -- the preview win
-  if self:populate_terminal_cmd(tmpbuf, entry) then
-    return
-  end
-
-  if entry.cmd then
-    return self:_populate_cmd_preview(tmpbuf, entry, entry_str)
-  end
-
-  if self:attach_snacks_image_buf(tmpbuf, entry) then
-    return self:preview_buf_post(entry)
-  end
-
-  ---@type (fzf-lua.line|string)[]?
-  local lines
-  if entry.debug then
-    lines = { { { entry.debug, "Error" } } }
-  elseif entry.content then
-    lines = entry.content
-  else
-    -- make sure the file is readable (or bad entry.path)
-    local fs_stat = entry.path and uv.fs_stat(entry.path)
-    local is_binary = fs_stat and fs_stat.size > 0 and utils.perl_file_is_binary(entry.path) or false
-    if not fs_stat then
-      lines = { string.format("Unable to stat file %s", entry.path) }
-    elseif is_binary then
-      lines = { "Preview is not supported for binary files." }
-    elseif tonumber(self.limit_b) > 0 and fs_stat.size > self.limit_b then
-      lines = {
-        ("Preview file size limit (>%dMB) reached, file size %dMB.")
-            :format(self.limit_b / (1024 * 1024), fs_stat.size / (1024 * 1024)),
-        -- "(configured via 'previewers.builtin.limit_b')"
-      }
-    end
-    if not lines then
-      return self:_populate_file_preview(tmpbuf, entry)
-    end
-  end
-
-  self:_set_preview_lines(tmpbuf, entry, lines)
-end
-
 ---@async
 ---@param entry_str string
 ---@return false? no preview
@@ -1018,11 +981,25 @@ function Previewer.buffer_or_file:populate_preview_buf(entry_str)
 
   if entry.bufnr and api.nvim_buf_is_loaded(entry.bufnr) and vim.bo[entry.bufnr].filetype ~= "image" then
     self:_populate_loaded_buffer_preview(tmpbuf or self:get_tmp_buffer(), entry)
+    return
   elseif entry.uri and entry.range then
     self:_populate_location_preview(tmpbuf, entry)
-  else -- not found in cache, attempt to load
-    self:_populate_standard_preview(tmpbuf or self:get_tmp_buffer(), entry, entry_str)
+    return
   end
+  tmpbuf = tmpbuf or self:get_tmp_buffer()
+  if self:populate_terminal_cmd(tmpbuf, entry) then
+    return
+  end
+  if entry.cmd then
+    return self:_populate_cmd_preview(tmpbuf, entry, entry_str)
+  end
+  if self:attach_snacks_image_buf(tmpbuf, entry) then
+    return self:preview_buf_post(entry)
+  end
+  if entry.content then
+    return self:_set_preview_lines(tmpbuf, entry)
+  end
+  self:_populate_file_preview(tmpbuf, entry)
 end
 
 -- Attach ts highlighter, neovim >= v0.9

--- a/lua/fzf-lua/previewer/builtin.lua
+++ b/lua/fzf-lua/previewer/builtin.lua
@@ -942,20 +942,6 @@ function Previewer.buffer_or_file:_populate_cmd_preview(tmpbuf, entry, entry_str
   end
 end
 
----@param tmpbuf integer
----@param entry fzf-lua.buffer_or_file.Entry
----@return nil
-function Previewer.buffer_or_file:_populate_file_preview(tmpbuf, entry)
-  utils.read_file_async(entry.path, vim.schedule_wrap(function(data)
-    -- if file ends in new line, don't write an empty string as the last
-    -- line.
-    api.nvim_buf_set_lines(tmpbuf, 0, -1, false, split_file_data(data))
-    -- swap preview buffer with new one
-    self:set_preview_buf(tmpbuf)
-    self:preview_buf_post(entry)
-  end))
-end
-
 ---@async
 ---@param entry_str string
 ---@return false? no preview
@@ -1004,7 +990,14 @@ function Previewer.buffer_or_file:populate_preview_buf(entry_str)
   if entry.content then
     return self:_set_preview_lines(buf, entry)
   end
-  self:_populate_file_preview(buf, entry)
+  utils.read_file_async(entry.path, vim.schedule_wrap(function(data)
+    if entry_str ~= self._last_entry then return end
+    -- if file ends in new line, don't write an empty string as the last line.
+    api.nvim_buf_set_lines(buf, 0, -1, false, split_file_data(data))
+    -- swap preview buffer with new one
+    self:set_preview_buf(buf)
+    self:preview_buf_post(entry)
+  end))
 end
 
 -- Attach ts highlighter, neovim >= v0.9

--- a/lua/fzf-lua/previewer/builtin.lua
+++ b/lua/fzf-lua/previewer/builtin.lua
@@ -854,27 +854,28 @@ function Previewer.buffer_or_file:_populate_loaded_buffer_preview(tmpbuf, entry)
   self:preview_buf_post(entry, entry.terminal)
 end
 
----@param tmpbuf integer?
+---@param tmpbuf integer
 ---@param entry fzf-lua.buffer_or_file.Entry
----@return nil
 function Previewer.buffer_or_file:_populate_location_preview(tmpbuf, entry)
   -- LSP 'jdt://' entries, see issue #195
   -- https://github.com/ibhagwan/fzf-lua/issues/195
-  api.nvim_win_call(self.win.preview_winid, function()
-    local loc = { uri = entry.uri, range = entry.range }
-    local ok, res = pcall(utils.jump_to_location, loc, "utf-16", false)
-    if ok then
-      self.preview_bufnr = api.nvim_get_current_buf()
-      return
-    end
-    -- in case of an error display the stacktrace in the preview buffer
-    local name = utils.__HAS_NVIM_011 and "show_document" or "jump_to_location"
-    local lines = { ("lsp.util.%s failed for '%s':"):format(name, entry.uri), "" }
-    vim.list_extend(lines, type(res) == "string" and utils.strsplit(res, "\n") or { "null" })
-    tmpbuf = tmpbuf or self:get_tmp_buffer()
-    api.nvim_buf_set_lines(tmpbuf, 0, -1, false, lines)
-    self:set_preview_buf(tmpbuf)
+  local loc = { uri = entry.uri, range = entry.range }
+  local win = self.win.preview_winid
+  local ok, res = api.nvim_win_call(win, function()
+    return pcall(utils.jump_to_location, loc, "utf-16", false)
   end)
+  if ok then
+    entry.bufnr = api.nvim_win_get_buf(win)
+    self:_populate_loaded_buffer_preview(tmpbuf, entry)
+    return
+  end
+  -- in case of an error display the stacktrace in the preview buffer
+  local name = utils.__HAS_NVIM_011 and "show_document" or "jump_to_location"
+  local lines = { ("lsp.util.%s failed for '%s':"):format(name, entry.uri), "" }
+  vim.list_extend(lines, type(res) == "string" and utils.strsplit(res, "\n") or { "null" })
+  tmpbuf = tmpbuf or self:get_tmp_buffer()
+  api.nvim_buf_set_lines(tmpbuf, 0, -1, false, lines)
+  self:set_preview_buf(tmpbuf)
   self:preview_buf_post(entry)
 end
 
@@ -976,30 +977,30 @@ function Previewer.buffer_or_file:populate_preview_buf(entry_str)
     return
   end
 
-  local tmpbuf = (cached or {}).bufnr -- cached must be stale now if exists
+  -- if cached exists, must be stale, otherwise alloc a new buffer
+  local buf = (cached or {}).bufnr or self:get_tmp_buffer()
   self:_stop_preview_job()
 
   if entry.bufnr and api.nvim_buf_is_loaded(entry.bufnr) and vim.bo[entry.bufnr].filetype ~= "image" then
-    self:_populate_loaded_buffer_preview(tmpbuf or self:get_tmp_buffer(), entry)
+    self:_populate_loaded_buffer_preview(buf, entry)
     return
   elseif entry.uri and entry.range then
-    self:_populate_location_preview(tmpbuf, entry)
+    self:_populate_location_preview(buf, entry)
     return
   end
-  tmpbuf = tmpbuf or self:get_tmp_buffer()
-  if self:populate_terminal_cmd(tmpbuf, entry) then
+  if self:populate_terminal_cmd(buf, entry) then
     return
   end
   if entry.cmd then
-    return self:_populate_cmd_preview(tmpbuf, entry, entry_str)
+    return self:_populate_cmd_preview(buf, entry, entry_str)
   end
-  if self:attach_snacks_image_buf(tmpbuf, entry) then
+  if self:attach_snacks_image_buf(buf, entry) then
     return self:preview_buf_post(entry)
   end
   if entry.content then
-    return self:_set_preview_lines(tmpbuf, entry)
+    return self:_set_preview_lines(buf, entry)
   end
-  self:_populate_file_preview(tmpbuf, entry)
+  self:_populate_file_preview(buf, entry)
 end
 
 -- Attach ts highlighter, neovim >= v0.9

--- a/lua/fzf-lua/previewer/builtin.lua
+++ b/lua/fzf-lua/previewer/builtin.lua
@@ -66,12 +66,9 @@ function Previewer.base:new(o, opts)
   self.treesitter = type(o.treesitter) == "table" and o.treesitter or {}
   self.toggle_behavior = o.toggle_behavior
   self.winopts_orig = {}
-  -- convert extension map to lower case
-  if o.extensions then
-    self.extensions = {}
-    for k, v in pairs(o.extensions) do
-      self.extensions[k:lower()] = v
-    end
+  self.extensions = {}
+  for k, v in pairs(o.extensions or {}) do
+    self.extensions[k:lower()] = v
   end
   -- validate the ueberzug image scaler
   local uz_scalers = {
@@ -535,6 +532,24 @@ function Previewer.buffer_or_file:entry_to_file(entry_str)
   return path.entry_to_file(entry_str, self.opts)
 end
 
+-- replace `{file}` placeholder with the filename
+---@param cmd string[]
+---@param filepath string
+---@param placeholder string
+---@return string[]
+local function replace_placeholder(cmd, placeholder, filepath)
+  local append = true
+  for i, arg in ipairs(cmd) do
+    if type(arg) == "string" and arg:match(placeholder) then
+      cmd[i] = arg:gsub(placeholder, filepath)
+      append = false
+    end
+  end
+  -- or add filename as last parameter
+  if append then cmd[#cmd + 1] = filepath end
+  return cmd
+end
+
 ---async result can be return by "_cb(res)"
 ---@param entry_str string
 ---@param _cb? function
@@ -543,15 +558,12 @@ function Previewer.buffer_or_file:parse_entry(entry_str, _cb)
   ---@type fzf-lua.buffer_or_file.Entry
   local entry = self:entry_to_file(entry_str)
   local buf = entry.bufnr
-  local loaded = buf and api.nvim_buf_is_loaded(buf)
-  if loaded then
+  if buf and api.nvim_buf_is_loaded(buf) then
     entry.tick = vim.b[buf].changedtick
-    return entry
-  end
-  -- buffer is not loaded, can happen when calling "lines" with `set nohidden`
-  -- or when starting nvim with an arglist, fix entry.path since it contains
-  -- filename only
-  if buf and api.nvim_buf_is_valid(buf) then
+  elseif buf and api.nvim_buf_is_valid(buf) then
+    -- buffer is not loaded, can happen when calling "lines" with `set nohidden`
+    -- or when starting nvim with an arglist, fix entry.path since it contains
+    -- filename only
     entry.path = path.relative_to(api.nvim_buf_get_name(buf), utils.cwd())
     if entry.path:find("^fugitive://") then
       api.nvim_buf_call(buf, function()
@@ -560,11 +572,23 @@ function Previewer.buffer_or_file:parse_entry(entry_str, _cb)
           pattern = entry.path
         })
       end)
-      return entry
     end
   end
-  if entry.path then
+  if not entry.tick and entry.path then
     entry.tick = vim.tbl_get(uv.fs_stat(entry.path) or {}, "mtime", "nsec")
+  end
+  if entry.path and next(self.extensions) then
+    local ext = path.extension(entry.path)
+    local cmd = ext and self.extensions[ext:lower()] or nil
+    cmd = type(cmd) == "string" and { cmd } or utils.deepcopy(cmd) or {}
+    if cmd[1] then
+      -- special case: we build ueberzug cmd separately
+      entry._is_ueberzug = cmd[1]:match("ueberzug") and true or false
+      if not entry._is_ueberzug and fn.executable(cmd[1]) == 1 then
+        entry.cmd = replace_placeholder(cmd, "[<{]file[}>]", entry.path)
+        entry.pty = true
+      end
+    end
   end
   return entry
 end
@@ -630,13 +654,12 @@ function Previewer.buffer_or_file:stop_ueberzug()
   end
 end
 
+---TODO: now this only handle ueberzug image previews
 ---@param tmpbuf integer
----@param cmd string|string[]
 ---@param entry fzf-lua.buffer_or_file.Entry
----@return boolean
-function Previewer.buffer_or_file:populate_terminal_cmd(tmpbuf, cmd, entry)
-  cmd = type(cmd) == "table" and utils.deepcopy(cmd) or { cmd }
-  if not cmd[1] or fn.executable(cmd[1]) ~= 1 then return false end
+---@return boolean?
+function Previewer.buffer_or_file:populate_terminal_cmd(tmpbuf, entry)
+  if not entry._is_ueberzug then return end
   -- no caching: preview buf must be reattached for
   -- terminal image previews to have the correct size
   entry.do_not_cache = true
@@ -649,59 +672,30 @@ function Previewer.buffer_or_file:populate_terminal_cmd(tmpbuf, cmd, entry)
   self.clear_on_redraw = true
   -- 2nd arg `true`: minimal style window
   self:set_preview_buf(tmpbuf, true)
-  if cmd[1]:match("ueberzug") then
-    local fifo = self:start_ueberzug()
-    if not fifo then return end
-    local wincfg = api.nvim_win_get_config(self.win.preview_winid)
-    local winpos = api.nvim_win_get_position(self.win.preview_winid)
-    local params = {
-      action     = "add",
-      identifier = "preview",
-      x          = winpos[2] + 1,
-      y          = winpos[1] + 2,
-      width      = wincfg.width - 2,
-      height     = wincfg.height - 2,
-      scaler     = self.ueberzug_scaler,
-      path       = path.is_absolute(entry.path) and entry.path or
-          path.join({ self.opts.cwd or utils.cwd(), entry.path }),
-    }
-    local json = vim.json.encode(params)
-    -- both 'fs_open|write|close' and 'fn.system' work.
-    -- We prefer the libuv method as it doesn't rely on the shell
-    -- cmd = { "sh", "-c", ("echo '%s' > %s"):format(json, self._ueberzug_fifo) }
-    -- fn.system(cmd)
-    local fd = uv.fs_open(self._ueberzug_fifo, "a", -1)
-    if fd then
-      uv.fs_write(fd, json .. "\n", nil, function(_)
-        uv.fs_close(fd)
-      end)
-    end
-  else
-    -- replace `{file}` placeholder with the filename
-    local add_file = true
-    for i, arg in ipairs(cmd) do
-      if type(arg) == "string" and arg:match("[<{]file[}>]") then
-        cmd[i] = entry.path
-        add_file = false
-      end
-    end
-    -- or add filename as last parameter
-    if add_file then
-      table.insert(cmd, entry.path)
-    end
-    -- must be modifiable or 'termopen' fails
-    vim.bo[tmpbuf].modifiable = true
-    api.nvim_buf_call(tmpbuf, function()
-      self._job_id = utils.termopen(cmd, {
-        cwd = self.opts.cwd,
-        on_exit = function()
-          -- run post only after terminal job finished
-          if self._job_id then
-            self:preview_buf_post(entry, true)
-            self._job_id = nil
-          end
-        end
-      })
+  local fifo = self:start_ueberzug()
+  if not fifo then return end
+  local wincfg = api.nvim_win_get_config(self.win.preview_winid)
+  local winpos = api.nvim_win_get_position(self.win.preview_winid)
+  local params = {
+    action     = "add",
+    identifier = "preview",
+    x          = winpos[2] + 1,
+    y          = winpos[1] + 2,
+    width      = wincfg.width - 2,
+    height     = wincfg.height - 2,
+    scaler     = self.ueberzug_scaler,
+    path       = entry.path and path.is_absolute(entry.path) and entry.path or
+        path.join({ self.opts.cwd or utils.cwd(), entry.path }),
+  }
+  local json = vim.json.encode(params)
+  -- both 'fs_open|write|close' and 'fn.system' work.
+  -- We prefer the libuv method as it doesn't rely on the shell
+  -- cmd = { "sh", "-c", ("echo '%s' > %s"):format(json, self._ueberzug_fifo) }
+  -- fn.system(cmd)
+  local fd = uv.fs_open(self._ueberzug_fifo, "a", -1)
+  if fd then
+    uv.fs_write(fd, json .. "\n", nil, function(_)
+      uv.fs_close(fd)
     end)
   end
   -- run here so title gets updated
@@ -751,7 +745,7 @@ local start_cmd = function(buf, entry, opts)
       chan = nil
     end
     if obj and not obj:is_closing() then
-      obj:kill(vim.uv.constants.SIGTERM)
+      obj:kill(uv.constants.SIGTERM)
       obj = nil
     end
     if err then error(err) end
@@ -896,6 +890,26 @@ end
 ---@return nil
 function Previewer.buffer_or_file:_populate_cmd_preview(tmpbuf, entry, entry_str)
   local opened = false
+  if entry.pty then
+    self.clear_on_redraw = true -- cache it, but clear on resize
+    self:set_preview_buf(tmpbuf, true)
+    vim.bo[tmpbuf].modifiable = true
+    api.nvim_buf_call(tmpbuf, function()
+      self:set_preview_buf(tmpbuf, true)
+      local job_id
+      job_id = utils.termopen(entry.cmd, {
+        cwd = self.opts.cwd,
+        on_exit = function()
+          -- run post only after terminal job finished
+          if not self._job_id or self._job_id ~= job_id then return end
+          self:preview_buf_post(entry, true)
+          self._job_id = nil
+        end
+      })
+      self._job_id = job_id
+    end)
+    return
+  end
   return start_cmd(tmpbuf, entry, {
     cancel = function() return entry_str ~= self._last_entry end,
     on_send = function()
@@ -928,20 +942,21 @@ end
 ---@param entry_str string
 ---@return nil
 function Previewer.buffer_or_file:_populate_standard_preview(tmpbuf, entry, entry_str)
-  local cmd
-  if entry.path and self.extensions and not utils.tbl_isempty(self.extensions) then
-    local ext = path.extension(entry.path)
-    cmd = ext and self.extensions[ext:lower()] or nil
-  end
   -- will return 'false' when cmd isn't executable.
   -- If we get here it means preview was successful
   -- it can still fail if using wrong command flags
   -- but the user will be able to see the error in
   -- the preview win
-  if cmd and self:populate_terminal_cmd(tmpbuf, cmd, entry) then return end
-  if self:attach_snacks_image_buf(tmpbuf, entry) then
-    self:preview_buf_post(entry)
+  if self:populate_terminal_cmd(tmpbuf, entry) then
     return
+  end
+
+  if entry.cmd then
+    return self:_populate_cmd_preview(tmpbuf, entry, entry_str)
+  end
+
+  if self:attach_snacks_image_buf(tmpbuf, entry) then
+    return self:preview_buf_post(entry)
   end
 
   ---@type (fzf-lua.line|string)[]?
@@ -950,8 +965,6 @@ function Previewer.buffer_or_file:_populate_standard_preview(tmpbuf, entry, entr
     lines = { { { entry.debug, "Error" } } }
   elseif entry.content then
     lines = entry.content
-  elseif entry.cmd then
-    return self:_populate_cmd_preview(tmpbuf, entry, entry_str)
   else
     -- make sure the file is readable (or bad entry.path)
     local fs_stat = entry.path and uv.fs_stat(entry.path)
@@ -982,7 +995,7 @@ function Previewer.buffer_or_file:populate_preview_buf(entry_str)
   if not self.win or not self.win:validate_preview() then return end
   -- stop ueberzug shell job
   self:stop_ueberzug()
-  local co = coroutine.running()
+  local co = assert(coroutine.running())
   -- schedule can avoid "cannot resume running coroutine"
   local entry = self:parse_entry(entry_str,
     vim.schedule_wrap(function(res) assert(coroutine.resume(co, res)) end))

--- a/lua/fzf-lua/previewer/builtin.lua
+++ b/lua/fzf-lua/previewer/builtin.lua
@@ -750,6 +750,7 @@ end
 ---@param buf integer
 ---@param entry fzf-lua.cmd.Entry
 ---@param opts table
+---@return vim.SystemObj
 local start_cmd = function(buf, entry, opts)
   local chan ---@type integer?
   local obj ---@type vim.SystemObj?
@@ -788,7 +789,7 @@ local start_cmd = function(buf, entry, opts)
   end)
   local sopts = entry.cmd_opts or {}
   sopts = vim.tbl_deep_extend("force", sopts, { stdout = stdout, stderr = stdout })
-  obj = vim.system(entry.cmd, sopts, on_exit)
+  return vim.system(entry.cmd, sopts, on_exit)
 end
 
 ---@param entry fzf-lua.buffer_or_file.Entry
@@ -826,12 +827,10 @@ end
 
 ---@return nil
 function Previewer.buffer_or_file:_stop_preview_job()
-  self.clear_on_redraw = false
-  -- kill previously running terminal jobs
-  -- when using external commands extension map
-  if self._job_id and self._job_id > 0 then
-    fn.jobstop(self._job_id)
-    self._job_id = nil
+  self:stop_ueberzug()
+  if self.stop_job then
+    self.stop_job()
+    self.stop_job = nil
   end
 end
 
@@ -903,38 +902,44 @@ end
 ---@param entry_str string
 ---@return nil
 function Previewer.buffer_or_file:_populate_cmd_preview(tmpbuf, entry, entry_str)
-  local opened = false
+  local opened, job = false, nil
   if entry.pty then
     self.clear_on_redraw = true -- cache it, but clear on resize
     self:set_preview_buf(tmpbuf, true)
     vim.bo[tmpbuf].modifiable = true
-    api.nvim_buf_call(tmpbuf, function()
-      self:set_preview_buf(tmpbuf, true)
-      local job_id
-      job_id = utils.termopen(entry.cmd, {
+    job = api.nvim_buf_call(tmpbuf, function()
+      return utils.termopen(entry.cmd, {
         cwd = self.opts.cwd,
-        on_exit = function()
-          -- run post only after terminal job finished
-          if not self._job_id or self._job_id ~= job_id then return end
+        on_exit = function() -- run post only after terminal job finished
+          if not job then return end
           self:preview_buf_post(entry, true)
           self._job_id = nil
         end
       })
-      self._job_id = job_id
     end)
+    self.stop_job = function()
+      self.clear_on_redraw = false
+      fn.jobstop(job)
+      job = nil
+    end
     return
   end
-  return start_cmd(tmpbuf, entry, {
+  job = start_cmd(tmpbuf, entry, {
     cancel = function() return entry_str ~= self._last_entry end,
     on_send = function()
-      if opened then return end
+      if not job or opened then return end
       opened = true
       self:set_preview_buf(tmpbuf, true)
     end,
     on_exit = function()
+      if not job then return end
       self:preview_buf_post(entry)
     end,
   })
+  self.stop_job = function()
+    job:kill(uv.constants.SIGTERM) ---@diagnostic disable-next-line: assign-type-mismatch
+    job = nil
+  end
 end
 
 ---@param tmpbuf integer
@@ -956,8 +961,6 @@ end
 ---@return false? no preview
 function Previewer.buffer_or_file:populate_preview_buf(entry_str)
   if not self.win or not self.win:validate_preview() then return end
-  -- stop ueberzug shell job
-  self:stop_ueberzug()
   local co = assert(coroutine.running())
   -- schedule can avoid "cannot resume running coroutine"
   local entry = self:parse_entry(entry_str,
@@ -966,6 +969,9 @@ function Previewer.buffer_or_file:populate_preview_buf(entry_str)
   entry = entry or coroutine.yield()
   if entry_str ~= self._last_entry or not self.win:validate_preview() then return false end
   if utils.tbl_isempty(entry) then return end
+
+  -- kill previously running jobs
+  self:_stop_preview_job()
 
   -- check if cached is update-to-date to be reuse
   local cached, stale = self.bcache:check(entry)
@@ -978,7 +984,6 @@ function Previewer.buffer_or_file:populate_preview_buf(entry_str)
 
   -- if cached exists, must be stale, otherwise alloc a new buffer
   local buf = (cached or {}).bufnr or self:get_tmp_buffer()
-  self:_stop_preview_job()
 
   if entry.bufnr and api.nvim_buf_is_loaded(entry.bufnr) and vim.bo[entry.bufnr].filetype ~= "image" then
     self:_populate_loaded_buffer_preview(buf, entry)

--- a/lua/fzf-lua/previewer/builtin.lua
+++ b/lua/fzf-lua/previewer/builtin.lua
@@ -893,7 +893,7 @@ end
 ---@diagnostic disable-next-line: unused
 ---@param entry fzf-lua.buffer_or_file.Entry
 ---@return string?
-function Previewer.buffer_or_file:key_from_entry(entry)
+local key_from_entry = function(entry)
   if entry.do_not_cache then return nil end
   return (entry.bufnr and string.format("bufnr:%d", entry.bufnr) or entry.uri or entry.path) or nil
 end
@@ -902,7 +902,7 @@ end
 ---@param entry fzf-lua.buffer_or_file.Entry
 ---@return fzf-lua.buffer_or_file.Bcache?
 function Previewer.buffer_or_file:check_bcache(entry)
-  local key = self:key_from_entry(entry)
+  local key = key_from_entry(entry)
   if not key then return end
   local cached = self.cached_buffers[key]
   if not cached then return end
@@ -1576,7 +1576,7 @@ function Previewer.buffer_or_file:preview_buf_post(entry, min_winopts)
 
   -- Should we cache the current preview buffer?
   -- we cache only named buffers with valid path/uri
-  local key = self:key_from_entry(entry)
+  local key = key_from_entry(entry)
   if not key then return end
   local cached = self:cache_buffer(self.preview_bufnr, key, min_winopts)
   cached.tick = entry.tick

--- a/lua/fzf-lua/previewer/builtin.lua
+++ b/lua/fzf-lua/previewer/builtin.lua
@@ -592,16 +592,6 @@ function Previewer.buffer_or_file:should_clear_preview(_)
   return false
 end
 
----@param entry fzf-lua.buffer_or_file.Entry|{}
----@return boolean
-function Previewer.buffer_or_file:should_load_buffer(entry)
-  -- we don't have a previous entry to compare to or `do_not_cache` is set meaning
-  -- it's a terminal command (chafa, viu, ueberzug) which requires a reload
-  -- return 'true' so the buffer will be loaded in ::populate_preview_buf
-  if not self.loaded_entry or self.loaded_entry.do_not_cache then return true end
-  return self.loaded_entry.cached ~= entry.cached
-end
-
 function Previewer.buffer_or_file:start_ueberzug()
   if self._ueberzug_fifo then return self._ueberzug_fifo end
   self._ueberzug_fifo = path.join({
@@ -875,10 +865,9 @@ function Previewer.buffer_or_file:populate_preview_buf(entry_str)
   if entry_str ~= self._last_entry or not self.win:validate_preview() then return false end
   if utils.tbl_isempty(entry) then return end
   local cached = self:check_bcache(entry)
-  if cached and not cached.invalid and not self:should_load_buffer(entry) then
-    assert(cached.bufnr == self.preview_bufnr)
-    -- same file/buffer as previous entry no need to reload content
-    -- only call post to set cursor location
+
+  -- same file/buffer as previous entry no need to change preview buf
+  if cached and not cached.invalid and cached.bufnr == self.preview_bufnr then
     if type(self.cached_bufnrs[self.preview_bufnr]) == "table"
         and ((entry.line and entry.line > 0 and entry.line ~= self.orig_pos[1])
           or (entry.col and entry.col > 0 and entry.col - 1 ~= self.orig_pos[2])) then

--- a/lua/fzf-lua/previewer/builtin.lua
+++ b/lua/fzf-lua/previewer/builtin.lua
@@ -38,7 +38,6 @@ local Previewer = {}
 ---@field extensions { [string]: string|string[]? }
 ---@field ueberzug_scaler "crop"|"distort"|"contain"|"fit_contain"|"cover"|"forced_cover"
 ---@field bcache fzf-lua.Bcache
----@field listed_buffers table<integer, boolean?>
 ---@field clear_on_redraw boolean?
 ---@field timers? table<string, uv.uv_timer_t?>
 ---@field orig_pos? [integer, integer]
@@ -87,12 +86,6 @@ function Previewer.base:new(o, opts)
   self.bcache = require("fzf-lua.previewer.bcache").new(function(buf)
     self:safe_buf_delete(buf, true)
   end)
-  -- store currently listed buffers, this helps us determine which buffers
-  -- navigated with 'vim.lsp.util.show_document' we can safely unload
-  -- since show_document reuses buffers and I couldn't find a better way
-  -- to determine if the destination buffer was listed prior to the jump
-  local is_listed = function(b) return fn.buflisted(b) == 1 end ---@type fun(b: integer): boolean
-  self.listed_buffers = vim.tbl_map(is_listed, api.nvim_list_bufs())
   return self
 end
 
@@ -168,7 +161,12 @@ function Previewer.base:safe_buf_delete(bufnr, del_cached)
   -- can be nil after closing preview with <F4>
   if not bufnr then return end
   assert(type(bufnr) == "number" and bufnr > 0)
-  if self.listed_buffers[bufnr] then
+  -- store currently listed buffers, this helps us determine which buffers
+  -- navigated with 'vim.lsp.util.show_document' we can safely unload
+  -- since show_document reuses buffers and I couldn't find a better way
+  -- to determine if the destination buffer was listed prior to the jump
+  local buflist = (utils.__CTX() or {}).buflist or utils.CTX({ includeBuflist = true }).buflist or {}
+  if vim.tbl_contains(buflist, bufnr) and fn.buflisted(bufnr) == 1 then
     -- print("safe_buf_delete LISTED", bufnr)
     return
   elseif not api.nvim_buf_is_valid(bufnr) then

--- a/lua/fzf-lua/previewer/builtin.lua
+++ b/lua/fzf-lua/previewer/builtin.lua
@@ -1262,59 +1262,86 @@ function Previewer.buffer_or_file:set_cursor_hl(entry)
 
   ---@diagnostic disable-next-line: unnecessary-assert
   local buf, win, hls = assert(self.preview_bufnr, self.win.preview_winid, self.win.hls)
-  pcall(api.nvim_win_call, win, function()
-    local cached_pos = self.bcache:get_pos(buf)
-    if type(cached_pos) ~= "table" then cached_pos = nil end
-    local lnum, col = entry.line, math.max(1, entry.col or 1)
-    if not lnum or lnum < 1 then
-      -- set win option is slow with bigfile
-      utils.wo.cursorline = false
-      self.orig_pos = { 1, 0 }
-      api.nvim_win_set_cursor(win, cached_pos or self.orig_pos)
-      return
-    end
 
-    self.orig_pos = { lnum, col - 1 }
+  local cached_pos = self.bcache:get_pos(buf)
+  if type(cached_pos) ~= "table" then cached_pos = nil end
+  local lnum, col = entry.line, math.max(1, entry.col or 1)
+
+  if not lnum and regex then
+    -- pcall(fn.clearmatches, self.win.preview_winid)
+    pcall(api.nvim_win_call, win, function()
+      -- start searching at line 1 in case we
+      -- didn't reload the buffer (same file)
+      api.nvim_win_set_cursor(0, { 1, 0 })
+      fn.clearmatches()
+      local ctag = utils.ctag_to_magic(assert(regex))
+      -- test the regex so we can alert the user of the search fail
+      if not utils.vim_regex(ctag, self.opts) then return end
+      fn.search(regex, "W")
+      if hls.search then fn.matchadd(hls.search, regex) end
+      self.orig_pos = api.nvim_win_get_cursor(0)
+      utils.zz()
+    end)
+    return
+  end
+
+  if not lnum or lnum < 1 then
+    -- set win option is slow with bigfile
+    utils.wo.cursorline = false
+    self.orig_pos = { 1, 0 }
     api.nvim_win_set_cursor(win, cached_pos or self.orig_pos)
-    self:maybe_set_cursorline(win, self.orig_pos)
+    return
+  end
 
-    self.ns_previewer = self.ns_previewer or api.nvim_create_namespace("fzf-lua.preview.hl")
-    api.nvim_buf_clear_namespace(buf, self.ns_previewer, 0, -1)
-    local extmark
+  self.orig_pos = { lnum, col - 1 }
+  if not pcall(api.nvim_win_set_cursor, win, cached_pos or self.orig_pos) then
+    return
+  end
+  self:maybe_set_cursorline(win, self.orig_pos)
 
-    -- If regex is available (grep/lgrep), match on current line
-    if regex and hls.search then
-      local regex_start, regex_end
-      local reg = utils.vim_regex(regex, { silent = true })
-      if reg then
-        if regex ~= regex:lower() then
-          regex_start, regex_end = reg:match_line(buf, lnum - 1, col - 1)
-        else
-          local line = api.nvim_buf_get_lines(buf, lnum - 1, lnum, false)[1] or ""
-          regex_start, regex_end = reg:match_str(line:sub(col):lower())
-        end
+  self.ns_previewer = self.ns_previewer or api.nvim_create_namespace("fzf-lua.preview.hl")
+  api.nvim_buf_clear_namespace(buf, self.ns_previewer, 0, -1)
+  local extmark
+
+  -- If regex is available (grep/lgrep), match on current line
+  if regex and hls.search then
+    local regex_start, regex_end
+    -- vim.regex is always magic, see `:help vim.regex`
+    ---@diagnostic disable-next-line: param-type-mismatch
+    local reg = utils.vim_regex(regex, { silent = true })
+    if reg then
+      if regex ~= regex:lower() then
+        regex_start, regex_end = reg:match_line(buf, lnum - 1, col - 1)
+      else
+        local line = api.nvim_buf_get_lines(buf, lnum - 1, lnum, false)[1] or ""
+        regex_start, regex_end = reg:match_str(line:sub(col):lower())
       end
-      if regex_start and regex_end then
-        extmark = api.nvim_buf_set_extmark(buf, self.ns_previewer, lnum - 1, regex_start + col - 1, {
-          end_line = lnum - 1,
-          end_col = regex_end + col - 1,
-          hl_group = entry.hlgroup or hls.search
-        })
-      end
+    elseif self.opts.silent ~= true then
+      utils.warn(
+        [[Unable to init vim.regex with "%s", %s. . Add 'silent=true' to hide this message.]],
+        regex, reg)
     end
-
-    -- Fallback to cursor hl, only if column exists
-    if not extmark and hls.cursor and entry.col then
-      local end_lnum, end_col = entry.end_line or lnum, entry.end_col or col + 1
-      api.nvim_buf_set_extmark(buf, self.ns_previewer, lnum - 1, col - 1, {
-        end_line = end_lnum - 1,
-        end_col = math.max(1, end_col) - 1,
-        hl_group = entry.hlgroup or hls.cursor,
+    if regex_start and regex_end then
+      extmark = api.nvim_buf_set_extmark(buf, self.ns_previewer, lnum - 1, regex_start + col - 1, {
+        end_line = lnum - 1,
+        end_col = regex_end + col - 1,
+        hl_group = entry.hlgroup or hls.search
       })
     end
+  end
 
-    utils.zz()
-  end)
+  -- Fallback to cursor hl, only if column exists
+  if not extmark and hls.cursor and entry.col then
+    local end_lnum, end_col = entry.end_line or lnum, entry.end_col or col + 1
+    -- stale line/col can cause out-of-range, e.g. marks
+    vim.F.nil_wrap(api.nvim_buf_set_extmark)(buf, self.ns_previewer, lnum - 1, col - 1, {
+      end_line = end_lnum - 1,
+      end_col = math.max(1, end_col) - 1,
+      hl_group = entry.hlgroup or hls.cursor,
+    })
+  end
+
+  api.nvim_win_call(win, utils.zz)
 end
 
 ---@param entry fzf-lua.buffer_or_file.Entry
@@ -1382,8 +1409,10 @@ function Previewer.buffer_or_file:preview_buf_post(entry, min_winopts)
   self.bcache:set(entry, self.preview_bufnr, min_winopts)
 end
 
+---@class fzf-lua.previewer.Tags : fzf-lua.previewer.BufferOrFile,{}
+Previewer.tags = Previewer.buffer_or_file:extend()
+
 ---@class fzf-lua.previewer.HelpTags : fzf-lua.previewer.BufferOrFile,{}
----@field super fzf-lua.previewer.BufferOrFile
 Previewer.help_tags = Previewer.buffer_or_file:extend()
 
 ---@diagnostic disable-next-line: unused
@@ -1410,7 +1439,7 @@ function Previewer.help_tags:parse_entry(entry_str)
   end)()
   return {
     htag = tag,
-    hregex = hregex,
+    ctag = hregex,
     path = vimdoc,
   }
 end
@@ -1421,25 +1450,6 @@ function Previewer.help_tags:gen_winopts()
     number = false
   }
   return vim.tbl_extend("keep", winopts, self.winopts)
-end
-
----@class fzf-lua.help_tags.Entry: fzf-lua.buffer_or_file.Entry
----@field hregex string
-
----@param entry fzf-lua.help_tags.Entry
-function Previewer.help_tags:set_cursor_hl(entry)
-  pcall(api.nvim_win_call, self.win.preview_winid, function()
-    -- start searching at line 1 in case we
-    -- didn't reload the buffer (same file)
-    api.nvim_win_set_cursor(0, { 1, 0 })
-    fn.clearmatches()
-    fn.search(entry.hregex, "W")
-    if self.win.hls.search then
-      fn.matchadd(self.win.hls.search, entry.hregex)
-    end
-    self.orig_pos = api.nvim_win_get_cursor(0)
-    utils.zz()
-  end)
 end
 
 ---@class fzf-lua.previewer.ManPages : fzf-lua.previewer.BufferOrFile,{}
@@ -1501,12 +1511,7 @@ function Previewer.marks:parse_entry(entry_str)
     filepath = api.nvim_buf_get_name(bufnr)
   end
   if #filepath > 0 then
-    local ok, res = pcall(libuv.expand, filepath)
-    if not ok then
-      filepath = ""
-    else
-      filepath = res
-    end
+    filepath = vim.F.npcall(libuv.expand, filepath) or ""
     filepath = path.relative_to(filepath, utils.cwd())
   end
   return {
@@ -1543,34 +1548,6 @@ function Previewer.jumps:parse_entry(entry_str)
     line  = utils.tointeger(lnum) or 1,
     col   = col and col + 1 or 1,
   }
-end
-
----@class fzf-lua.previewer.Tags : fzf-lua.previewer.BufferOrFile,{}
----@field super fzf-lua.previewer.BufferOrFile,{}
-Previewer.tags = Previewer.buffer_or_file:extend()
-
----@param entry fzf-lua.buffer_or_file.Entry
-function Previewer.tags:set_cursor_hl(entry)
-  if tonumber(entry.line) and entry.line > 0 then
-    Previewer.buffer_or_file.set_cursor_hl(self, entry)
-    return
-  end
-  -- pcall(fn.clearmatches, self.win.preview_winid)
-  pcall(api.nvim_win_call, self.win.preview_winid, function()
-    -- start searching at line 1 in case we
-    -- didn't reload the buffer (same file)
-    api.nvim_win_set_cursor(0, { 1, 0 })
-    fn.clearmatches()
-    local ctag = utils.ctag_to_magic(assert(entry.ctag))
-    -- test the regex so we can alert the user of the search fail
-    if not utils.vim_regex(ctag, self.opts) then return end
-    fn.search(ctag, "W")
-    if self.win.hls.search then
-      fn.matchadd(self.win.hls.search, ctag)
-    end
-    self.orig_pos = api.nvim_win_get_cursor(0)
-    utils.zz()
-  end)
 end
 
 ---@class fzf-lua.previewer.Hightlights : fzf-lua.previewer.BufferOrFile,{}

--- a/lua/fzf-lua/previewer/builtin.lua
+++ b/lua/fzf-lua/previewer/builtin.lua
@@ -37,8 +37,7 @@ local Previewer = {}
 ---@field winopts_orig table
 ---@field extensions { [string]: string[]? }
 ---@field ueberzug_scaler "crop"|"distort"|"contain"|"fit_contain"|"cover"|"forced_cover"
----@field cached_bufnrs table<integer, [integer, integer]|true?> items are cached_pos
----@field cached_buffers table<string, fzf-lua.buffer_or_file.Bcache?>
+---@field bcache fzf-lua.Bcache
 ---@field listed_buffers table<integer, boolean?>
 ---@field clear_on_redraw boolean?
 ---@field timers? table<string, uv.uv_timer_t?>
@@ -88,9 +87,9 @@ function Previewer.base:new(o, opts)
     utils.warn(("Invalid ueberzug image scaler '%s', option will be omitted.")
       :format(o.ueberzug_scaler))
   end
-  -- cached buffers
-  self.cached_bufnrs = {}
-  self.cached_buffers = {}
+  self.bcache = require("fzf-lua.previewer.bcache").new(function(buf)
+    self:safe_buf_delete(buf, true)
+  end)
   -- store currently listed buffers, this helps us determine which buffers
   -- navigated with 'vim.lsp.util.show_document' we can safely unload
   -- since show_document reuses buffers and I couldn't find a better way
@@ -119,9 +118,7 @@ function Previewer.base:close(do_not_clear_cache)
   TSContext.deregister()
   self:restore_winopts()
   self:clear_preview_buf()
-  if not do_not_clear_cache then
-    self:clear_cached_buffers()
-  end
+  if not do_not_clear_cache and self.bcache then self.bcache:clear() end
   self.winopts_orig = {}
 end
 
@@ -180,7 +177,7 @@ function Previewer.base:safe_buf_delete(bufnr, del_cached)
   elseif not api.nvim_buf_is_valid(bufnr) then
     -- print("safe_buf_delete INVALID", bufnr)
     return
-  elseif not del_cached and self.cached_bufnrs[bufnr] then
+  elseif not del_cached and self.bcache:get_pos(bufnr) then
     -- print("safe_buf_delete CACHED", bufnr)
     return
   end
@@ -223,15 +220,6 @@ function Previewer.base:set_preview_buf(newbuf, min_winopts, no_wipe)
     -- get wiped when pressing `ctrl-g` too quickly
     self:safe_buf_delete(curbuf)
   end
-end
-
-function Previewer.base:clear_cached_buffers()
-  -- clear the buffer cache
-  for _, c in pairs(self.cached_buffers) do
-    self:safe_buf_delete(c.bufnr, true)
-  end
-  self.cached_bufnrs = {}
-  self.cached_buffers = {}
 end
 
 ---@param newbuf boolean?
@@ -454,13 +442,8 @@ function Previewer.base:scroll(direction)
   -- Conditionally toggle 'cursorline' based on cursor position
   self:maybe_set_cursorline(preview_winid, self.orig_pos)
   -- HACK: Hijack cached bufnr value as last scroll position
-  if self.cached_bufnrs[self.preview_bufnr] then
-    if direction == "reset" then
-      self.cached_bufnrs[self.preview_bufnr] = true
-    else
-      self.cached_bufnrs[self.preview_bufnr] = api.nvim_win_get_cursor(preview_winid)
-    end
-  end
+  self.bcache:update_pos(self.preview_bufnr,
+    direction == "reset" or api.nvim_win_get_cursor(preview_winid))
   self.win:update_preview_scrollbar()
   self:update_render_markdown()
   self:update_ts_context()
@@ -726,56 +709,6 @@ function Previewer.buffer_or_file:populate_terminal_cmd(tmpbuf, cmd, entry)
   return true
 end
 
----@diagnostic disable-next-line: unused
----@param entry fzf-lua.buffer_or_file.Entry
----@return string?
-local key_from_entry = function(entry)
-  if entry.do_not_cache then return nil end
-  return (entry.bufnr and string.format("bufnr:%d", entry.bufnr) or entry.uri or entry.path) or nil
-end
-
----get and check if cached is update-to-date to be reuse
----@param entry fzf-lua.buffer_or_file.Entry
----@return fzf-lua.buffer_or_file.Bcache?
-function Previewer.buffer_or_file:check_bcache(entry)
-  local key = key_from_entry(entry)
-  if not key then return end
-  local cached = self.cached_buffers[key]
-  if not cached then return end
-  entry.cached = cached
-  assert(self.cached_bufnrs[cached.bufnr])
-  assert(api.nvim_buf_is_valid(cached.bufnr))
-  if entry.tick ~= cached.tick then
-    cached.invalid = true
-    cached.tick = entry.tick
-  end
-  return cached
-end
-
----cache the bufnr for the entry, evict previous cache if exists
----@param bufnr integer
----@param entry fzf-lua.buffer_or_file.Entry
----@param min_winopts boolean?
-function Previewer.buffer_or_file:cache_buffer(bufnr, entry, min_winopts)
-  local key = key_from_entry(entry)
-  if not key then return end
-  local cached = self.cached_buffers[key]
-  if cached then
-    if cached.bufnr == bufnr then
-      -- already cached, nothing to do
-      return cached
-    else
-      -- new cached buffer for key, wipe current cached buf
-      self.cached_bufnrs[cached.bufnr] = nil
-      self:safe_buf_delete(cached.bufnr)
-    end
-  end
-  self.cached_bufnrs[bufnr] = true -- reset scroll position
-  self.cached_buffers[key] = { bufnr = bufnr, min_winopts = min_winopts, tick = entry.tick }
-  -- remove buffer auto-delete since it's now cached
-  vim.bo[bufnr].bufhidden = "hide"
-end
-
 ---@alias fzf-lua.line (string|[string,string])[]
 ---@param content (string|fzf-lua.line)[]
 ---@return string[], table
@@ -864,26 +797,28 @@ function Previewer.buffer_or_file:populate_preview_buf(entry_str)
   entry = entry or coroutine.yield()
   if entry_str ~= self._last_entry or not self.win:validate_preview() then return false end
   if utils.tbl_isempty(entry) then return end
-  local cached = self:check_bcache(entry)
+
+  -- check if cached is update-to-date to be reuse
+  local cached, stale = self.bcache:check(entry)
+  entry.cached = cached
 
   -- same file/buffer as previous entry no need to change preview buf
-  if cached and not cached.invalid and cached.bufnr == self.preview_bufnr then
-    if type(self.cached_bufnrs[self.preview_bufnr]) == "table"
-        and ((entry.line and entry.line > 0 and entry.line ~= self.orig_pos[1])
-          or (entry.col and entry.col > 0 and entry.col - 1 ~= self.orig_pos[2])) then
-      -- entry is within the same buffer but line|col has changed
-      -- clear cached buffer position so we scroll to entry's line|col
-      self.cached_bufnrs[self.preview_bufnr] = true
+  -- (e.g. only lnum changed, or unhide/resume)
+  if cached and not stale and cached.bufnr == self.preview_bufnr then
+    local line = entry.line and entry.line > 0 and entry.line or nil
+    local col = entry.col and entry.col > 0 and entry.col - 1 or nil
+    if not vim.deep_equal({ line, col }, self.orig_pos) then
+      self.bcache:reset_pos(self.preview_bufnr)
     end
-    self:preview_buf_post(entry)
+    self:preview_buf_post(entry, cached.min_winopts)
     return
   end
-  if cached and not cached.invalid then
+  if cached and not stale then
     self:set_preview_buf(cached.bufnr, cached.min_winopts)
     self:preview_buf_post(entry, cached.min_winopts)
     return
   end
-  local reuse_buf = (cached or {}).bufnr -- cached must be invalid now if exists
+  local reuse_buf = (cached or {}).bufnr -- cached must be stale now if exists
   self.clear_on_redraw = false
   -- kill previously running terminal jobs
   -- when using external commands extension map
@@ -1281,7 +1216,7 @@ function Previewer.buffer_or_file:set_cursor_hl(entry)
   ---@diagnostic disable-next-line: unnecessary-assert
   local buf, win, hls = assert(self.preview_bufnr, self.win.preview_winid, self.win.hls)
   pcall(api.nvim_win_call, win, function()
-    local cached_pos = self.cached_bufnrs[buf]
+    local cached_pos = self.bcache:get_pos(buf)
     if type(cached_pos) ~= "table" then cached_pos = nil end
     local lnum, col = entry.line, math.max(1, entry.col or 1)
     if not lnum or lnum < 1 then
@@ -1397,7 +1332,7 @@ function Previewer.buffer_or_file:preview_buf_post(entry, min_winopts)
 
   -- Should we cache the current preview buffer?
   -- we cache only named buffers with valid path/uri
-  self:cache_buffer(self.preview_bufnr, entry, min_winopts)
+  self.bcache:set(entry, self.preview_bufnr, min_winopts)
 end
 
 ---@class fzf-lua.previewer.HelpTags : fzf-lua.previewer.BufferOrFile,{}

--- a/lua/fzf-lua/previewer/builtin.lua
+++ b/lua/fzf-lua/previewer/builtin.lua
@@ -1019,7 +1019,7 @@ function Previewer.buffer_or_file:populate_preview_buf(entry_str)
     self:preview_buf_post(entry)
     return
   end
-  if cached and not cached.invalid and cached.bufnr then
+  if cached and not cached.invalid then
     self:set_preview_buf(cached.bufnr, cached.min_winopts)
     self:preview_buf_post(entry, cached.min_winopts)
     return
@@ -1333,9 +1333,9 @@ local filetype_detect = function(bufnr, filepath)
   return ft ~= "" and ft or nil
 end
 
----@param entry? fzf-lua.buffer_or_file.Entry
+---@param entry fzf-lua.buffer_or_file.Entry
 function Previewer.buffer_or_file:do_syntax(entry)
-  if not self.preview_bufnr or not entry or entry.cached then return end -- vim.bo[buf]._ft
+  if not self.preview_bufnr or entry.cached then return end -- vim.bo[buf]._ft
   local bufnr = self.preview_bufnr
   local preview_winid = self.win.preview_winid
   local filepath = entry.path ---@type string?

--- a/lua/fzf-lua/previewer/builtin.lua
+++ b/lua/fzf-lua/previewer/builtin.lua
@@ -3,143 +3,12 @@ local shell = require "fzf-lua.shell"
 local utils = require "fzf-lua.utils"
 local libuv = require "fzf-lua.libuv"
 local Object = require "fzf-lua.class"
+local TSContext = require "fzf-lua.previewer.tscontext"
 
 ---@diagnostic disable-next-line: deprecated
 local uv = vim.uv or vim.loop
 local api = vim.api
 local fn = vim.fn
-
-
----@class fzf-lua.TSContext
----@field private _winids table<integer, integer>
-local TSContext = {}
-
----@param opts TSContext.UserConfig
----@return boolean
-function TSContext.setup(opts)
-  if TSContext._setup then return true end
-  if not package.loaded["treesitter-context"] then
-    return false
-  end
-  -- Our temp nvim-treesitter-context config
-  TSContext._setup_opts = {}
-  for k, v in pairs(opts) do
-    TSContext._setup_opts[k] = { v }
-  end
-  local config = require("treesitter-context.config")
-  TSContext._config = utils.tbl_deep_clone(config)
-  for k, v in pairs(TSContext._setup_opts) do
-    v[2] = config[k]
-    config[k] = v[1]
-  end
-  TSContext._winids = {}
-  TSContext._setup = true
-  return true
-end
-
-function TSContext.deregister()
-  if not TSContext._setup then return end
-  for winid, _ in pairs(TSContext._winids) do
-    TSContext.close(winid)
-  end
-  local config = require("treesitter-context.config")
-  for k, v in pairs(TSContext._setup_opts) do
-    config[k] = v[2]
-  end
-  TSContext._config = nil
-  TSContext._winids = nil
-  TSContext._setup = nil
-end
-
----@param winid integer
----@return boolean?
-function TSContext.is_attached(winid)
-  if not TSContext._setup then return false end
-  return TSContext._winids[winid] and true or false
-end
-
----@param winid integer
-function TSContext.close(winid)
-  if not TSContext._setup then return end
-  require("treesitter-context.render").close(winid)
-  TSContext._winids[winid] = nil
-end
-
----@param winid integer
----@param bufnr integer
-function TSContext.toggle(winid, bufnr)
-  if not TSContext._setup then return end
-  if TSContext.is_attached(winid) then
-    TSContext.close(winid)
-  else
-    TSContext.update(winid, bufnr)
-  end
-end
-
-function TSContext.inc_dec_maxlines(num, winid, bufnr)
-  if not TSContext._setup then return end
-  local n = tonumber(num)
-  if not n then return end
-  local config = require("treesitter-context.config")
-  local max_lines = config.max_lines or 0
-  config.max_lines = math.max(0, max_lines + n)
-  utils.info("treesitter-context `max_lines` set to %d.", config.max_lines)
-  if TSContext.is_attached(winid) then
-    for _, t in ipairs({ 0, 20 }) do
-      vim.defer_fn(function() TSContext.update(winid, bufnr) end, t)
-    end
-  end
-end
-
----@alias TSContext.UserConfig table
----@param winid integer
----@param bufnr integer
----@param opts? TSContext.UserConfig
-function TSContext.update(winid, bufnr, opts)
-  opts = opts or {}
-  if not TSContext.setup(opts) then return end
-  assert(not api.nvim_win_is_valid(winid) or bufnr == api.nvim_win_get_buf(winid))
-  local render = require("treesitter-context.render")
-  local context_ranges, context_lines = require("treesitter-context.context").get(winid)
-  if not context_ranges or #context_ranges == 0 then
-    TSContext.close(winid)
-  else
-    assert(context_lines)
-    local function open()
-      if api.nvim_buf_is_valid(bufnr) and api.nvim_win_is_valid(winid) then
-        -- ensure context win is above
-        local fix = function(win, zindex)
-          if win and api.nvim_win_is_valid(win) then
-            utils.win_set_config(win, { zindex = zindex })
-            -- noautocmd don't ignore WinResized/WinScrolled
-            utils.wo[win].eventignorewin = "WinResized"
-          end
-        end
-        api.nvim_win_call(winid, function()
-          render.open(winid, context_ranges, context_lines)
-          TSContext.window_contexts = TSContext.window_contexts or
-              utils.upvfind(render.open, "window_contexts")
-          if not TSContext.window_contexts then return end
-          local window_context = TSContext.window_contexts[winid]
-          if not window_context then return end
-          fix(window_context.context_winid, TSContext.zindex)
-          fix(window_context.gutter_winid, TSContext.zindex)
-        end)
-        TSContext._winids[winid] = bufnr
-      end
-    end
-    -- NOTE: no longer required since adding `eventignore` to `FzfWin:set_winopts`
-    -- if TSContext.is_attached(winid) == bufnr then
-    open()
-    -- else
-    --   -- HACK: but the entire nvim-treesitter-context is essentially a hack
-    --   -- https://github.com/ibhagwan/fzf-lua/issues/1552#issuecomment-2525456813
-    --   for _, t in ipairs({ 0, 20 }) do
-    --     vim.defer_fn(function() open() end, t)
-    --   end
-    -- end
-  end
-end
 
 local Previewer = {}
 
@@ -1191,50 +1060,12 @@ function Previewer.base:update_ts_context()
   then
     return
   end
-  local ft = vim.b[bufnr] and vim.b[bufnr]._ft
-  if not ft then
-    TSContext.close(self.win.preview_winid)
-    return
+  local cancel = function()
+    local new_bufnr = self.preview_bufnr
+    return bufnr ~= new_bufnr or not api.nvim_buf_is_valid(bufnr)
   end
-  -- HACK: since TS async parsing commit we cannot guarantee the TSContext ranges as these will
-  -- return empty unless parsing is complete and we have no access to the `on_parse` event
-  -- https://github.com/neovim/neovim/commit/45e606b1fddbfeee8fe28385b5371ca6f2fba71b
-  -- For more info see #1922
-  local lang = vim.treesitter.language.get_lang(ft)
-  if not lang or not utils.has_ts_parser(lang, "context") then
-    TSContext.close(self.win.preview_winid)
-    return
-  end
-  local parser, err = vim.treesitter.get_parser(bufnr, lang, { error = false })
-  -- TODO: fix `has_ts_parser` regression from a953548 (#2366)
-  -- should never fail since `utils.has_ts_parser` returned true
-  -- assert(parser, "'vim.treesitter.get_parser' err: " .. tostring(err))
-  if not parser or err then
-    TSContext.close(self.win.preview_winid)
-    return
-  end
-  local context_updated
-  TSContext.zindex = self.win.winopts.zindex + 20
-  for _, t in ipairs({ 0, 20, 50, 100 }) do
-    vim.defer_fn(function()
-      local new_bufnr = self.preview_bufnr
-      if context_updated
-          or bufnr ~= new_bufnr
-          or not bufnr
-          or not api.nvim_buf_is_valid(bufnr)
-      then
-        return
-      end
-      if parser:is_valid(true) then
-        context_updated = true
-        TSContext.update(self.win.preview_winid, bufnr, vim.tbl_extend("force",
-          type(self.treesitter.context) == "table" and self.treesitter.context or {}, {
-            -- `multiwindow` must be set regardless of user options
-            multiwindow = true,
-          }))
-      end
-    end, t)
-  end
+  TSContext.schedule_update(self.win.preview_winid, bufnr, self.win.winopts.zindex + 20, cancel,
+    self.treesitter.context)
 end
 
 function Previewer.base:update_render_markdown()

--- a/lua/fzf-lua/previewer/builtin.lua
+++ b/lua/fzf-lua/previewer/builtin.lua
@@ -35,7 +35,7 @@ local Previewer = {}
 ---@field treesitter table
 ---@field toggle_behavior "default"|"extend"
 ---@field winopts_orig table
----@field extensions { [string]: string[]? }
+---@field extensions { [string]: string|string[]? }
 ---@field ueberzug_scaler "crop"|"distort"|"contain"|"fit_contain"|"cover"|"forced_cover"
 ---@field bcache fzf-lua.Bcache
 ---@field listed_buffers table<integer, boolean?>
@@ -630,12 +630,13 @@ function Previewer.buffer_or_file:stop_ueberzug()
   end
 end
 
+---@param tmpbuf integer
+---@param cmd string|string[]
+---@param entry fzf-lua.buffer_or_file.Entry
+---@return boolean
 function Previewer.buffer_or_file:populate_terminal_cmd(tmpbuf, cmd, entry)
-  if not cmd then return end
   cmd = type(cmd) == "table" and utils.deepcopy(cmd) or { cmd }
-  if not cmd[1] or fn.executable(cmd[1]) ~= 1 then
-    return false
-  end
+  if not cmd[1] or fn.executable(cmd[1]) ~= 1 then return false end
   -- no caching: preview buf must be reattached for
   -- terminal image previews to have the correct size
   entry.do_not_cache = true
@@ -782,6 +783,198 @@ local start_cmd = function(buf, entry, opts)
   obj = vim.system(entry.cmd, sopts, on_exit)
 end
 
+---@param entry fzf-lua.buffer_or_file.Entry
+---@return [integer?, integer?]
+local entry_pos = function(entry)
+  local line = entry.line and entry.line > 0 and entry.line or nil
+  local col = entry.col and entry.col > 0 and entry.col - 1 or nil
+  return { line, col }
+end
+
+---@param data string
+---@return string[]
+local split_file_data = function(data)
+  local lines = vim.split(data, "[\r]?\n")
+  if data:sub(#data, #data) == "\n" or data:sub(#data - 1, #data) == "\r\n" then
+    table.remove(lines)
+  end
+  return lines
+end
+
+---@param entry fzf-lua.buffer_or_file.Entry
+---@param cached fzf-lua.BcacheEntry
+function Previewer.buffer_or_file:_apply_cached_preview(entry, cached)
+  -- same file/buffer as previous entry no need to change preview buf
+  -- (e.g. only lnum changed, or unhide/resume)
+  if cached.bufnr == self.preview_bufnr then
+    if not vim.deep_equal(entry_pos(entry), self.orig_pos) then
+      self.bcache:reset_pos(self.preview_bufnr)
+    end
+  else
+    self:set_preview_buf(cached.bufnr, cached.min_winopts)
+  end
+  self:preview_buf_post(entry, cached.min_winopts)
+end
+
+---@return nil
+function Previewer.buffer_or_file:_stop_preview_job()
+  self.clear_on_redraw = false
+  -- kill previously running terminal jobs
+  -- when using external commands extension map
+  if self._job_id and self._job_id > 0 then
+    fn.jobstop(self._job_id)
+    self._job_id = nil
+  end
+end
+
+---@param tmpbuf integer
+---@param entry fzf-lua.buffer_or_file.Entry
+---@return nil
+function Previewer.buffer_or_file:_populate_loaded_buffer_preview(tmpbuf, entry)
+  -- WE NO LONGER REUSE THE CURRENT BUFFER
+  -- this changes the buffer's 'getbufinfo[1].lastused'
+  -- which messes up our `buffers()` sort
+  entry.filetype = vim.bo[entry.bufnr].filetype
+  local lines = api.nvim_buf_get_lines(entry.bufnr, 0, -1, false)
+  vim.bo[tmpbuf].expandtab = vim.bo[entry.bufnr].expandtab
+  vim.bo[tmpbuf].shiftwidth = vim.bo[entry.bufnr].shiftwidth
+  vim.bo[tmpbuf].tabstop = vim.bo[entry.bufnr].tabstop
+  api.nvim_buf_set_lines(tmpbuf, 0, -1, false, lines)
+  -- terminal buffers use minimal window style (2nd arg)
+  self:set_preview_buf(tmpbuf, entry.terminal)
+  self:preview_buf_post(entry, entry.terminal)
+end
+
+---@param tmpbuf integer?
+---@param entry fzf-lua.buffer_or_file.Entry
+---@return nil
+function Previewer.buffer_or_file:_populate_location_preview(tmpbuf, entry)
+  -- LSP 'jdt://' entries, see issue #195
+  -- https://github.com/ibhagwan/fzf-lua/issues/195
+  api.nvim_win_call(self.win.preview_winid, function()
+    local loc = { uri = entry.uri, range = entry.range }
+    local ok, res = pcall(utils.jump_to_location, loc, "utf-16", false)
+    if ok then
+      self.preview_bufnr = api.nvim_get_current_buf()
+      return
+    end
+    -- in case of an error display the stacktrace in the preview buffer
+    local name = utils.__HAS_NVIM_011 and "show_document" or "jump_to_location"
+    local lines = { ("lsp.util.%s failed for '%s':"):format(name, entry.uri), "" }
+    vim.list_extend(lines, type(res) == "string" and utils.strsplit(res, "\n") or { "null" })
+    tmpbuf = tmpbuf or self:get_tmp_buffer()
+    api.nvim_buf_set_lines(tmpbuf, 0, -1, false, lines)
+    self:set_preview_buf(tmpbuf)
+  end)
+  self:preview_buf_post(entry)
+end
+
+---@param tmpbuf integer
+---@param entry fzf-lua.buffer_or_file.Entry
+---@param lines (fzf-lua.line|string)[]
+---@return nil
+function Previewer.buffer_or_file:_set_preview_lines(tmpbuf, entry, lines)
+  local textlines, extmarks = parse_rich(lines)
+  extmarks = entry.extmarks or extmarks
+  pcall(api.nvim_buf_set_lines, tmpbuf, 0, -1, false, textlines)
+  if extmarks and #extmarks > 0 then
+    local setmark = vim.F.nil_wrap(api.nvim_buf_set_extmark)
+    local ns = api.nvim_create_namespace("fzf-lua.preview.hl")
+    for _, extmark in ipairs(extmarks) do
+      setmark(tmpbuf, ns, extmark.row, extmark.col,
+        { end_col = extmark.end_col, hl_group = extmark.hl_group })
+    end
+  end
+  if entry.open_term then api.nvim_open_term(tmpbuf, {}) end
+  self:set_preview_buf(tmpbuf)
+  self:preview_buf_post(entry)
+end
+
+---@param tmpbuf integer
+---@param entry fzf-lua.buffer_or_file.Entry
+---@param entry_str string
+---@return nil
+function Previewer.buffer_or_file:_populate_cmd_preview(tmpbuf, entry, entry_str)
+  local opened = false
+  return start_cmd(tmpbuf, entry, {
+    cancel = function() return entry_str ~= self._last_entry end,
+    on_send = function()
+      if opened then return end
+      opened = true
+      self:set_preview_buf(tmpbuf, true)
+    end,
+    on_exit = function()
+      self:preview_buf_post(entry)
+    end,
+  })
+end
+
+---@param tmpbuf integer
+---@param entry fzf-lua.buffer_or_file.Entry
+---@return nil
+function Previewer.buffer_or_file:_populate_file_preview(tmpbuf, entry)
+  utils.read_file_async(entry.path, vim.schedule_wrap(function(data)
+    -- if file ends in new line, don't write an empty string as the last
+    -- line.
+    api.nvim_buf_set_lines(tmpbuf, 0, -1, false, split_file_data(data))
+    -- swap preview buffer with new one
+    self:set_preview_buf(tmpbuf)
+    self:preview_buf_post(entry)
+  end))
+end
+
+---@param tmpbuf integer
+---@param entry fzf-lua.buffer_or_file.Entry
+---@param entry_str string
+---@return nil
+function Previewer.buffer_or_file:_populate_standard_preview(tmpbuf, entry, entry_str)
+  local cmd
+  if entry.path and self.extensions and not utils.tbl_isempty(self.extensions) then
+    local ext = path.extension(entry.path)
+    cmd = ext and self.extensions[ext:lower()] or nil
+  end
+  -- will return 'false' when cmd isn't executable.
+  -- If we get here it means preview was successful
+  -- it can still fail if using wrong command flags
+  -- but the user will be able to see the error in
+  -- the preview win
+  if cmd and self:populate_terminal_cmd(tmpbuf, cmd, entry) then return end
+  if self:attach_snacks_image_buf(tmpbuf, entry) then
+    self:preview_buf_post(entry)
+    return
+  end
+
+  ---@type (fzf-lua.line|string)[]?
+  local lines
+  if entry.debug then
+    lines = { { { entry.debug, "Error" } } }
+  elseif entry.content then
+    lines = entry.content
+  elseif entry.cmd then
+    return self:_populate_cmd_preview(tmpbuf, entry, entry_str)
+  else
+    -- make sure the file is readable (or bad entry.path)
+    local fs_stat = entry.path and uv.fs_stat(entry.path)
+    local is_binary = fs_stat and fs_stat.size > 0 and utils.perl_file_is_binary(entry.path) or false
+    if not fs_stat then
+      lines = { string.format("Unable to stat file %s", entry.path) }
+    elseif is_binary then
+      lines = { "Preview is not supported for binary files." }
+    elseif tonumber(self.limit_b) > 0 and fs_stat.size > self.limit_b then
+      lines = {
+        ("Preview file size limit (>%dMB) reached, file size %dMB.")
+            :format(self.limit_b / (1024 * 1024), fs_stat.size / (1024 * 1024)),
+        -- "(configured via 'previewers.builtin.limit_b')"
+      }
+    end
+    if not lines then
+      return self:_populate_file_preview(tmpbuf, entry)
+    end
+  end
+
+  self:_set_preview_lines(tmpbuf, entry, lines)
+end
+
 ---@async
 ---@param entry_str string
 ---@return false? no preview
@@ -802,156 +995,20 @@ function Previewer.buffer_or_file:populate_preview_buf(entry_str)
   local cached, stale = self.bcache:check(entry)
   entry.cached = cached
 
-  -- same file/buffer as previous entry no need to change preview buf
-  -- (e.g. only lnum changed, or unhide/resume)
-  if cached and not stale and cached.bufnr == self.preview_bufnr then
-    local line = entry.line and entry.line > 0 and entry.line or nil
-    local col = entry.col and entry.col > 0 and entry.col - 1 or nil
-    if not vim.deep_equal({ line, col }, self.orig_pos) then
-      self.bcache:reset_pos(self.preview_bufnr)
-    end
-    self:preview_buf_post(entry, cached.min_winopts)
-    return
-  end
   if cached and not stale then
-    self:set_preview_buf(cached.bufnr, cached.min_winopts)
-    self:preview_buf_post(entry, cached.min_winopts)
+    self:_apply_cached_preview(entry, cached)
     return
   end
-  local reuse_buf = (cached or {}).bufnr -- cached must be stale now if exists
-  self.clear_on_redraw = false
-  -- kill previously running terminal jobs
-  -- when using external commands extension map
-  if self._job_id and self._job_id > 0 then
-    fn.jobstop(self._job_id)
-    self._job_id = nil
-  end
-  if entry.bufnr and api.nvim_buf_is_loaded(entry.bufnr) and vim.bo[entry.bufnr].filetype ~= "image" then
-    -- WE NO LONGER REUSE THE CURRENT BUFFER
-    -- this changes the buffer's 'getbufinfo[1].lastused'
-    -- which messes up our `buffers()` sort
-    entry.filetype = vim.bo[entry.bufnr].filetype
-    local lines = api.nvim_buf_get_lines(entry.bufnr, 0, -1, false)
-    local tmpbuf = reuse_buf or self:get_tmp_buffer()
-    vim.bo[tmpbuf].expandtab = vim.bo[entry.bufnr].expandtab
-    vim.bo[tmpbuf].shiftwidth = vim.bo[entry.bufnr].shiftwidth
-    vim.bo[tmpbuf].tabstop = vim.bo[entry.bufnr].tabstop
-    api.nvim_buf_set_lines(tmpbuf, 0, -1, false, lines)
-    -- terminal buffers use minimal window style (2nd arg)
-    self:set_preview_buf(tmpbuf, entry.terminal)
-    self:preview_buf_post(entry, entry.terminal)
-  elseif entry.uri and entry.range then
-    -- LSP 'jdt://' entries, see issue #195
-    -- https://github.com/ibhagwan/fzf-lua/issues/195
-    api.nvim_win_call(self.win.preview_winid, function()
-      local loc = { uri = entry.uri, range = entry.range }
-      local ok, res = pcall(utils.jump_to_location, loc, "utf-16", false)
-      if ok then
-        self.preview_bufnr = api.nvim_get_current_buf()
-      else
-        -- in case of an error display the stacktrace in the preview buffer
-        local lines = type(res) == "string" and utils.strsplit(res, "\n") or { "null" }
-        table.insert(lines, 1,
-          string.format("lsp.util.%s failed for '%s':",
-            utils.__HAS_NVIM_011 and "show_document" or "jump_to_location", entry.uri))
-        table.insert(lines, 2, "")
-        local tmpbuf = reuse_buf or self:get_tmp_buffer()
-        api.nvim_buf_set_lines(tmpbuf, 0, -1, false, lines)
-        self:set_preview_buf(tmpbuf)
-      end
-    end)
-    self:preview_buf_post(entry)
-  else
-    -- not found in cache, attempt to load
-    local tmpbuf = reuse_buf or self:get_tmp_buffer()
-    if entry.path and self.extensions and not utils.tbl_isempty(self.extensions) then
-      local ext = path.extension(entry.path)
-      local cmd = ext and self.extensions[ext:lower()]
-      if cmd and self:populate_terminal_cmd(tmpbuf, cmd, entry) then
-        -- will return 'false' when cmd isn't executable.
-        -- If we get here it means preview was successful
-        -- it can still fail if using wrong command flags
-        -- but the user will be able to see the error in
-        -- the preview win
-        return
-      end
-    end
-    if self:attach_snacks_image_buf(tmpbuf, entry) then
-      self:preview_buf_post(entry)
-      return
-    end
-    do
-      ---@type (fzf-lua.line|string)[]
-      local lines
-      if entry.debug then
-        lines = { { { entry.debug, "Error" } } }
-      elseif entry.content then
-        lines = entry.content
-      elseif entry.cmd then
-        local opened = false
-        return start_cmd(tmpbuf, entry, {
-          cancel = function() return entry_str ~= self._last_entry end,
-          on_send = function()
-            if opened then return end
-            opened = true
-            self:set_preview_buf(tmpbuf, true)
-          end,
-          on_exit = function()
-            self:preview_buf_post(entry)
-          end,
-        })
-      else
-        -- make sure the file is readable (or bad entry.path)
-        local fs_stat = entry.path and uv.fs_stat(entry.path)
-        if not fs_stat then
-          lines = { string.format("Unable to stat file %s", entry.path) }
-        elseif fs_stat.type == "directory" then
-          local cmd = utils._if_win({ "cmd.exe", "/c", "dir" }, { "ls", "-la" })
-          table.insert(cmd, entry.path)
-          lines, _ = utils.io_systemlist(cmd)
-        elseif fs_stat.size > 0 and utils.perl_file_is_binary(entry.path) then
-          lines = { "Preview is not supported for binary files." }
-        elseif tonumber(self.limit_b) > 0 and fs_stat.size > self.limit_b then
-          lines = {
-            ("Preview file size limit (>%dMB) reached, file size %dMB.")
-                :format(self.limit_b / (1024 * 1024), fs_stat.size / (1024 * 1024)),
-            -- "(configured via 'previewers.builtin.limit_b')"
-          }
-        end
-      end
-      if lines then
-        local textlines, extmarks = parse_rich(lines)
-        extmarks = entry.extmarks or extmarks
-        pcall(api.nvim_buf_set_lines, tmpbuf, 0, -1, false, textlines)
-        if extmarks and #extmarks > 0 then
-          local setmark = vim.F.nil_wrap(api.nvim_buf_set_extmark)
-          local ns = api.nvim_create_namespace("fzf-lua.preview.hl")
-          for _, extmark in ipairs(extmarks) do
-            setmark(tmpbuf, ns, extmark.row, extmark.col,
-              { end_col = extmark.end_col, hl_group = extmark.hl_group })
-          end
-        end
-        if entry.open_term then api.nvim_open_term(tmpbuf, {}) end
-        -- swap preview buffer with new one
-        self:set_preview_buf(tmpbuf)
-        self:preview_buf_post(entry)
-        return
-      end
-    end
-    -- read the file into the buffer
-    utils.read_file_async(entry.path, vim.schedule_wrap(function(data)
-      local lines = vim.split(data, "[\r]?\n")
 
-      -- if file ends in new line, don't write an empty string as the last
-      -- line.
-      if data:sub(#data, #data) == "\n" or data:sub(#data - 1, #data) == "\r\n" then
-        table.remove(lines)
-      end
-      api.nvim_buf_set_lines(tmpbuf, 0, -1, false, lines)
-      -- swap preview buffer with new one
-      self:set_preview_buf(tmpbuf)
-      self:preview_buf_post(entry)
-    end))
+  local tmpbuf = (cached or {}).bufnr -- cached must be stale now if exists
+  self:_stop_preview_job()
+
+  if entry.bufnr and api.nvim_buf_is_loaded(entry.bufnr) and vim.bo[entry.bufnr].filetype ~= "image" then
+    self:_populate_loaded_buffer_preview(tmpbuf or self:get_tmp_buffer(), entry)
+  elseif entry.uri and entry.range then
+    self:_populate_location_preview(tmpbuf, entry)
+  else -- not found in cache, attempt to load
+    self:_populate_standard_preview(tmpbuf or self:get_tmp_buffer(), entry, entry_str)
   end
 end
 

--- a/lua/fzf-lua/previewer/builtin.lua
+++ b/lua/fzf-lua/previewer/builtin.lua
@@ -586,7 +586,8 @@ function Previewer.buffer_or_file:parse_entry(entry_str, _cb)
     end
   end
   local stat = entry.path and not entry.uri and uv.fs_stat(entry.path) or nil
-  entry.tick = entry.tick or vim.tbl_get(stat or {}, "mtime", "nsec")
+  entry.tick = entry.tick or
+      (stat and vim.inspect(stat.mtime, { newline = "", indent = "" }) or nil)
   if entry.debug then
     entry.content = { { { entry.debug, "Error" } } }
   elseif not stat then

--- a/lua/fzf-lua/previewer/builtin.lua
+++ b/lua/fzf-lua/previewer/builtin.lua
@@ -356,29 +356,6 @@ function Previewer.base:set_preview_buf(newbuf, min_winopts, no_wipe)
   end
 end
 
----@param bufnr integer
----@param key string
----@param min_winopts boolean?
----@return fzf-lua.buffer_or_file.Bcache
-function Previewer.base:cache_buffer(bufnr, key, min_winopts)
-  local cached = self.cached_buffers[key]
-  if cached then
-    if cached.bufnr == bufnr then
-      -- already cached, nothing to do
-      return cached
-    else
-      -- new cached buffer for key, wipe current cached buf
-      self.cached_bufnrs[cached.bufnr] = nil
-      self:safe_buf_delete(cached.bufnr)
-    end
-  end
-  self.cached_bufnrs[bufnr] = true
-  self.cached_buffers[key] = { bufnr = bufnr, min_winopts = min_winopts }
-  -- remove buffer auto-delete since it's now cached
-  vim.bo[bufnr].bufhidden = "hide"
-  return self.cached_buffers[key]
-end
-
 function Previewer.base:clear_cached_buffers()
   -- clear the buffer cache
   for _, c in pairs(self.cached_buffers) do
@@ -914,6 +891,30 @@ function Previewer.buffer_or_file:check_bcache(entry)
     cached.tick = entry.tick
   end
   return cached
+end
+
+---cache the bufnr for the entry, evict previous cache if exists
+---@param bufnr integer
+---@param entry fzf-lua.buffer_or_file.Entry
+---@param min_winopts boolean?
+function Previewer.buffer_or_file:cache_buffer(bufnr, entry, min_winopts)
+  local key = key_from_entry(entry)
+  if not key then return end
+  local cached = self.cached_buffers[key]
+  if cached then
+    if cached.bufnr == bufnr then
+      -- already cached, nothing to do
+      return cached
+    else
+      -- new cached buffer for key, wipe current cached buf
+      self.cached_bufnrs[cached.bufnr] = nil
+      self:safe_buf_delete(cached.bufnr)
+    end
+  end
+  self.cached_bufnrs[bufnr] = true -- reset scroll position
+  self.cached_buffers[key] = { bufnr = bufnr, min_winopts = min_winopts, tick = entry.tick }
+  -- remove buffer auto-delete since it's now cached
+  vim.bo[bufnr].bufhidden = "hide"
 end
 
 ---@alias fzf-lua.line (string|[string,string])[]
@@ -1576,10 +1577,7 @@ function Previewer.buffer_or_file:preview_buf_post(entry, min_winopts)
 
   -- Should we cache the current preview buffer?
   -- we cache only named buffers with valid path/uri
-  local key = key_from_entry(entry)
-  if not key then return end
-  local cached = self:cache_buffer(self.preview_bufnr, key, min_winopts)
-  cached.tick = entry.tick
+  self:cache_buffer(self.preview_bufnr, entry, min_winopts)
 end
 
 ---@class fzf-lua.previewer.HelpTags : fzf-lua.previewer.BufferOrFile,{}

--- a/lua/fzf-lua/previewer/tscontext.lua
+++ b/lua/fzf-lua/previewer/tscontext.lua
@@ -1,0 +1,183 @@
+local api = vim.api
+local utils = require("fzf-lua.utils")
+
+---@class fzf-lua.TSContext
+---@field zindex? integer
+---@field private _winids table<integer, integer> win to buf
+---@field private _setup_opts TSContext.UserConfig
+local M = {}
+
+---@param opts TSContext.UserConfig
+---@return boolean
+function M.setup(opts)
+  if M._setup then return true end
+  if not package.loaded["treesitter-context"] then
+    return false
+  end
+  -- Our temp nvim-treesitter-context config
+  M._setup_opts = {}
+  for k, v in pairs(opts) do
+    M._setup_opts[k] = { v }
+  end
+  local config = require("treesitter-context.config")
+  M._config = utils.tbl_deep_clone(config)
+  for k, v in pairs(M._setup_opts) do
+    v[2] = config[k]
+    config[k] = v[1]
+  end
+  M._winids = {}
+  M._setup = true
+  return true
+end
+
+function M.deregister()
+  if not M._setup then return end
+  for winid, _ in pairs(M._winids) do
+    M.close(winid)
+  end
+  local config = require("treesitter-context.config")
+  for k, v in pairs(M._setup_opts) do
+    config[k] = v[2]
+  end
+  M._config = nil
+  M._winids = nil
+  M._setup = nil
+end
+
+---@param winid integer
+---@return boolean?
+function M.is_attached(winid)
+  if not M._setup then return false end
+  return M._winids[winid] and true or false
+end
+
+---@param winid integer
+function M.close(winid)
+  if not M._setup then return end
+  require("treesitter-context.render").close(winid)
+  M._winids[winid] = nil
+end
+
+---@param winid integer
+---@param bufnr integer
+function M.toggle(winid, bufnr)
+  if not M._setup then return end
+  if M.is_attached(winid) then
+    M.close(winid)
+  else
+    M.update(winid, bufnr)
+  end
+end
+
+function M.inc_dec_maxlines(num, winid, bufnr)
+  if not M._setup then return end
+  local n = tonumber(num)
+  if not n then return end
+  local config = require("treesitter-context.config")
+  local max_lines = config.max_lines or 0
+  config.max_lines = math.max(0, max_lines + n)
+  utils.info("treesitter-context `max_lines` set to %d.", config.max_lines)
+  if M.is_attached(winid) then
+    for _, t in ipairs({ 0, 20 }) do
+      vim.defer_fn(function() M.update(winid, bufnr) end, t)
+    end
+  end
+end
+
+-- ts-context support global zindex config
+-- but we must override zindex to ensure zindex order:
+-- normal win's context < fzf win < (fzf) preview's context
+---@param win integer
+---@param zindex integer
+local set_zindex = function(win, zindex)
+  if win and api.nvim_win_is_valid(win) then
+    utils.win_set_config(win, { zindex = zindex })
+    -- noautocmd don't ignore WinResized/WinScrolled
+    utils.wo[win].eventignorewin = "WinResized"
+  end
+end
+
+---@alias TSContext.UserConfig table
+---@param winid integer
+---@param bufnr integer
+---@param opts? TSContext.UserConfig
+function M.update(winid, bufnr, opts)
+  opts = opts or {}
+  if not M.setup(opts) then return end
+  assert(not api.nvim_win_is_valid(winid) or bufnr == api.nvim_win_get_buf(winid))
+  local render = require("treesitter-context.render")
+  local context_ranges, context_lines = require("treesitter-context.context").get(winid)
+  if not context_ranges or #context_ranges == 0 then
+    M.close(winid)
+  else
+    assert(context_lines)
+    local function open()
+      if api.nvim_buf_is_valid(bufnr) and api.nvim_win_is_valid(winid) then
+        api.nvim_win_call(winid, function()
+          render.open(winid, context_ranges, context_lines)
+          M.window_contexts = M.window_contexts or
+              utils.upvfind(render.open, "window_contexts")
+          if not M.window_contexts then return end
+          local window_context = M.window_contexts[winid]
+          if not window_context or not M.zindex then return end
+          set_zindex(window_context.context_winid, M.zindex)
+          set_zindex(window_context.gutter_winid, M.zindex)
+        end)
+        M._winids[winid] = bufnr
+      end
+    end
+    -- NOTE: no longer required since adding `eventignore` to `FzfWin:set_winopts`
+    -- if TSContext.is_attached(winid) == bufnr then
+    open()
+    -- else
+    --   -- HACK: but the entire nvim-treesitter-context is essentially a hack
+    --   -- https://github.com/ibhagwan/fzf-lua/issues/1552#issuecomment-2525456813
+    --   for _, t in ipairs({ 0, 20 }) do
+    --     vim.defer_fn(function() open() end, t)
+    --   end
+    -- end
+  end
+end
+
+---@param winid integer
+---@param bufnr integer
+---@param zindex integer
+---@param cancel fun(): boolean
+---@param opts TSContext.UserConfig
+function M.schedule_update(winid, bufnr, zindex, cancel, opts)
+  local ft = vim.b[bufnr] and vim.b[bufnr]._ft
+  if not ft then
+    M.close(winid)
+    return
+  end
+  -- HACK: since TS async parsing commit we cannot guarantee the TSContext ranges as these will
+  -- return empty unless parsing is complete and we have no access to the `on_parse` event
+  -- https://github.com/neovim/neovim/commit/45e606b1fddbfeee8fe28385b5371ca6f2fba71b
+  -- For more info see #1922
+  local lang = vim.treesitter.language.get_lang(ft)
+  if not lang or not utils.has_ts_parser(lang, "context") then
+    M.close(winid)
+    return
+  end
+  local parser, err = vim.treesitter.get_parser(bufnr, lang, { error = false })
+  -- TODO: fix `has_ts_parser` regression from a953548 (#2366)
+  -- should never fail since `utils.has_ts_parser` returned true
+  -- assert(parser, "'vim.treesitter.get_parser' err: " .. tostring(err))
+  if not parser or err then
+    M.close(winid)
+    return
+  end
+  local context_updated
+  M.zindex = zindex
+  -- `multiwindow` must be set regardless of user options
+  opts = vim.tbl_extend("force", opts or {}, { multiwindow = true })
+  for _, t in ipairs({ 0, 20, 50, 100 }) do
+    vim.defer_fn(function()
+      if context_updated or cancel() or not parser:is_valid(true) then return end
+      context_updated = true
+      M.update(winid, bufnr, opts)
+    end, t)
+  end
+end
+
+return M

--- a/lua/fzf-lua/types.lua
+++ b/lua/fzf-lua/types.lua
@@ -30,23 +30,18 @@ local FzfLua = require("fzf-lua")
 ---@field no_scrollbar? boolean
 ---@field tick? integer
 ---@field no_syntax? boolean
----@field cached? fzf-lua.buffer_or_file.Bcache
+---@field cached? fzf-lua.BcacheEntry
 ---@field filetype? string
 ---@field content? (string|fzf-lua.line)[]
 ---@field end_line? integer 1-based
 ---@field end_col? integer 1-based
 ---@field open_term? boolean open_term for content (cmd always open_term)
+---@field cache_key? any unique cache key for entry (to reuse preview buffer)
 
 ---@class fzf-lua.keymap.Entry: fzf-lua.buffer_or_file.Entry
 ---@field vmap string?
 ---@field mode string?
 ---@field key string?
-
----@class fzf-lua.buffer_or_file.Bcache
----@field bufnr integer
----@field min_winopts? boolean
----@field invalid? boolean buffer content changed
----@field tick? integer
 
 ---@alias fzf-lua.config.Action fzf-lua.ActionSpec|fzf-lua.shell.data2|fzf-lua.shell.data2[]|false
 ---@alias fzf-lua.config.Actions { [1]?: boolean, [string]: fzf-lua.config.Action }

--- a/lua/fzf-lua/types.lua
+++ b/lua/fzf-lua/types.lua
@@ -24,6 +24,8 @@ local FzfLua = require("fzf-lua")
 ---@field cmd? string[] cmd used to generated content
 ---@field cmd_stream? boolean stream process cmd content
 ---@field cmd_opts? vim.SystemOpts vim.system opts for cmd
+---@field _is_ueberzug? boolean ueberzug cmd
+---@field pty? boolean require pty for cmd
 
 ---@class fzf-lua.buffer_or_file.Entry : fzf-lua.path.Entry, fzf-lua.cmd.Entry,{}
 ---@field do_not_cache? boolean

--- a/lua/fzf-lua/win.lua
+++ b/lua/fzf-lua/win.lua
@@ -866,12 +866,10 @@ function FzfWin:redraw_main()
   }, self.layout.fzf)
 
   if self:validate() then
-    if self._previewer
-        and self._previewer.clear_on_redraw
-        and self._previewer.clear_preview_buf
-        and self._previewer.clear_cached_buffers then
-      self._previewer:clear_preview_buf(true)
-      self._previewer:clear_cached_buffers()
+    local prev = self._previewer
+    if prev and prev.clear_on_redraw then
+      if prev.clear_preview_buf then prev:clear_preview_buf(true) end
+      if prev.bcache then prev.bcache:clear() end
     end
     utils.win_set_config(self.fzf_winid, winopts)
   else

--- a/tests/api_spec.lua
+++ b/tests/api_spec.lua
@@ -189,7 +189,7 @@ T["api"]["fzf_live"]["rg"]["error"] = new_set({}, {
       debug = 1,
       query = "[",
       __after_open = function()
-        child.wait_until(function() return child.lua_get([[_G._fzf_load_called]]) == true end)
+        if not helpers.IS_LINUX() then vim.uv.sleep(250) end
       end,
       -- fzf_opts = { ["--wrap"] = true },
     })

--- a/tests/files_spec.lua
+++ b/tests/files_spec.lua
@@ -212,7 +212,7 @@ T["files"]["line_query"] = function()
     previewer = "builtin",
     line_query = true,
     query = "lic es :21",
-    __after_open = function() if helpers.IS_WIN() then sleep(250) end end
+    __after_open = function() if not helpers.IS_LINUX() then sleep(250) end end
   }
   helpers.FzfLua.files(child, opts)
   -- child.wait_until(function() return exec_lua([[return _G._fzf_lua_on_create]]) == vim.NIL end)

--- a/tests/win_spec.lua
+++ b/tests/win_spec.lua
@@ -154,21 +154,16 @@ T["win"]["keymap"]["no error"] = new_set({
   function(key, _action)
     local builtin = child.lua_get [[FzfLua.defaults.keymap.builtin]]
     for _, event in ipairs({ "start", "load", "result" }) do
-      exec_lua([[
-        FzfLua.files {
-          query = "README.md",
-          winopts = { preview = { wrap = false } },
-          keymap = { true, fzf = { [...] = function() end } },
-        }
-      ]], { event })
-      child.wait_until(function()
-        return child.lua_get([[_G._fzf_load_called]]) == true
-      end)
-      child.type_keys(key)
-      child.type_keys("<c-c>")
-      child.wait_until(function()
-        return child.lua_get([[_G._fzf_load_called]]) == vim.NIL
-      end)
+      helpers.FzfLua.files(child, {
+        __abort_key = key .. "<c-c>",
+        __expect_lines = false,
+        __after_open = function()
+          if helpers.IS_WIN() then vim.uv.sleep(250) end
+        end,
+        query = "README.md",
+        winopts = { preview = { wrap = false } },
+        keymap = { true, fzf = { [event] = function() end } },
+      })
     end
   end })
 


### PR DESCRIPTION
- **tscontext**
- **bcache**
- **chore: useless check**
- **refactor: key_from_entry only related to entry**
- **refactor: make cache_buffer buffer previewer only**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Treesitter-context rendering added to preview windows for clearer code context

* **Refactor**
  * Buffer cache added for more reliable preview reuse and cursor/scroll position tracking
  * Modularized preview pipeline for files, commands, terminals, locations, and images
  * Improved cursor/highlight positioning and safer regex handling
  * Simplified terminal/image preview modes and command execution flow

* **Chores**
  * Simplified preview cache clearing during window redraws

* **Tests**
  * Made timing hooks platform-aware (non-Linux sleep behavior) and simplified test invocation flows
<!-- end of auto-generated comment: release notes by coderabbit.ai -->