### PR TITLE
fix(global): convert other nest config

### DIFF
--- a/lua/fzf-lua/providers/meta.lua
+++ b/lua/fzf-lua/providers/meta.lua
@@ -194,7 +194,8 @@ M.global = function(opts)
       -- with-nth for the transform (e.g. for blines)
       -- TODO: we can probably inerit all opts but I'm not sure what would be
       -- the effects of that, this entire picker needs refactoring
-      local picker_opts = config.normalize_opts(t.opts, name:gsub("^lsp_", "lsp."))
+      local picker_opts = config.normalize_opts(t.opts,
+        name:gsub("^lsp_", "lsp."):gsub("^git_", "git."):gsub("^dap_", "dap."))
       if not utils.map_get(def, "opts.fzf_opts") then utils.map_set(def, "opts.fzf_opts", {}) end
       def.opts.fzf_opts = vim.tbl_deep_extend("force", def.opts.fzf_opts, picker_opts.fzf_opts)
       -- Instantiate the previewer, opts isn't guaranteed if the picker


### PR DESCRIPTION
`FzfLua global` error on cli
```
~ master ❯ E5113: Lua chunk: lua/fzf-lua/config.lua:193: attempt to index local 'picker_opts' (a nil value)
stack traceback:
        lua/fzf-lua/config.lua:193: in function <lua/fzf-lua/config.lua:190>
        lua/fzf-lua/config.lua:195: in function 'normalize_opts'
        lua/fzf-lua/providers/meta.lua:197: in function <lua/fzf-lua/providers/meta.lua:151>
        lua/fzf-lua/cmd.lua:38: in function 'run_command'
        scripts/cli.lua:66: in main chunk
```
