### PR TITLE
fix(actions): set lnum=0 + valid=1 in sel_to_qf

### DIFF
--- a/lua/fzf-lua/actions.lua
+++ b/lua/fzf-lua/actions.lua
@@ -314,7 +314,8 @@ local sel_to_qf = function(selected, opts, is_loclist)
     table.insert(qf_list, {
       bufnr = file.bufnr,
       filename = file.bufname or file.path or file.uri,
-      lnum = file.line > 0 and file.line or 1,
+      lnum = file.line or 0,
+      valid = 1,
       col = file.col,
       text = text,
     })

--- a/lua/fzf-lua/profiles/cli.lua
+++ b/lua/fzf-lua/profiles/cli.lua
@@ -133,8 +133,9 @@ return {
             local text = e.stripped:match(":%d+:%d?%d?%d?%d?:?(.*)$") or ""
             table.insert(qf_items, {
               filename = e.path,
-              lnum = math.max(1, e.line or 1),
-              col = math.max(1, e.col or 1),
+              lnum = e.line or 0,
+              col = e.col or 0,
+              valid = 1,
               text = text,
             })
           end


### PR DESCRIPTION
For any qf entry with/without lnum, `:cnext` don't respect
`:h restore-cursor`.

With lnum=0, user can rewrite `:cnext` in script to custom
the jump behavior, since this is a file entry.

`valid=1` to make sure `:cfdo` can work as expected (#1560).

e.g.:
```lua
---@param next boolean
local qf_next = function(next)
  next = next ~= false
  local list = fn.getqflist({ idx = 0, size = 0, items = 0 })
  local items, size, idx = list.items, list.size, list.idx
  local start, stop, step = unpack(next and { idx + 1, size, 1 } or { idx - 1, 1, -1 })
  for i = start, stop, step do
    local item = items[i]
    if item.valid == 1 and item.lnum == 0 then
      fn.setqflist({}, 'r', { idx = i })
      return vim.cmd('buffer ' .. item.bufnr)
    elseif next then
      return (pcall(vim.cmd.cnext) or pcall(vim.cmd.cfirst))
    else
      return (pcall(vim.cmd.cprevious) or pcall(vim.cmd.clast))
    end
  end
  if next then
    return (pcall(vim.cmd.cfirst))
  else
    return (pcall(vim.cmd.clast))
  end
end

---@param next boolean
M.next = function(next)
  if vim.bo.filetype ~= 'qf' then return qf_next(next) end
  return vim._with({ win = fn.win_getid(fn.winnr('#')) }, function() return qf_next(next) end)
end
```
