### PR TITLE
fix(tsinjector): pass lnum to line_parser

### DIFF
--- a/lua/fzf-lua/defaults.lua
+++ b/lua/fzf-lua/defaults.lua
@@ -1389,7 +1389,7 @@ M.defaults.tags = {
   -- field_index_expr = "{}", -- For `_fmt.from` to work with `bat_native`
   _actions      = function() return M.globals.actions.files end,
   actions       = { ["ctrl-g"] = { actions.grep_lgrep } },
-  _treesitter   = function(line) return ctag_line_parser(line, true) end,
+  _treesitter   = function(line, _) return ctag_line_parser(line, true) end,
 }
 
 ---Search current buffer ctags.

--- a/lua/fzf-lua/types.lua
+++ b/lua/fzf-lua/types.lua
@@ -204,7 +204,7 @@ local FzfLua = require("fzf-lua")
 ---@field _actions? fun():fzf-lua.config.Actions?
 ---@field __ACT_TO? function
 ---@field _start? boolean
----@field _treesitter? (fun(line: string):string?,string?,string?,string?)|boolean?
+---@field _treesitter? (fun(line: string, lnum: integer):string?,string?,string?,string?)|boolean?
 ---@field help_open_win? fun(buf: integer, enter: boolean, config: vim.api.keyset.win_config): integer
 ---Auto close fzf-lua interface when a terminal is opened, set to `false` to keep the interface open.
 ---@field autoclose? boolean

--- a/lua/fzf-lua/types.lua
+++ b/lua/fzf-lua/types.lua
@@ -116,6 +116,8 @@ local FzfLua = require("fzf-lua")
 ---@field get fun(self: fzf-lua.PidObject): integer
 ---@field set fun(self: fzf-lua.PidObject, pid: integer?)
 
+---@alias fzf-lua.treesitter.lineParser (fun(line: string, lnum?: integer):string?,string?,string|table?,string?)
+
 ---a basic config can be used by fzf_exec?
 ---generated from the result of `:=FzfLua.config.normalize_opts({}, {})`
 ---@class fzf-lua.config.Base
@@ -203,7 +205,7 @@ local FzfLua = require("fzf-lua")
 ---@field _actions? fun():fzf-lua.config.Actions?
 ---@field __ACT_TO? function
 ---@field _start? boolean
----@field _treesitter? (fun(line: string):string?,string?,string|table?,string?)|boolean?
+---@field _treesitter? fzf-lua.treesitter.lineParser
 ---@field help_open_win? fun(buf: integer, enter: boolean, config: vim.api.keyset.win_config): integer
 ---Auto close fzf-lua interface when a terminal is opened, set to `false` to keep the interface open.
 ---@field autoclose? boolean

--- a/lua/fzf-lua/win/tsinjector.lua
+++ b/lua/fzf-lua/win/tsinjector.lua
@@ -133,7 +133,7 @@ function M.attach(self, buf, line_parser)
   -- local utf8 = require("fzf-lua.lib.utf8")
   local function trim(s) return (string.gsub(s, "^%s*(.-)%s*$", "%1")) end
   ---@type fun(line: string):string?,string?,string?,string?
-  local default_line_parser = function(line) return line:match("(.-):?(%d+)[: ](.+)$") end
+  local default_line_parser = function(line, _) return line:match("(.-):?(%d+)[: ](.+)$") end
   line_parser = vim.is_callable(line_parser) and line_parser or default_line_parser
   M.cache[buf] = {}
   api.nvim_buf_attach(buf, false, {
@@ -171,7 +171,7 @@ function M.attach(self, buf, line_parser)
           -- file:line:text       (grep_project or missing "--column" flag)
           -- line:col:text        (grep_curbuf)
           -- line<U+00A0>text     (lines|blines)
-          local filepath, _lnum, text, _ft = line_parser(line:sub(min_col))
+          local filepath, _lnum, text, _ft = line_parser(line:sub(min_col), i)
           if not text or text == 0 then return end
 
           text = text:gsub("^%d+:", "") -- remove col nr if exists

--- a/lua/fzf-lua/win/tsinjector.lua
+++ b/lua/fzf-lua/win/tsinjector.lua
@@ -127,14 +127,14 @@ end
 
 ---@param self fzf-lua.Win
 ---@param buf integer
----@param line_parser (fun(line: string):string?,string?,string|table?,string?)|boolean?
+---@param line_parser? fzf-lua.treesitter.lineParser
 ---@return function detach
 function M.attach(self, buf, line_parser)
   -- local utf8 = require("fzf-lua.lib.utf8")
   local function trim(s) return (string.gsub(s, "^%s*(.-)%s*$", "%1")) end
   ---@type fun(line: string):string?,string?,string?,string?
-  local default_line_parser = function(line) return line:match("(.-):?(%d+)[: ](.+)$") end
-  ---@type (fun(line: string):string?,string?,string|table?,string?)
+  local default_line_parser = function(line, _) return line:match("(.-):?(%d+)[: ](.+)$") end
+  ---@type fzf-lua.treesitter.lineParser
   line_parser = vim.is_callable(line_parser) and line_parser or default_line_parser
   M.cache[buf] = {}
   api.nvim_buf_attach(buf, false, {
@@ -172,7 +172,7 @@ function M.attach(self, buf, line_parser)
           -- file:line:text       (grep_project or missing "--column" flag)
           -- line:col:text        (grep_curbuf)
           -- line<U+00A0>text     (lines|blines)
-          local filepath, _lnum, info, _ft = line_parser(line:sub(min_col + 1))
+          local filepath, _lnum, info, _ft = line_parser(line:sub(min_col + 1), i)
 
           -- info can be a string or `{ text = ..., start_col, end_col }`
           info = type(info) == "table" and info or { text = info }


### PR DESCRIPTION
It's non trivial to determine where the "prompt" line is.
When we have reverse/default layout, info/header/footer border

This is a workaround for user find the prompt hl annoying:
```lua
opts.command_history._treesitter = function(line, lnum)
  if lnum == 1 then return end
  return line:match("(.-):?(%d+)[: ](.+)$")
end
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Treesitter callbacks now receive optional line number information, enabling custom parsers to perform more contextual text processing.
  * Existing parsing behavior remains unchanged for current configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->