### PR TITLE
fix(git_diff): logic to match git diff command

### DIFF
--- a/lua/fzf-lua/core.lua
+++ b/lua/fzf-lua/core.lua
@@ -836,6 +836,22 @@ M.set_header = function(opts)
         return opts.search and #opts.search > 0 and opts.search
       end,
     },
+    ref = {
+      hdr_txt_opt = "ref_header_txt",
+      hdr_txt_str = "ref: ",
+      hdr_txt_col = opts.hls.header_text,
+      val = function()
+        return opts.ref and #opts.ref > 0 and opts.ref
+      end,
+    },
+    ref1 = {
+      hdr_txt_opt = "ref1_header_txt",
+      hdr_txt_str = "ref1: ",
+      hdr_txt_col = opts.hls.header_text,
+      val = function()
+        return opts.ref1 and #opts.ref1 > 0 and opts.ref1
+      end,
+    },
     lsp_query = {
       hdr_txt_opt = "lsp_query_header_txt",
       hdr_txt_str = "Query: ",

--- a/lua/fzf-lua/defaults.lua
+++ b/lua/fzf-lua/defaults.lua
@@ -666,15 +666,16 @@ M.defaults.git                   = {
   },
   ---Git diff (changed files vs a git ref).
   ---@class fzf-lua.config.GitDiff: fzf-lua.config.GitBase
-  ---Git reference to compare against.
-  ---@field ref? string
+  ---Git reference(s) to compare against.
+  ---@field ref? string|string[]
   ---Git reference used as the base for the comparison.
-  ---@field compare_against? string
+  -- `compare_against` was renamed to `ref1`
+  ---@field ref1? string
   diff = {
-    cmd               = "git --no-pager diff --name-only {compare_against} {ref}",
-    ref               = "HEAD",
-    compare_against   = "",
-    preview           = "git diff {compare_against} {ref} {file}",
+    cmd               = "git --no-pager diff --name-only {ref1} {ref}",
+    ref               = nil,
+    ref1              = nil,
+    preview           = "git diff {ref1} {ref} {file}",
     preview_pager     = M._preview_pager_fn,
     multiprocess      = 1, ---@type integer|boolean
     _type             = "file",
@@ -683,7 +684,14 @@ M.defaults.git                   = {
     fzf_opts          = { ["--multi"] = true },
     _fzf_nth_devicons = true,
     _actions          = function() return M.globals.actions.files end,
-    _headers          = { "cwd" },
+    _headers          = { "cwd", "actions" },
+    actions           = {
+      ["ctrl-q"] = {
+        fn = function() FzfLua.git_commits() end,
+        reuse = true,
+        header = "git commits"
+      },
+    },
   },
   ---Git diff hunks (changed lines).
   ---@class fzf-lua.config.GitHunks: fzf-lua.config.GitBase
@@ -717,6 +725,17 @@ M.defaults.git                   = {
     actions       = {
       ["enter"]  = actions.git_checkout,
       ["ctrl-y"] = { fn = actions.git_yank_commit, exec_silent = true },
+      ["ctrl-d"] = {
+        fn = function(s, _o)
+          if not s[1] then return FzfLua.utils.fzf_exit() end
+          local o = vim.deepcopy(_o.__call_opts)
+          o.ref = s[1]:match("[^ ]+")
+          o.ref1 = o.ref .. "~"
+          FzfLua.git_diff(o)
+        end,
+        reuse = true,
+        header = "git diff"
+      },
     },
     fzf_opts      = { ["--no-multi"] = true },
     _headers      = { "actions", "cwd" },
@@ -816,6 +835,7 @@ M.defaults.git                   = {
   },
   ---Git stashes.
   ---@class fzf-lua.config.GitStash: fzf-lua.config.GitBase
+  ---@field search? string
   stash = {
     cmd           = "git --no-pager stash list",
     preview       = "git --no-pager stash show --patch --color {1}",

--- a/lua/fzf-lua/path.lua
+++ b/lua/fzf-lua/path.lua
@@ -563,6 +563,9 @@ end
 
 ---@overload fun(cmd: string, opts: table): string
 ---@overload fun(cmd: string[], opts: table): string[]
+---@param cmd string|string[]
+---@param opts table
+---@return string|string[]
 function M.git_cwd(cmd, opts)
   local git_args = {
     { "cwd",          "-C" },

--- a/lua/fzf-lua/providers/git.lua
+++ b/lua/fzf-lua/providers/git.lua
@@ -91,39 +91,61 @@ local function git_preview(opts, file)
   return opts.preview
 end
 
+---@param opts fzf-lua.config.GitBase|{}?
+---@param ref string
+---@return boolean
+local git_validate_ref = function(opts, ref)
+  local cmd = path.git_cwd({ "git", "rev-parse", "--verify", ref }, opts --[[@as table]])
+  local _, exit_code = utils.io_systemlist(cmd --[[@as string[] ]])
+  if exit_code ~= 0 then
+    utils.warn("Invalid git ref %s", ref)
+    return false
+  end
+  return true
+end
+
 ---@param opts fzf-lua.config.GitDiff|{}?
 ---@return thread?, string?, table?
 M.diff = function(opts)
   ---@type fzf-lua.config.GitDiff
   opts = config.normalize_opts(opts, "git.diff")
   if not opts then return end
-  -- Ensure that ref is a commit hash in this git repository.
-  local validation_ref = path.git_cwd({ "git", "rev-parse", "--verify", opts.ref }, opts)
-  local _, exit_status_code_ref = utils.io_systemlist(validation_ref)
-  if exit_status_code_ref ~= 0 then
-    utils.warn("Invalid git ref %s", opts.ref)
-    return
+  -- Backward compat `compare_against` -> `ref1`
+  ---@diagnostic disable-next-line: undefined-field
+  opts.ref1 = opts.compare_against or opts.ref1
+  -- Convinience: ref as string array
+  if type(opts.ref) == "table" then
+    opts.ref, opts.ref1 = opts.ref[1], (opts.ref[2] or opts.ref1)
   end
-  -- If compare_against is given, ensure that it is a commit hash in this git repository.
-  if type(opts.compare_against) == "string" and #opts.compare_against > 0 then
-    local validation_comp = path.git_cwd({ "git", "rev-parse", "--verify", opts.compare_against },
-      opts)
-    local _, exit_code_status_comp = utils.io_systemlist(validation_comp)
-    if exit_code_status_comp ~= 0 then
-      utils.warn("Invalid git ref %s", opts.compare_against)
+  -- Ensure supplied refs are valid in this git repository.
+  for _, r in ipairs({ "ref", "ref1" }) do
+    if type(opts[r]) == "string" and #opts[r] > 0 and not git_validate_ref(opts, opts[r]) then
       return
     end
-  else
-    -- Default to diffing against ref and its direct parent commit.
-    opts.compare_against = opts.ref .. "^"
   end
-  opts.cmd = opts.cmd:gsub("[<{]ref[}>]", opts.ref)
-  opts.cmd = opts.cmd:gsub("[<{]compare_against[}>]", opts.compare_against)
-  opts.preview = opts.preview:gsub("[<{]ref[}>]", opts.ref)
-  opts.preview = opts.preview:gsub("[<{]compare_against[}>]", opts.compare_against)
+  -- If no ref was supplied default to last commit, otherwise compare against the index
+  if not opts.ref and not opts.ref1 then
+    local cmd = path.git_cwd(
+      { "git", "-c", "color.status=false", "--no-optional-locks", "status", "--porcelain=v1" },
+      opts --[[@as table]])
+    local out, exit_code = utils.io_systemlist(cmd --[[@as string[] ]])
+    if exit_code == 0 and #out == 0 then
+      opts.ref = "HEAD^"
+    else
+      opts.ref = "HEAD"
+    end
+  end
+  opts.cmd = opts.cmd:gsub("[<{]ref[}>]", opts.ref or "")
+  opts.cmd = opts.cmd:gsub("[<{]ref1[}>]", opts.ref1 or "")
+  opts.preview = opts.preview:gsub("[<{]ref[}>]", opts.ref or "")
+  opts.preview = opts.preview:gsub("[<{]ref1[}>]", opts.ref1 or "")
   opts = set_git_cwd_args(opts)
   if not opts.cwd then return end
   opts.preview = git_preview(opts, "{-1}")
+  if type(opts._headers) == "table" then
+    table.insert(opts._headers, "ref")
+    table.insert(opts._headers, "ref1")
+  end
   return core.fzf_exec(opts.cmd, opts)
 end
 
@@ -301,13 +323,10 @@ M.hunks = function(opts)
   ---@type fzf-lua.config.GitHunks
   opts = config.normalize_opts(opts, "git.hunks")
   if not opts then return end
-  local cmd = path.git_cwd({ "git", "rev-parse", "--verify", opts.ref }, opts)
-  local _, err = utils.io_systemlist(cmd)
-  if err ~= 0 then
-    utils.warn("Invalid git ref %s", opts.ref)
+  if type(opts.ref) == "string" and #opts.ref > 0 and not git_validate_ref(opts, opts.ref) then
     return
   end
-  opts.cmd = opts.cmd:gsub("[<{]ref[}>]", opts.ref)
+  opts.cmd = opts.cmd:gsub("[<{]ref[}>]", opts.ref or "")
   opts = set_git_cwd_args(opts)
   if not opts.cwd then return end
 


### PR DESCRIPTION
fix #2615

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * More flexible diff references: multi-value refs and explicit base ref support, with validation and smarter defaults.
  * Diff previews and commands updated to use the new reference behavior.
  * File lists and headers now include an "actions" column and display ref/ref1 when present.
  * Added parameter/return annotations for a git-path helper.

* **New Features**
  * Search in stash browsing.
  * New shortcuts: Ctrl-Q opens commit view; Ctrl-D runs a diff against the previous commit.

* **Documentation**
  * Notes updated to reflect renamed/expanded reference fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->