### PR TITLE
ci: fix headless tests on nightly

### DIFF
--- a/tests/headless_spec.lua
+++ b/tests/headless_spec.lua
@@ -45,13 +45,19 @@ local exec_term = function(c, cmd, args)
   eq(tonumber(id) > 0, true)
   c.lua(string.format("vim.fn.jobwait({%s})", tostring(id)))
   c.wait_until(function()
-    local lines = c.get_lines()
-    for i = #lines, 1, -1 do
-      if lines[i] == "" then
-        table.remove(lines, i)
+    if FzfLua.utils.__HAS_NVIM_012 then
+      -- https://github.com/neovim/neovim/pull/37987
+      local exitcode = c.lua_get("vim.api.nvim_get_chan_info(vim.bo.channel).exitcode")
+      return tonumber(exitcode) == 0
+    else
+      local lines = c.get_lines()
+      for i = #lines, 1, -1 do
+        if lines[i] == "" then
+          table.remove(lines, i)
+        end
       end
+      return lines[#lines] == "[Process exited 0]"
     end
-    return lines[#lines] == "[Process exited 0]"
   end)
 end
 


### PR DESCRIPTION
ref: https://github.com/neovim/neovim/pull/37987

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved headless test detection of process success across Neovim versions: newer versions use native exit-code checks while older versions retain the prior output-based fallback, ensuring more reliable cross-version test results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->