### PR TITLE
fix(preview): buf can be deleted when preview (e.g. actions.buf_del)

### DIFF
--- a/lua/fzf-lua/previewer/builtin.lua
+++ b/lua/fzf-lua/previewer/builtin.lua
@@ -656,7 +656,7 @@ function Previewer.base:copy_extmarks()
     on_win = function(_, win, buf, topline, botline)
       if win ~= self.win.preview_winid then return end
       local src_buf = self.loaded_entry and self.loaded_entry.bufnr
-      if not src_buf then return end
+      if not src_buf or not api.nvim_buf_is_valid(src_buf) then return end
       copy_extmarks(src_buf, buf, win, topline, botline, self.ns_extmarks)
       return false
     end,


### PR DESCRIPTION
```
Decoration provider "win" (ns=fzf-lua.preview.extmarks):
Lua: fzf-lua/previewer/builtin.lua:466: Invalid buffer id: 23
stack traceback:
	[C]: in function 'nvim_buf_get_extmarks'
	fzf-lua/previewer/builtin.lua:466: in function 'copy_extmarks'
	fzf-lua/previewer/builtin.lua:489: in function <fzf-lua/previewer/builtin.lua:485>
```
