### PR TITLE
refactor(binds): consolidate all binds into a ...

### DIFF
--- a/docs/specs/2026-03-27-unified-binds-design.md
+++ b/docs/specs/2026-03-27-unified-binds-design.md
@@ -1,0 +1,441 @@
+# Unified Binds with Consolidated Transform Entry Point
+
+## Overview
+
+Refactor fzf-lua's bind system to unify `keymap.fzf`, `keymap.builtin`, and
+`actions` into a single `binds` table, and consolidate all complex fzf binds
+into a single `--bind=...:transform:SHELL_CMD` entry point using
+`shell.stringify_data`. Gated to fzf >= 0.59.
+
+## Motivation
+
+The current bind system is fragmented across multiple tables and code paths:
+
+- `keymap.fzf` — fzf-native key bindings
+- `keymap.builtin` — neovim terminal-mode keymaps for built-in actions
+- `actions` — accept/reload/exec_silent functions, processed by separate
+  conversion functions for built-in actions
+
+Bind construction is scattered across `create_fzf_binds`,
+`convert_reload_actions`, `convert_exec_silent_actions`, `setup_keybinds`,
+`setup_fzf_live_flags`, and `on_SIGWINCH`, producing many `--bind` arguments
+that inflate the fzf command line.
+
+This refactor consolidates everything into:
+1. A single user-facing `binds` table
+2. A single `--bind=...:transform:SHELL_CMD` for all complex operations
+3. Cleaner internal architecture with fewer code paths
+
+## User-Facing API
+
+### The Unified `binds` Table
+
+```lua
+require("fzf-lua").setup({
+  -- New unified format
+  binds = {
+    -- Simple fzf actions (direct --bind, no RPC overhead)
+    ["ctrl-z"]     = "abort",
+    ["ctrl-u"]     = "unix-line-discard",
+    ["ctrl-f"]     = "half-page-down",
+    ["alt-a"]      = "toggle-all",
+
+    -- Builtin neovim actions (routed through transform)
+    ["<F1>"]       = "toggle-help",
+    ["<F4>"]       = "toggle-preview",
+    ["<F5>"]       = "toggle-preview-cw",
+    ["<M-Esc>"]    = "hide",
+    ["<S-down>"]   = "preview-page-down",
+
+    -- Accept actions (print+accept, run in neovim after fzf exits)
+    ["enter"]      = { fn = actions.file_edit_or_qf, accept = true },
+    ["ctrl-s"]     = { fn = actions.file_split, accept = true },
+    ["ctrl-v"]     = { fn = actions.file_vsplit, accept = true },
+
+    -- Bare lua functions default to accept = true
+    ["ctrl-t"]     = actions.file_tabedit,
+
+    -- Reload actions (execute in transform, reload list)
+    ["ctrl-x"]     = { fn = actions.buf_del, reload = true },
+    ["left"]       = { fn = actions.git_stage, reload = true },
+
+    -- Exec-silent actions (execute in transform, no reload)
+    ["ctrl-y"]     = { fn = actions.git_yank_commit, exec_silent = true },
+
+    -- Reuse actions (accept but don't close window)
+    ["alt-i"]      = { fn = actions.toggle_ignore, reuse = true, header = false },
+
+    -- Events
+    ["load"]       = function() return "rebind(...)" end,
+    ["start"]      = function() return "change-header(...)" end,
+    ["resize"]     = function(args) ... end,
+
+    -- Help string support
+    ["ctrl-g"]     = { "first", desc = "Go to first" },
+  },
+
+  -- Old format still works (merge strategy, no deprecation)
+  keymap = {
+    fzf     = { ... },
+    builtin = { ... },
+  },
+  actions = { ... },
+})
+```
+
+### Key Format
+
+Both fzf-style (`ctrl-y`, `alt-a`, `f4`) and neovim-style (`<C-y>`, `<M-a>`,
+`<F4>`) keys are accepted. Keys are normalized internally using
+`utils.neovim_bind_to_fzf()` and `utils.fzf_bind_to_neovim()`.
+
+### Value Auto-Detection
+
+1. `type(v) == "function"` — bare lua function, treated as `{ fn = v, accept = true }`
+2. `type(v) == "table"` with `.fn` — complex action, properties preserved
+   (`accept`, `reload`, `exec_silent`, `reuse`, `noclose`, `desc`, `prefix`,
+   `postfix`, `field_index`, `header`)
+3. `type(v) == "string"` matching a known builtin action name — routed through
+   transform (calls neovim-side function, returns fzf action)
+4. `type(v) == "string"` not matching builtins — fzf-native action (direct bind)
+5. Key matching a known event name (including but not limited to: `load`,
+   `start`, `resize`, `change`, `zero`, `one`, `focus`, `result`, `multi`,
+   `click-header`, `click-footer`, `backward-eof`) — event bind
+
+Known builtin actions (from `keymap_tbl` and `_preview_keymaps` in win.lua):
+`toggle-help`, `toggle-fullscreen`, `toggle-preview`, `toggle-preview-cw`,
+`toggle-preview-ccw`, `toggle-preview-behavior`, `toggle-preview-wrap`,
+`toggle-preview-ts-ctx`, `toggle-preview-undo`, `preview-ts-ctx-dec`,
+`preview-ts-ctx-inc`, `preview-reset`, `preview-page-down`, `preview-page-up`,
+`preview-half-page-up`, `preview-half-page-down`, `preview-down`, `preview-up`,
+`preview-top`, `preview-bottom`, `focus-preview`, `hide`.
+
+### Precedence Order
+
+When the same key appears in multiple tables (highest wins):
+
+1. `binds`
+2. `actions`
+3. `keymap.fzf`
+4. `keymap.builtin`
+
+### Backward Compatibility
+
+All three old tables (`keymap.fzf`, `keymap.builtin`, `actions`) continue to
+work indefinitely. No deprecation. The `binds` table is additive — it takes
+precedence over the old tables for the same key, but doesn't require migrating
+existing configs.
+
+## Architecture
+
+### Consolidated Transform Entry Point (fzf >= 0.59)
+
+All complex binds share a **single RPC function registration** via
+`shell.pipe_wrap_fn` (called with an empty field index; the caller appends field
+expressions when constructing `--bind` entries). The generated base command
+(`BASE_CMD`) is reused across multiple `--bind` entries:
+
+- **Keys** share one `--bind` with comma-separated triggers, dispatched by
+  `$FZF_KEY`:
+  ```text
+  --bind=ctrl-r,ctrl-g,f4,f1:transform:BASE_CMD {+} {q} {n}
+  ```
+- **Events** get individual `--bind` entries with the event name baked in as a
+  literal argument:
+  ```text
+  --bind=load:transform:BASE_CMD __evt__load {+} {q} {n}
+  --bind=resize:transform:BASE_CMD __evt__resize {+} {q} {n}
+  --bind=start:transform:BASE_CMD __evt__start {+} {q} {n}
+  ```
+
+**Field index `{+} {q} {n}`:** All transform binds use the same field index
+pattern. `{+}` expands to the selected item(s), `{q}` to the current query,
+and `{n}` to the match count. This follows the pattern established by
+`stringify_data2` (shell.lua) which appends `{q} {n}` for query preservation
+on resume and zero-selected/zero-match disambiguation. The handler strips `{q}`
+and `{n}` from the tail of `items` before dispatching, and updates the resume
+query via `FzfLua.config.resume_set("query", query, opts)`.
+
+**Why separate `--bind` for events?** `$FZF_KEY` is only set for actual
+keypresses (fzf 0.50+). For events like `load`, `resize`, `start`, `$FZF_KEY`
+is empty (`""`). Rather than relying on `$FZF_ACTION` (which is unreliable —
+it reflects the last *action* executed, not the triggering event), we pass the
+event identity as a literal prefix argument (`__evt__<name>`) in the fzf field
+index. The handler checks `items[1]` for this prefix.
+
+The dispatch handler (one registration, shared by all binds):
+
+```lua
+-- Registered once via shell.pipe_wrap_fn (with empty field index)
+local function transform_handler(pipe, items, fzf_lines, fzf_columns, ctx)
+  -- Strip trailing {q} and {n} from items (appended by field index)
+  local match_count = table.remove(items)  -- {n}
+  local query = table.remove(items)         -- {q}
+  FzfLua.config.resume_set("query", query, opts)
+
+  -- Determine trigger: event prefix or $FZF_KEY
+  local key
+  if items[1] and items[1]:match("^__evt__") then
+    key = items[1]:sub(8)  -- strip "__evt__" prefix
+    table.remove(items, 1)
+  else
+    key = ctx.env.FZF_KEY
+  end
+
+  -- Zero-match/zero-selected fixup (same logic as stringify_data2)
+  local zero_matched = not tonumber(match_count)
+  local zero_selected = #items == 0 or (#items == 1 and #items[1] == 0)
+  if zero_matched and zero_selected then items = {} end
+
+  local handlers = opts.__transform_handlers[key]
+  if not handlers then
+    -- return empty string (no-op)
+    uv.write(pipe, ""); uv.close(pipe); return
+  end
+  local results = {}
+  for _, handler in ipairs(handlers) do
+    local act = handler(items, ctx)
+    if act and #act > 0 then table.insert(results, act) end
+  end
+  local result = table.concat(results, "+")
+  uv.write(pipe, result)
+  uv.close(pipe)
+end
+```
+
+**Note on `pipe_wrap_fn`:** The current implementation defaults `nil` field
+index to `"{+}"`. The consolidated handler needs `pipe_wrap_fn` called with
+`""` (empty string) so that no field index is baked into `BASE_CMD`. The field
+index is instead appended by the caller when constructing each `--bind` entry.
+This requires a minor adjustment: either pass `""` and accept a trailing space,
+or add a small guard in `pipe_wrap_fn` to omit the trailing space when field
+index is empty.
+
+The resulting fzf CLI has these `--bind` groups:
+
+1. **Direct binds:** `--bind=ctrl-z:abort,ctrl-u:unix-line-discard,...`
+   (simple fzf actions, combined into one)
+2. **Accept binds:** `--bind=enter:print(enter)+accept,...`
+   (accept actions via `actions.expect` or equivalent)
+3. **Key transform:** `--bind=ctrl-r,ctrl-g,f4,...:transform:BASE_CMD {+} {q} {n}`
+   (consolidated transform for all complex key binds)
+4. **Event transforms:** `--bind=load:transform:BASE_CMD __evt__load {+} {q} {n}`, etc.
+   (one per registered event, same RPC function)
+
+Plus any provider-specific binds from `_fzf_cli_args` (e.g.,
+`change:+transform:CMD` from `setup_fzf_live_flags` for live pickers).
+
+### Bind Classification (5 Categories)
+
+| Category | Condition | Routing |
+|----------|-----------|---------|
+| **Direct** | String value, not a known builtin | `--bind=key:action` (combined) |
+| **Accept** | `accept = true`, `reuse = true`, or bare function | `print(key)+accept` via `--bind` |
+| **Transform** | `reload`, `exec_silent`, builtin name, event, lua fn with explicit non-accept/non-reuse property | Consolidated `--bind=...:transform:BASE_CMD` |
+| **SIGWINCH** | Neovim-only key (no fzf equivalent), neovim terminal mode | `vim.keymap.set("t",...)` + SIGWINCH signal → transform's resize handler |
+| **Dropped** | Neovim-only key in tmux/CLI/Windows | Silently skipped (no terminal buffer) |
+
+### Three Operating Modes
+
+| Mode | Condition | Transform | SIGWINCH | Neovim-only keys |
+|------|-----------|-----------|----------|-----------------|
+| **Full** | fzf >= 0.59, neovim terminal | Yes | Yes | Yes (via SIGWINCH bridge) |
+| **Partial** | fzf >= 0.59, fzf-tmux or CLI profile | Yes | No | Dropped (no terminal buffer) |
+| **Legacy** | fzf < 0.59 | No (current paths) | Partial (>= 0.46) | Only via `keymap.builtin` |
+
+**Full mode:** All features available. Neovim-only keys (e.g., `<C-Enter>`,
+`<C-BS>`) use the SIGWINCH bridge: a neovim terminal keymap captures the
+keypress, sets a trigger scope on `opts.__sigwinch_triggers`, sends POSIX signal
+28 to fzf children, which fires the `resize` event in the consolidated
+transform. The handler checks `opts.__sigwinch_triggers` and dispatches to the
+registered handler.
+
+**Partial mode (fzf-tmux / CLI profile):** The consolidated transform works
+(headless nvim RPC is independent of where fzf runs) but SIGWINCH is unavailable
+because there is no neovim terminal buffer to capture keypresses or send signals
+from. Keys without fzf equivalents are silently dropped.
+
+**Legacy mode (fzf < 0.59):** The `binds` table is internally split into
+`keymap.fzf` and `keymap.builtin` during normalization, and existing code paths
+(`create_fzf_binds`, `convert_reload_actions`, `convert_exec_silent_actions`,
+`setup_keybinds`, `on_SIGWINCH`) handle them unchanged.
+
+### Builtin Actions in Transform
+
+When a builtin action (e.g., `toggle-preview`) is bound and the key has an fzf
+equivalent, it goes through the consolidated transform. The transform handler:
+
+1. Receives `$FZF_KEY` (e.g., `"f4"`)
+2. Calls the neovim-side function via RPC (e.g., `win.toggle_preview()`)
+3. Returns the appropriate fzf action string (e.g.,
+   `"change-preview-window(right,50%)"`)
+
+This is simpler than the current SIGWINCH approach for fzf-supported keys —
+the transform IS the RPC bridge, so no signal roundtrip is needed.
+
+### SIGWINCH Bridge (Neovim-Only Keys)
+
+For keys that have no fzf equivalent (e.g., `<C-Enter>`, `<C-BS>`):
+
+1. `vim.keymap.set("t", key, function() ... end)` captures the keypress
+2. Handler sets `opts.__sigwinch_triggers = { key_id }`
+3. Calls `self:SIGWINCH(...)` — sends signal 28 to fzf child processes
+4. Fzf fires the `resize` event → hits the consolidated transform
+5. Transform handler checks `opts.__sigwinch_triggers`, dispatches to the
+   registered handler for `key_id`
+6. Returns fzf action string
+
+The `resize` event is always included in the consolidated transform's key/event
+list when there are any SIGWINCH-bridged keys.
+
+## Actions Table Integration
+
+### Auto-Merge into Binds
+
+During `normalize_binds(opts)`, entries from `opts.actions` are converted and
+merged into the internal bind representation:
+
+| Actions entry | Converted to |
+|---------------|-------------|
+| `actions["ctrl-s"] = fn` | `{ fn = fn, accept = true }` |
+| `actions["ctrl-s"] = { fn1, fn2 }` | `{ fn = fn1, accept = true, chain = { fn2 } }` |
+| `actions["ctrl-x"] = { fn, actions.resume }` | `{ fn = fn, reload = true }` (backward compat pattern) |
+
+The `chain` field preserves the current behavior where `actions.act` iterates
+over an array of functions. In the normalized representation, `fn` is the
+primary function and `chain` holds additional functions to call sequentially
+with the same `(entries, opts)` arguments. `actions.act` continues to handle
+chained dispatch — no change to the post-exit accept flow.
+
+**Note:** The `{ fn, actions.resume }` array pattern is detected during
+normalization as a backward-compatible reload shorthand (`actions.resume`
+triggers fzf restart). This conversion happens before `chain` processing.
+
+| `actions["ctrl-x"] = { fn = fn, reload = true }` | `{ fn = fn, reload = true }` (preserved) |
+| `actions["alt-i"] = { fn = fn, reuse = true }` | `{ fn = fn, reuse = true }` (preserved) |
+| `actions["_internal"] = fn` | Not merged (underscore prefix = internal) |
+
+### Accept Actions
+
+Accept actions use fzf's `print(key)+accept` mechanism. They do NOT go through
+the consolidated transform because:
+- They need fzf to print the triggering key and exit
+- The post-exit `actions.act` dispatch reads the printed key to select the
+  handler
+- This is fundamentally different from in-flight actions
+
+### Hide Profile Support
+
+The hide profile's `enrich` function converts `accept = true` actions to
+`exec_silent = true`, wrapping the original function with `fzf.hide()`:
+
+```lua
+-- Hide profile enrich (adapted):
+for k, bind in pairs(merged_binds) do
+  if type(bind) == "table"
+      and bind.accept
+      and not bind.exec_silent
+      and not bind.reload
+      and not bind.noclose
+      and not bind.reuse
+      and not k:match("^_")
+  then
+    local original_fn = bind.fn
+    bind.accept = nil
+    bind.exec_silent = true
+    bind.fn = function(...)
+      fzf.hide()
+      if original_fn then original_fn(...) end
+      -- append to fzf history file if needed...
+    end
+  end
+end
+```
+
+The explicit `accept = true` property makes this introspection cleaner than the
+current approach (which infers accept by absence of other properties).
+
+**Timing:** `enrich` runs during `config.normalize_opts`, before
+`normalize_binds` generates the final `--bind` arguments. So `accept →
+exec_silent` conversion happens before bind routing classification, and the
+converted actions naturally end up in the transform handler instead of the
+accept path.
+
+## Normalization Flow
+
+```text
+User Config                         normalize_binds()                    Build Phase
+───────────                         ─────────────────                    ───────────
+
+binds = { ... }     ─┐                                                  create_fzf_binds()
+                     │                                                       │
+actions = { ... }   ─┤─► merge by precedence ─► classify each entry ─►  ┌───┴────┐
+                     │   (binds > actions >      into 5 categories      │        │
+keymap.fzf = { ... }─┤    keymap.fzf >                                  │  fzf   │
+                     │    keymap.builtin)     ┌─ direct ──────────► direct --bind │
+keymap.builtin={..} ─┘                       ├─ accept ──────────► print+accept  │
+                                             ├─ transform ────────► consolidated │
+                                             ├─ sigwinch ─────────► vim.keymap + │
+                                             │                      resize event │
+                                             └─ dropped ──────────► (skipped)    │
+                                                                    └────────────┘
+```
+
+## What Changes From Current Code
+
+| Current | New (fzf >= 0.59) |
+|---------|-------------------|
+| `create_fzf_binds` generates many `--bind` args | Generates few groups: direct, accept, key transform, event transforms |
+| `convert_reload_actions` adds per-key binds + `load:+rebind(...)` | Reload logic inside transform handler (atomic) |
+| `convert_exec_silent_actions` adds per-key binds | exec_silent logic inside transform handler |
+| `setup_keybinds` cross-registers builtin↔fzf + `vim.keymap.set("t",...)` | Builtins in transform; SIGWINCH bridge only for neovim-only keys |
+| `on_SIGWINCH` creates separate `resize:+transform:` | Resize is part of the consolidated transform |
+| Multiple `pipe_wrap_fn` / `stringify_data` calls | Single `pipe_wrap_fn` registration for all complex binds |
+| `actions.expect` generates `--expect` / `print(key)+accept` binds | Same mechanism, but sourced from unified bind representation |
+
+## What Stays The Same
+
+- **`setup_fzf_live_flags`**: `change:+transform:CMD` and `start:+transform:CMD`
+  for live pickers stay separate (they use the reload command directly, not the
+  dispatch handler)
+- **`FZF_DEFAULT_COMMAND`**: Stays as environment variable for string commands
+- **`actions.expect` / `actions.act`**: Continue to handle accept action
+  post-exit dispatch
+- **All code paths for fzf < 0.59**: Legacy mode is unchanged
+- **`--expect` generation**: Accept actions still produce appropriate `--bind`
+  entries via `actions.expect` or equivalent logic
+
+## Edge Cases
+
+1. **Duplicate keys across tables:** Resolved by precedence
+   (binds > actions > keymap.fzf > keymap.builtin)
+2. **Same key in different formats:** `ctrl-y` and `<C-y>` normalize to the same
+   key via `normalize_key`; within the same table, last-write-wins (iteration
+   order of Lua tables is non-deterministic, so users should avoid defining the
+   same key in two formats in one table). Across tables, precedence
+   (binds > actions > keymap.fzf > keymap.builtin) determines the winner.
+3. **Provider overrides:** Provider-specific `binds`/`actions` merge with globals
+   via `vim.tbl_deep_extend` (same as current behavior for `keymap`)
+4. **Help/which-key:** `desc` field preserved on all bind types for the help
+   window (`toggle-help` / `<F1>`)
+5. **Live pickers:** `change:+transform:CMD` stays separate; if user also binds
+   `change` event in `binds`, both coexist (fzf supports additive `+` prefix)
+6. **Windows:** SIGWINCH (signal 28) unavailable; neovim-only keys dropped
+   (same as current behavior)
+7. **Internal actions:** `_underscore`-prefixed actions in `opts.actions` are not
+   merged into binds (preserved for internal use)
+
+## Version Requirements
+
+- **fzf >= 0.59**: Full unified transform path (comma-separated key/event lists
+  in `--bind`, which is the highest version dependency for the core feature)
+- **fzf >= 0.53**: `print(key)+accept` for accept actions
+- **fzf >= 0.50**: `$FZF_KEY` environment variable for dispatch
+- **fzf >= 0.46**: `resize` event and `transform` action (SIGWINCH bridge)
+- **fzf >= 0.45**: `transform` action
+- **fzf >= 0.36**: Minimum supported version (current)
+
+The unified transform path gates on **fzf >= 0.59** which implies all lower
+version requirements are met. Individual features from newer fzf versions
+(e.g., `change-header-lines` from 0.70, `bg-transform-*` from 0.63) can be
+used opportunistically when the user's fzf version supports them.

--- a/lua/fzf-lua/binds.lua
+++ b/lua/fzf-lua/binds.lua
@@ -11,47 +11,47 @@ local M = {}
 -- Known fzf events (not keys) — used to distinguish event binds
 -- from key binds during classification
 local FZF_EVENTS = {
-  ["load"]            = true,
-  ["start"]           = true,
-  ["resize"]          = true,
-  ["change"]          = true,
-  ["zero"]            = true,
-  ["one"]             = true,
-  ["focus"]           = true,
-  ["result"]          = true,
-  ["multi"]           = true,
-  ["click-header"]    = true,
-  ["click-footer"]    = true,
-  ["backward-eof"]    = true,
-  ["jump"]            = true,
-  ["jump-cancel"]     = true,
+  ["load"]         = true,
+  ["start"]        = true,
+  ["resize"]       = true,
+  ["change"]       = true,
+  ["zero"]         = true,
+  ["one"]          = true,
+  ["focus"]        = true,
+  ["result"]       = true,
+  ["multi"]        = true,
+  ["click-header"] = true,
+  ["click-footer"] = true,
+  ["backward-eof"] = true,
+  ["jump"]         = true,
+  ["jump-cancel"]  = true,
 }
 
 -- Known builtin actions that are handled neovim-side (from win.lua)
 -- These go through the transform handler instead of direct fzf binds
 local BUILTIN_ACTIONS = {
-  ["hide"]                       = true,
-  ["toggle-help"]                = true,
-  ["toggle-fullscreen"]          = true,
-  ["toggle-preview"]             = true,
-  ["toggle-preview-cw"]          = true,
-  ["toggle-preview-ccw"]         = true,
-  ["toggle-preview-behavior"]    = true,
-  ["toggle-preview-wrap"]        = true,
-  ["toggle-preview-ts-ctx"]      = true,
-  ["toggle-preview-undo"]        = true,
-  ["preview-ts-ctx-dec"]         = true,
-  ["preview-ts-ctx-inc"]         = true,
-  ["preview-reset"]              = true,
-  ["preview-page-down"]          = true,
-  ["preview-page-up"]            = true,
-  ["preview-half-page-up"]       = true,
-  ["preview-half-page-down"]     = true,
-  ["preview-down"]               = true,
-  ["preview-up"]                 = true,
-  ["preview-top"]                = true,
-  ["preview-bottom"]             = true,
-  ["focus-preview"]              = true,
+  ["hide"]                    = true,
+  ["toggle-help"]             = true,
+  ["toggle-fullscreen"]       = true,
+  ["toggle-preview"]          = true,
+  ["toggle-preview-cw"]       = true,
+  ["toggle-preview-ccw"]      = true,
+  ["toggle-preview-behavior"] = true,
+  ["toggle-preview-wrap"]     = true,
+  ["toggle-preview-ts-ctx"]   = true,
+  ["toggle-preview-undo"]     = true,
+  ["preview-ts-ctx-dec"]      = true,
+  ["preview-ts-ctx-inc"]      = true,
+  ["preview-reset"]           = true,
+  ["preview-page-down"]       = true,
+  ["preview-page-up"]         = true,
+  ["preview-half-page-up"]    = true,
+  ["preview-half-page-down"]  = true,
+  ["preview-down"]            = true,
+  ["preview-up"]              = true,
+  ["preview-top"]             = true,
+  ["preview-bottom"]          = true,
+  ["focus-preview"]           = true,
 }
 
 -- Keys with modifier+special combos that fzf doesn't support.
@@ -312,11 +312,11 @@ function M.build_transform_binds(opts)
   local merged = M.normalize_binds(opts)
 
   -- Classify all binds
-  local direct = {}      -- key -> fzf action string
-  local accept = {}      -- key -> bind entry (for actions.expect)
-  local transform = {}   -- key -> bind entry (keys for consolidated handler)
-  local events = {}      -- event_name -> bind entry
-  local sigwinch = {}    -- key -> bind entry
+  local direct = {}    -- key -> fzf action string
+  local accept = {}    -- key -> bind entry (for actions.expect)
+  local transform = {} -- key -> bind entry (keys for consolidated handler)
+  local events = {}    -- event_name -> bind entry
+  local sigwinch = {}  -- key -> bind entry
 
   for key, entry in pairs(merged) do
     local category = classify_bind(key, entry, opts)
@@ -665,16 +665,16 @@ function M._execute_builtin(builtin_name, opts)
 
   -- Map builtin names to their win.lua implementations
   local builtin_map = {
-    ["hide"] = function()
+    ["hide"]                    = function()
       win.hide()
     end,
-    ["toggle-help"] = function()
+    ["toggle-help"]             = function()
       win.toggle_help()
     end,
-    ["toggle-fullscreen"] = function()
+    ["toggle-fullscreen"]       = function()
       win.toggle_fullscreen()
     end,
-    ["toggle-preview"] = function()
+    ["toggle-preview"]          = function()
       win.toggle_preview()
       local self = winobj()
       if not self then return "" end
@@ -693,11 +693,11 @@ function M._execute_builtin(builtin_name, opts)
           self:normalize_preview_layout().str)
       end
     end,
-    ["toggle-preview-cw"] = function()
+    ["toggle-preview-cw"]       = function()
       win.toggle_preview_cw(1)
       return change_preview_window()
     end,
-    ["toggle-preview-ccw"] = function()
+    ["toggle-preview-ccw"]      = function()
       win.toggle_preview_cw(-1)
       return change_preview_window()
     end,
@@ -739,7 +739,7 @@ function M._create_dispatch_handler(opts)
     local key
     local is_event = false
     if items[1] and type(items[1]) == "string" and items[1]:match("^__evt__") then
-      key = items[1]:sub(8)  -- strip "__evt__" prefix
+      key = items[1]:sub(8) -- strip "__evt__" prefix
       table.remove(items, 1)
       is_event = true
     else
@@ -751,8 +751,8 @@ function M._create_dispatch_handler(opts)
     local custom_fi = is_event and opts.__transform_custom_fi
         and opts.__transform_custom_fi[key]
     if not custom_fi then
-      local match_count = table.remove(items)  -- {n}
-      local query = table.remove(items)         -- {q}
+      local match_count = table.remove(items) -- {n}
+      local query = table.remove(items)       -- {q}
 
       -- Update resume query
       if query then

--- a/lua/fzf-lua/binds.lua
+++ b/lua/fzf-lua/binds.lua
@@ -54,46 +54,47 @@ local BUILTIN_ACTIONS = {
   ["focus-preview"]              = true,
 }
 
+-- Keys with modifier+special combos that fzf doesn't support.
+-- Used by normalize_key to route these through the SIGWINCH bridge.
+local SPECIAL_NEOVIM_ONLY = {
+  ["ctrl-cr"]     = true,
+  ["ctrl-enter"]  = true,
+  ["ctrl-bs"]     = true,
+  ["shift-cr"]    = true,
+  ["shift-enter"] = true,
+  ["alt-esc"]     = true,
+}
+
 -- Bind categories
-M.DIRECT    = "direct"
-M.ACCEPT    = "accept"
+M.DIRECT = "direct"
+M.ACCEPT = "accept"
 M.TRANSFORM = "transform"
-M.SIGWINCH  = "sigwinch"
-M.DROPPED   = "dropped"
+M.SIGWINCH = "sigwinch"
+M.DROPPED = "dropped"
 
 --- Normalize a key from neovim format to fzf format if needed.
 --- Accepts both styles: `<C-y>` -> `ctrl-y`, `ctrl-y` stays as-is.
+--- Both paths check SPECIAL_NEOVIM_ONLY so raw fzf-style unsupported
+--- keys (e.g. "ctrl-enter") are treated the same as "<C-Enter>".
 ---@param key string
 ---@return string fzf_key
 ---@return boolean is_neovim_only true if key has no fzf equivalent
 local function normalize_key(key)
-  -- Already in fzf format (no angle brackets)
-  if not key:match("^<.*>$") then
-    return key, false
+  local fzf_key
+  if key:match("^<.*>$") then
+    fzf_key = utils.neovim_bind_to_fzf(key)
+    -- Collapse shift-<letter> to uppercase letter in fzf key format.
+    -- neovim_bind_to_fzf produces e.g. "alt-shift-j" from "<M-S-j>"
+    -- but fzf expects "alt-J" (shift+letter = uppercase letter).
+    -- Only applies to single ASCII letters, not special keys like
+    -- shift-down, shift-tab, etc.
+    fzf_key = fzf_key:gsub("shift%-(%a)$", function(letter)
+      return letter:upper()
+    end)
+  else
+    fzf_key = key
   end
-  local fzf_key = utils.neovim_bind_to_fzf(key)
-  -- Collapse shift-<letter> to uppercase letter in fzf key format.
-  -- neovim_bind_to_fzf produces e.g. "alt-shift-j" from "<M-S-j>"
-  -- but fzf expects "alt-J" (shift+letter = uppercase letter).
-  -- Only applies to single ASCII letters, not special keys like
-  -- shift-down, shift-tab, etc.
-  fzf_key = fzf_key:gsub("shift%-(%a)$", function(letter)
-    return letter:upper()
-  end)
-  -- Check if the conversion produces a valid fzf key
-  -- Keys like <C-Enter>, <C-BS> have no fzf equivalent and
-  -- neovim_bind_to_fzf will produce something like "ctrl-enter"
-  -- which fzf doesn't recognize for some modifier+special combos
-  -- For now, keys with shift-/ctrl- + special keys that fzf doesn't support:
-  local special_neovim_only = {
-    ["ctrl-cr"]    = true,
-    ["ctrl-enter"] = true,
-    ["ctrl-bs"]    = true,
-    ["shift-cr"]   = true,
-    ["shift-enter"] = true,
-    ["alt-esc"]    = true,
-  }
-  return fzf_key, special_neovim_only[fzf_key] or false
+  return fzf_key, SPECIAL_NEOVIM_ONLY[fzf_key] or false
 end
 
 --- Normalize a single bind value into the canonical table form.
@@ -101,16 +102,21 @@ end
 ---@param key string the fzf-format key
 ---@param value any the bind value
 ---@param is_event boolean whether the key is an fzf event name
+---@param source string? which table the value came from (e.g. "keymap.fzf")
 ---@return table? normalized bind entry or nil to skip
-local function normalize_value(key, value, is_event)
+local function normalize_value(key, value, is_event, source)
   if value == false or value == nil then
     return nil
   end
 
-  -- Bare function → accept action (events are always transform)
+  -- Bare function — behavior depends on source
   if type(value) == "function" then
     if is_event then
       return { fn = value, event = true }
+    elseif source == "keymap.fzf" then
+      -- Legacy: bare functions in keymap.fzf are execute-silent
+      -- (core.lua create_fzf_binds converts them to execute-silent:...)
+      return { fn = value, exec_silent = true }
     else
       return { fn = value, accept = true }
     end
@@ -137,6 +143,9 @@ local function normalize_value(key, value, is_event)
 
   -- Table with string [1] (help string support: {"first", desc = "Go to first"})
   if type(value) == "table" and type(value[1]) == "string" then
+    if BUILTIN_ACTIONS[value[1]] then
+      return { builtin = value[1], desc = value.desc }
+    end
     return { fzf_action = value[1], desc = value.desc }
   end
 
@@ -173,7 +182,7 @@ function M.normalize_binds(opts)
     for key, value in pairs(opts.keymap.builtin) do
       if type(key) == "string" and value and value ~= true then
         local fzf_key = normalize_key(key)
-        local entry = normalize_value(fzf_key, value, FZF_EVENTS[fzf_key])
+        local entry = normalize_value(fzf_key, value, FZF_EVENTS[fzf_key], "keymap.builtin")
         if entry then
           entry._source = "keymap.builtin"
           entry._nvim_key = key
@@ -187,7 +196,7 @@ function M.normalize_binds(opts)
   if type(opts.keymap) == "table" and type(opts.keymap.fzf) == "table" then
     for key, value in pairs(opts.keymap.fzf) do
       local fzf_key = normalize_key(key)
-      local entry = normalize_value(fzf_key, value, FZF_EVENTS[fzf_key])
+      local entry = normalize_value(fzf_key, value, FZF_EVENTS[fzf_key], "keymap.fzf")
       if entry then
         entry._source = "keymap.fzf"
         entry._nvim_key = key
@@ -202,7 +211,7 @@ function M.normalize_binds(opts)
       -- Internal actions (underscore prefix) are not merged
       if type(key) == "string" and not key:match("^_") then
         local fzf_key = normalize_key(key)
-        local entry = normalize_value(fzf_key, value, FZF_EVENTS[fzf_key])
+        local entry = normalize_value(fzf_key, value, FZF_EVENTS[fzf_key], "actions")
         if entry then
           entry._source = "actions"
           entry._nvim_key = key
@@ -216,14 +225,21 @@ function M.normalize_binds(opts)
   if type(opts.binds) == "table" then
     for key, value in pairs(opts.binds) do
       local fzf_key = normalize_key(key)
-      local entry = normalize_value(fzf_key, value, FZF_EVENTS[fzf_key])
+      local entry = normalize_value(fzf_key, value, FZF_EVENTS[fzf_key], "binds")
       if entry then
         entry._source = "binds"
         entry._nvim_key = key
         merged[fzf_key] = entry
       elseif value == false then
-        -- Explicit false removes the bind
+        -- Explicit false removes the bind and clears legacy tables
+        -- so actions.expect()/create_fzf_binds() can't resurrect it
         merged[fzf_key] = nil
+        if type(opts.actions) == "table" then
+          opts.actions[key] = nil
+        end
+        if type(opts.keymap) == "table" and type(opts.keymap.fzf) == "table" then
+          opts.keymap.fzf[key] = nil
+        end
       end
     end
   end
@@ -346,7 +362,14 @@ function M.build_transform_binds(opts)
         field_index = entry.field_index,
       }
     else
-      action_entry = entry.fn or entry
+      action_entry = {
+        fn = entry.fn or entry,
+        prefix = entry.prefix,
+        postfix = entry.postfix,
+        desc = entry.desc,
+        header = entry.header,
+        field_index = entry.field_index,
+      }
     end
     opts.actions[key] = action_entry
   end
@@ -493,6 +516,16 @@ function M.build_transform_binds(opts)
     else
       opts.keymap.fzf[key] = action
     end
+    -- Also mark action with _ignore so actions.expect() doesn't generate
+    -- a competing print(key)+accept for DIRECT entries (e.g. Windows
+    -- toggle-preview which is classified DIRECT instead of TRANSFORM)
+    if opts.actions[key] then
+      if type(opts.actions[key]) == "table" then
+        opts.actions[key]._ignore = true
+      else
+        opts.actions[key] = { fn = opts.actions[key], _ignore = true }
+      end
+    end
   end
 
   -- Mark actions that were routed to transform as _ignore
@@ -575,8 +608,15 @@ function M._make_handler(key, entry, opts)
       if type(entry.fn) == "function" then
         entry.fn(items, opts)
       end
-      -- exec_silent returns empty string (no fzf UI change)
-      return ""
+      -- Preserve prefix/postfix wrappers (e.g. "select-all+...")
+      local parts = {}
+      if type(entry.prefix) == "string" then
+        table.insert(parts, entry.prefix:gsub("%+$", ""))
+      end
+      if type(entry.postfix) == "string" then
+        table.insert(parts, entry.postfix:gsub("^%+", ""))
+      end
+      return #parts > 0 and table.concat(parts, "+") or ""
     end
   end
 
@@ -746,11 +786,15 @@ function M._create_dispatch_handler(opts)
   end
 end
 
---- Check if unified binds should be used (fzf >= 0.59, not skim)
+--- Check if unified binds should be used (fzf >= 0.59, not skim, not Windows)
+--- On Windows the consolidated transform shell command doesn't work with
+--- cmd.exe; fall back to legacy path which uses execute-silent binds.
 ---@param opts table
 ---@return boolean
 function M.can_unified(opts)
-  return utils.has(opts, "fzf", { 0, 59 }) and not utils.has(opts, "sk")
+  return utils.has(opts, "fzf", { 0, 59 })
+      and not utils.has(opts, "sk")
+      and not utils.__IS_WINDOWS
 end
 
 return M

--- a/lua/fzf-lua/binds.lua
+++ b/lua/fzf-lua/binds.lua
@@ -1,0 +1,756 @@
+---@diagnostic disable-next-line: deprecated
+local uv = vim.uv or vim.loop
+local utils = require("fzf-lua.utils")
+local shell = require("fzf-lua.shell")
+local config = require("fzf-lua.config")
+local actions = require("fzf-lua.actions")
+local libuv = require("fzf-lua.libuv")
+
+local M = {}
+
+-- Known fzf events (not keys) — used to distinguish event binds
+-- from key binds during classification
+local FZF_EVENTS = {
+  ["load"]            = true,
+  ["start"]           = true,
+  ["resize"]          = true,
+  ["change"]          = true,
+  ["zero"]            = true,
+  ["one"]             = true,
+  ["focus"]           = true,
+  ["result"]          = true,
+  ["multi"]           = true,
+  ["click-header"]    = true,
+  ["click-footer"]    = true,
+  ["backward-eof"]    = true,
+  ["jump"]            = true,
+  ["jump-cancel"]     = true,
+}
+
+-- Known builtin actions that are handled neovim-side (from win.lua)
+-- These go through the transform handler instead of direct fzf binds
+local BUILTIN_ACTIONS = {
+  ["hide"]                       = true,
+  ["toggle-help"]                = true,
+  ["toggle-fullscreen"]          = true,
+  ["toggle-preview"]             = true,
+  ["toggle-preview-cw"]          = true,
+  ["toggle-preview-ccw"]         = true,
+  ["toggle-preview-behavior"]    = true,
+  ["toggle-preview-wrap"]        = true,
+  ["toggle-preview-ts-ctx"]      = true,
+  ["toggle-preview-undo"]        = true,
+  ["preview-ts-ctx-dec"]         = true,
+  ["preview-ts-ctx-inc"]         = true,
+  ["preview-reset"]              = true,
+  ["preview-page-down"]          = true,
+  ["preview-page-up"]            = true,
+  ["preview-half-page-up"]       = true,
+  ["preview-half-page-down"]     = true,
+  ["preview-down"]               = true,
+  ["preview-up"]                 = true,
+  ["preview-top"]                = true,
+  ["preview-bottom"]             = true,
+  ["focus-preview"]              = true,
+}
+
+-- Bind categories
+M.DIRECT    = "direct"
+M.ACCEPT    = "accept"
+M.TRANSFORM = "transform"
+M.SIGWINCH  = "sigwinch"
+M.DROPPED   = "dropped"
+
+--- Normalize a key from neovim format to fzf format if needed.
+--- Accepts both styles: `<C-y>` -> `ctrl-y`, `ctrl-y` stays as-is.
+---@param key string
+---@return string fzf_key
+---@return boolean is_neovim_only true if key has no fzf equivalent
+local function normalize_key(key)
+  -- Already in fzf format (no angle brackets)
+  if not key:match("^<.*>$") then
+    return key, false
+  end
+  local fzf_key = utils.neovim_bind_to_fzf(key)
+  -- Collapse shift-<letter> to uppercase letter in fzf key format.
+  -- neovim_bind_to_fzf produces e.g. "alt-shift-j" from "<M-S-j>"
+  -- but fzf expects "alt-J" (shift+letter = uppercase letter).
+  -- Only applies to single ASCII letters, not special keys like
+  -- shift-down, shift-tab, etc.
+  fzf_key = fzf_key:gsub("shift%-(%a)$", function(letter)
+    return letter:upper()
+  end)
+  -- Check if the conversion produces a valid fzf key
+  -- Keys like <C-Enter>, <C-BS> have no fzf equivalent and
+  -- neovim_bind_to_fzf will produce something like "ctrl-enter"
+  -- which fzf doesn't recognize for some modifier+special combos
+  -- For now, keys with shift-/ctrl- + special keys that fzf doesn't support:
+  local special_neovim_only = {
+    ["ctrl-cr"]    = true,
+    ["ctrl-enter"] = true,
+    ["ctrl-bs"]    = true,
+    ["shift-cr"]   = true,
+    ["shift-enter"] = true,
+    ["alt-esc"]    = true,
+  }
+  return fzf_key, special_neovim_only[fzf_key] or false
+end
+
+--- Normalize a single bind value into the canonical table form.
+--- Handles all accepted value types (function, string, table).
+---@param key string the fzf-format key
+---@param value any the bind value
+---@param is_event boolean whether the key is an fzf event name
+---@return table? normalized bind entry or nil to skip
+local function normalize_value(key, value, is_event)
+  if value == false or value == nil then
+    return nil
+  end
+
+  -- Bare function → accept action (events are always transform)
+  if type(value) == "function" then
+    if is_event then
+      return { fn = value, event = true }
+    else
+      return { fn = value, accept = true }
+    end
+  end
+
+  -- String value
+  if type(value) == "string" then
+    if BUILTIN_ACTIONS[value] then
+      return { builtin = value }
+    else
+      -- fzf-native action string (e.g. "abort", "half-page-down")
+      return { fzf_action = value }
+    end
+  end
+
+  -- Table with `fn` property — complex action definition
+  if type(value) == "table" and value.fn then
+    local entry = vim.tbl_extend("keep", {}, value)
+    if is_event then
+      entry.event = true
+    end
+    return entry
+  end
+
+  -- Table with string [1] (help string support: {"first", desc = "Go to first"})
+  if type(value) == "table" and type(value[1]) == "string" then
+    return { fzf_action = value[1], desc = value.desc }
+  end
+
+  -- Array of functions — chained action (from actions table)
+  if type(value) == "table" and type(value[1]) == "function" then
+    -- Check for backward compat pattern: { fn, actions.resume }
+    if value[2] == actions.resume then
+      return { fn = value[1], reload = true }
+    end
+    -- Chained accept action
+    local entry = { fn = value[1], accept = true }
+    if #value > 1 then
+      local chain = {}
+      for i = 2, #value do
+        table.insert(chain, value[i])
+      end
+      entry.chain = chain
+    end
+    return entry
+  end
+
+  return nil
+end
+
+--- Merge all bind sources into a single normalized table.
+--- Precedence: binds > actions > keymap.fzf > keymap.builtin
+---@param opts table
+---@return table<string, table> merged table of normalized bind entries keyed by fzf-format key
+function M.normalize_binds(opts)
+  local merged = {}
+
+  -- 4. keymap.builtin (lowest precedence)
+  if type(opts.keymap) == "table" and type(opts.keymap.builtin) == "table" then
+    for key, value in pairs(opts.keymap.builtin) do
+      if type(key) == "string" and value and value ~= true then
+        local fzf_key = normalize_key(key)
+        local entry = normalize_value(fzf_key, value, FZF_EVENTS[fzf_key])
+        if entry then
+          entry._source = "keymap.builtin"
+          entry._nvim_key = key
+          merged[fzf_key] = entry
+        end
+      end
+    end
+  end
+
+  -- 3. keymap.fzf
+  if type(opts.keymap) == "table" and type(opts.keymap.fzf) == "table" then
+    for key, value in pairs(opts.keymap.fzf) do
+      local fzf_key = normalize_key(key)
+      local entry = normalize_value(fzf_key, value, FZF_EVENTS[fzf_key])
+      if entry then
+        entry._source = "keymap.fzf"
+        entry._nvim_key = key
+        merged[fzf_key] = entry
+      end
+    end
+  end
+
+  -- 2. actions
+  if type(opts.actions) == "table" then
+    for key, value in pairs(opts.actions) do
+      -- Internal actions (underscore prefix) are not merged
+      if type(key) == "string" and not key:match("^_") then
+        local fzf_key = normalize_key(key)
+        local entry = normalize_value(fzf_key, value, FZF_EVENTS[fzf_key])
+        if entry then
+          entry._source = "actions"
+          entry._nvim_key = key
+          merged[fzf_key] = entry
+        end
+      end
+    end
+  end
+
+  -- 1. binds (highest precedence)
+  if type(opts.binds) == "table" then
+    for key, value in pairs(opts.binds) do
+      local fzf_key = normalize_key(key)
+      local entry = normalize_value(fzf_key, value, FZF_EVENTS[fzf_key])
+      if entry then
+        entry._source = "binds"
+        entry._nvim_key = key
+        merged[fzf_key] = entry
+      elseif value == false then
+        -- Explicit false removes the bind
+        merged[fzf_key] = nil
+      end
+    end
+  end
+
+  return merged
+end
+
+--- Classify a normalized bind entry into one of the 5 categories.
+---@param key string fzf-format key
+---@param entry table normalized bind entry
+---@param opts table
+---@return string category one of M.DIRECT, M.ACCEPT, M.TRANSFORM, M.SIGWINCH, M.DROPPED
+local function classify_bind(key, entry, opts)
+  local is_event = FZF_EVENTS[key]
+  local _, is_neovim_only = normalize_key(entry._nvim_key or key)
+
+  -- Neovim-only keys (e.g. <C-Enter>, <M-Esc>) cannot be sent to fzf as --bind
+  -- entries. Route through SIGWINCH bridge (neovim terminal) or DROP (tmux/CLI).
+  if is_neovim_only and not is_event then
+    if opts._is_fzf_tmux or _G.fzf_jobstart or utils.__IS_WINDOWS then
+      return M.DROPPED
+    end
+    return M.SIGWINCH
+  end
+
+  -- Direct: string fzf-native action (not a builtin)
+  if entry.fzf_action then
+    return M.DIRECT
+  end
+
+  -- Builtin action → transform
+  if entry.builtin then
+    return M.TRANSFORM
+  end
+
+  -- Event → always transform
+  if is_event then
+    return M.TRANSFORM
+  end
+
+  -- Accept: bare function, accept=true, or reuse=true
+  if entry.accept then
+    return M.ACCEPT
+  end
+
+  -- Reuse: goes through accept path (print+accept, but reopens)
+  if entry.reuse then
+    return M.ACCEPT
+  end
+
+  -- Reload/exec_silent → transform
+  if entry.reload or entry.exec_silent then
+    return M.TRANSFORM
+  end
+
+  -- Function with no explicit property → accept
+  if entry.fn and type(entry.fn) == "function" then
+    return M.ACCEPT
+  end
+
+  return M.DIRECT
+end
+
+--- Build the consolidated transform handler and all --bind entries.
+--- This replaces `convert_reload_actions`, `convert_exec_silent_actions`,
+--- and much of `create_fzf_binds` for fzf >= 0.59.
+---@param opts table
+---@return table opts with modified fzf_opts and _fzf_cli_args
+function M.build_transform_binds(opts)
+  local merged = M.normalize_binds(opts)
+
+  -- Classify all binds
+  local direct = {}      -- key -> fzf action string
+  local accept = {}      -- key -> bind entry (for actions.expect)
+  local transform = {}   -- key -> bind entry (keys for consolidated handler)
+  local events = {}      -- event_name -> bind entry
+  local sigwinch = {}    -- key -> bind entry
+
+  for key, entry in pairs(merged) do
+    local category = classify_bind(key, entry, opts)
+    if category == M.DIRECT then
+      direct[key] = entry
+    elseif category == M.ACCEPT then
+      accept[key] = entry
+    elseif category == M.TRANSFORM then
+      if FZF_EVENTS[key] then
+        events[key] = entry
+      else
+        transform[key] = entry
+      end
+    elseif category == M.SIGWINCH then
+      sigwinch[key] = entry
+    end
+    -- DROPPED: silently skipped
+  end
+
+  -- ============================================================
+  -- 1. ACCEPT binds: write into opts.actions for actions.expect
+  -- ============================================================
+  -- We populate opts.actions so that the existing actions.expect()
+  -- and actions.act() machinery handles accept actions unchanged.
+  opts.actions = opts.actions or {}
+  for key, entry in pairs(accept) do
+    -- Reconstruct the action table that actions.expect understands
+    local action_entry
+    if entry.chain then
+      -- Chained actions: array of functions
+      action_entry = { entry.fn }
+      for _, f in ipairs(entry.chain) do
+        table.insert(action_entry, f)
+      end
+    elseif entry.reuse then
+      action_entry = {
+        fn = entry.fn,
+        reuse = entry.reuse,
+        prefix = entry.prefix,
+        postfix = entry.postfix,
+        desc = entry.desc,
+        header = entry.header,
+        field_index = entry.field_index,
+      }
+    else
+      action_entry = entry.fn or entry
+    end
+    opts.actions[key] = action_entry
+  end
+
+  -- ============================================================
+  -- 2. TRANSFORM binds: consolidated handler
+  -- ============================================================
+  local transform_keys = vim.tbl_keys(transform)
+  local event_keys = vim.tbl_keys(events)
+  local has_transform = #transform_keys > 0 or #event_keys > 0
+
+  if has_transform then
+    -- Build the handler dispatch table on opts
+    opts.__transform_handlers = {}
+
+    -- Register key handlers
+    for key, entry in pairs(transform) do
+      opts.__transform_handlers[key] = M._make_handler(key, entry, opts)
+    end
+
+    -- Register event handlers
+    for evname, entry in pairs(events) do
+      opts.__transform_handlers[evname] = M._make_handler(evname, entry, opts)
+    end
+
+    -- Build the unbind/rebind strings for reload actions
+    local reload_keys = {}
+    for key, entry in pairs(transform) do
+      if entry.reload then
+        table.insert(reload_keys, key)
+      end
+    end
+
+    local unbind_str, rebind_str
+    if #reload_keys > 0 then
+      unbind_str = table.concat(vim.tbl_map(function(k)
+        return string.format("unbind(%s)", k)
+      end, reload_keys), "+")
+      rebind_str = table.concat(vim.tbl_map(function(k)
+        return string.format("rebind(%s)", k)
+      end, reload_keys), "+")
+    end
+
+    -- Store for handler use
+    opts.__transform_unbind = unbind_str
+    opts.__transform_rebind = rebind_str
+    opts.__transform_reload_cmd = type(opts._contents) == "string" and opts._contents or nil
+
+    -- Register the single RPC function via pipe_wrap_fn (empty field index)
+    local base_cmd = shell.pipe_wrap_fn(
+      M._create_dispatch_handler(opts),
+      "", -- empty field index, caller appends per-bind
+      opts.debug
+    )
+
+    -- Build the consolidated --bind entries
+    local bind_entries = {}
+
+    -- Key transform: --bind=key1,key2,...:transform:BASE_CMD {+} {q} {n}
+    if #transform_keys > 0 then
+      table.sort(transform_keys)
+      table.insert(bind_entries,
+        string.format("%s:transform:%s {+} {q} {n}",
+          table.concat(transform_keys, ","),
+          base_cmd))
+    end
+
+    -- Event transforms: --bind=<event>:+transform:BASE_CMD __evt__<event> <field_index>
+    for _, evname in ipairs(event_keys) do
+      local entry = events[evname]
+      local field_index
+      if entry.field_index then
+        -- Custom field_index: use as-is, mark handler to not strip {q}/{n}
+        field_index = entry.field_index
+        opts.__transform_custom_fi = opts.__transform_custom_fi or {}
+        opts.__transform_custom_fi[evname] = true
+      else
+        field_index = "{+} {q} {n}"
+      end
+      -- Use "+transform" for events to be additive (don't override other event binds)
+      table.insert(bind_entries,
+        string.format("%s:+transform:%s __evt__%s %s",
+          evname, base_cmd, evname, field_index))
+    end
+
+    -- Add rebind on load event if we have reload keys
+    if rebind_str then
+      table.insert(bind_entries,
+        string.format("load:+%s", rebind_str))
+    end
+
+    -- Add to _fzf_cli_args as separate --bind entries
+    opts._fzf_cli_args = opts._fzf_cli_args or {}
+    for _, bind in ipairs(bind_entries) do
+      table.insert(opts._fzf_cli_args, "--bind=" .. libuv.shellescape(bind))
+    end
+  end
+
+  -- ============================================================
+  -- 3. SIGWINCH binds: register neovim terminal keymaps + resize
+  -- ============================================================
+  -- SIGWINCH bridge: for neovim-only keys (e.g. <C-Enter>) that have no fzf
+  -- equivalent. A terminal keymap in neovim pushes the handler name into
+  -- `opts.__sigwinches` and sends POSIX SIGWINCH (signal 28) to fzf.
+  -- Fzf fires `resize` event, which triggers the `on_SIGWINCH` callback,
+  -- which processes the queued handler names via `opts.__sigwinch_cb`.
+  if not utils.tbl_isempty(sigwinch) then
+    local win = require("fzf-lua.win")
+    opts.__sigwinch_triggers = opts.__sigwinch_triggers or {}
+    for key, entry in pairs(sigwinch) do
+      local nvim_key = entry._nvim_key or utils.fzf_bind_to_neovim(key)
+      local handler_key = "__sigwinch__" .. key
+      local handler = M._make_handler(key, entry, opts)
+
+      -- Register as on_SIGWINCH callback — runs when handler_key is in __sigwinches
+      win.on_SIGWINCH(opts, handler_key, function(_args)
+        -- Ignore args (preview lines), call our handler with empty items
+        return handler({}, {})
+      end)
+
+      -- Store the neovim key → handler_key mapping for the terminal keymap
+      -- setup in win.lua:setup_keybinds()
+      opts.__sigwinch_triggers[nvim_key] = handler_key
+    end
+  end
+
+  -- ============================================================
+  -- 4. Write direct binds to opts.fzf_opts["--bind"]
+  -- ============================================================
+  opts.keymap = opts.keymap or {}
+  opts.keymap.fzf = opts.keymap.fzf or {}
+  -- Clear keymap.fzf entries that we've already handled to prevent
+  -- create_fzf_binds from double-processing them
+  for key, _ in pairs(merged) do
+    if not direct[key] then
+      opts.keymap.fzf[key] = nil
+    end
+  end
+  -- Write direct binds into keymap.fzf for create_fzf_binds to pick up
+  for key, entry in pairs(direct) do
+    local action = entry.fzf_action
+    if entry.desc then
+      opts.keymap.fzf[key] = { action, desc = entry.desc }
+    else
+      opts.keymap.fzf[key] = action
+    end
+  end
+
+  -- Mark actions that were routed to transform as _ignore
+  -- so actions.expect() doesn't double-process them
+  for key, entry in pairs(transform) do
+    if opts.actions[key] then
+      if type(opts.actions[key]) == "table" then
+        opts.actions[key]._ignore = true
+      else
+        opts.actions[key] = { fn = opts.actions[key], _ignore = true }
+      end
+    end
+  end
+  for key, _ in pairs(events) do
+    if opts.actions[key] then
+      if type(opts.actions[key]) == "table" then
+        opts.actions[key]._ignore = true
+      else
+        opts.actions[key] = { fn = opts.actions[key], _ignore = true }
+      end
+    end
+  end
+
+  return opts
+end
+
+--- Create a handler function for a single bind entry.
+--- Returns a function(items, ctx) -> fzf_action_string
+---@param key string
+---@param entry table normalized bind entry
+---@param opts table
+---@return function
+function M._make_handler(key, entry, opts)
+  -- Direct fzf action routed through SIGWINCH bridge (neovim-only key)
+  if entry.fzf_action then
+    return function(_items, _ctx)
+      return entry.fzf_action
+    end
+  end
+
+  if entry.builtin then
+    -- Builtin action: call neovim-side function, return fzf action
+    return function(items, ctx)
+      return M._execute_builtin(entry.builtin, opts)
+    end
+  end
+
+  if entry.reload then
+    -- Reload action: execute fn, then reload
+    return function(items, ctx)
+      local reload_cmd = opts.__transform_reload_cmd
+      local unbind = opts.__transform_unbind
+
+      -- Execute the function
+      if type(entry.fn) == "function" then
+        entry.fn(items, opts)
+      end
+
+      -- Build the fzf action string: unbind+reload(cmd)+postfix
+      local parts = {}
+      if type(entry.prefix) == "string" then
+        table.insert(parts, entry.prefix:gsub("%+$", ""))
+      end
+      if unbind then
+        table.insert(parts, unbind)
+      end
+      if reload_cmd then
+        table.insert(parts, string.format("reload(%s)", reload_cmd))
+      end
+      if type(entry.postfix) == "string" then
+        table.insert(parts, entry.postfix:gsub("^%+", ""))
+      end
+      return table.concat(parts, "+")
+    end
+  end
+
+  if entry.exec_silent then
+    -- Exec-silent action: execute fn, return empty (no fzf action)
+    return function(items, ctx)
+      if type(entry.fn) == "function" then
+        entry.fn(items, opts)
+      end
+      -- exec_silent returns empty string (no fzf UI change)
+      return ""
+    end
+  end
+
+  if entry.event then
+    -- Event handler: call fn, return result as fzf action
+    return function(items, ctx)
+      if type(entry.fn) == "function" then
+        local result = entry.fn(items, opts)
+        return type(result) == "string" and result or ""
+      end
+      return ""
+    end
+  end
+
+  -- Generic function handler (shouldn't normally reach here for transform)
+  return function(items, ctx)
+    if type(entry.fn) == "function" then
+      local result = entry.fn(items, opts)
+      return type(result) == "string" and result or ""
+    end
+    return ""
+  end
+end
+
+--- Execute a builtin action (e.g. toggle-preview) on the neovim side.
+--- Returns the appropriate fzf action string.
+---@param builtin_name string
+---@param opts table
+---@return string fzf action string
+function M._execute_builtin(builtin_name, opts)
+  local win = require("fzf-lua.win")
+
+  -- Helper: get the FzfWin singleton for layout queries
+  local function winobj()
+    return win.__SELF()
+  end
+
+  -- Helper: get fzf change-preview-window action with current layout
+  local function change_preview_window()
+    local self = winobj()
+    if self then
+      return string.format("change-preview-window(%s)", self:normalize_preview_layout().str)
+    end
+    return ""
+  end
+
+  -- Map builtin names to their win.lua implementations
+  local builtin_map = {
+    ["hide"] = function()
+      win.hide()
+    end,
+    ["toggle-help"] = function()
+      win.toggle_help()
+    end,
+    ["toggle-fullscreen"] = function()
+      win.toggle_fullscreen()
+    end,
+    ["toggle-preview"] = function()
+      win.toggle_preview()
+      local self = winobj()
+      if not self then return "" end
+      -- For builtin previewer without split, fzf's preview pane is zero-width
+      -- (--preview-window=nohidden:right:0). Don't send toggle-preview to fzf
+      -- or the zero-width pane gets toggled visible, creating an unwanted box.
+      -- The neovim preview is managed entirely by win.toggle_preview().
+      if self.previewer_is_builtin and not self.winopts.split then
+        return ""
+      end
+      -- For split layouts or fzf-native previewers, sync fzf's preview state:
+      if self.preview_hidden then
+        return "toggle-preview"
+      else
+        return string.format("toggle-preview+change-preview-window(%s)",
+          self:normalize_preview_layout().str)
+      end
+    end,
+    ["toggle-preview-cw"] = function()
+      win.toggle_preview_cw(1)
+      return change_preview_window()
+    end,
+    ["toggle-preview-ccw"] = function()
+      win.toggle_preview_cw(-1)
+      return change_preview_window()
+    end,
+    ["toggle-preview-behavior"] = function()
+      win.toggle_preview_behavior()
+    end,
+    ["toggle-preview-wrap"]     = function() win.toggle_preview_wrap() end,
+    ["toggle-preview-ts-ctx"]   = function() win.toggle_preview_ts_ctx() end,
+    ["toggle-preview-undo"]     = function() win.toggle_preview_undo_diff() end,
+    ["preview-ts-ctx-dec"]      = function() win.preview_ts_ctx_inc_dec(-1) end,
+    ["preview-ts-ctx-inc"]      = function() win.preview_ts_ctx_inc_dec(1) end,
+    ["preview-reset"]           = function() win.preview_scroll("reset") end,
+    ["preview-page-down"]       = function() win.preview_scroll("page-down") end,
+    ["preview-page-up"]         = function() win.preview_scroll("page-up") end,
+    ["preview-half-page-up"]    = function() win.preview_scroll("half-page-up") end,
+    ["preview-half-page-down"]  = function() win.preview_scroll("half-page-down") end,
+    ["preview-down"]            = function() win.preview_scroll("line-down") end,
+    ["preview-up"]              = function() win.preview_scroll("line-up") end,
+    ["preview-top"]             = function() win.preview_scroll("top") end,
+    ["preview-bottom"]          = function() win.preview_scroll("bottom") end,
+    ["focus-preview"]           = function() win.focus_preview() end,
+  }
+
+  local handler = builtin_map[builtin_name]
+  if handler then
+    local result = handler()
+    return type(result) == "string" and result or ""
+  end
+  return ""
+end
+
+--- Create the single dispatch handler that all transform binds share.
+--- This is the function registered with pipe_wrap_fn.
+---@param opts table
+---@return function the pipe handler function(pipe, items, preview_lines, preview_cols, ctx)
+function M._create_dispatch_handler(opts)
+  return function(pipe, items, preview_lines, preview_cols, ctx)
+    -- Determine trigger: event prefix or $FZF_KEY
+    local key
+    local is_event = false
+    if items[1] and type(items[1]) == "string" and items[1]:match("^__evt__") then
+      key = items[1]:sub(8)  -- strip "__evt__" prefix
+      table.remove(items, 1)
+      is_event = true
+    else
+      key = ctx.env.FZF_KEY or ""
+    end
+
+    -- Strip trailing {q} and {n} from items (appended by field index)
+    -- unless event has custom field_index
+    local custom_fi = is_event and opts.__transform_custom_fi
+        and opts.__transform_custom_fi[key]
+    if not custom_fi then
+      local match_count = table.remove(items)  -- {n}
+      local query = table.remove(items)         -- {q}
+
+      -- Update resume query
+      if query then
+        config.resume_set("query", query, opts)
+      end
+
+      -- Zero-match/zero-selected fixup (same logic as stringify_data2)
+      local zero_matched = not tonumber(match_count)
+      local zero_selected = #items == 0 or (#items == 1 and #items[1] == 0)
+      if zero_matched and zero_selected then items = {} end
+    end
+
+    local handler = opts.__transform_handlers and opts.__transform_handlers[key]
+    if not handler then
+      -- No handler found, return empty (no-op)
+      uv.write(pipe, "")
+      uv.close(pipe)
+      return
+    end
+
+    -- pcall to ensure the pipe is always closed and fzf doesn't hang.
+    -- Mirrors the resilience of the legacy execute-silent path where
+    -- errors in the headless nvim process don't freeze the parent.
+    local ok, result = pcall(handler, items, ctx)
+    if not ok then
+      utils.warn(string.format("transform handler error [%s]: %s", key, result))
+      result = ""
+    end
+    uv.write(pipe, result or "")
+    uv.close(pipe)
+  end
+end
+
+--- Check if unified binds should be used (fzf >= 0.59, not skim)
+---@param opts table
+---@return boolean
+function M.can_unified(opts)
+  return utils.has(opts, "fzf", { 0, 59 }) and not utils.has(opts, "sk")
+end
+
+return M

--- a/lua/fzf-lua/binds.lua
+++ b/lua/fzf-lua/binds.lua
@@ -271,7 +271,38 @@ local function classify_bind(key, entry, opts)
   end
 
   -- Builtin action → transform
+  -- Preview scroll actions with fzf previewer should be DIRECT so fzf
+  -- can scroll its own preview pane (the neovim-side functions only
+  -- work for the builtin previewer). Only route actions that are valid
+  -- fzf action names; neovim-only preview actions (preview-reset,
+  -- preview-ts-ctx-*, etc.) must stay as TRANSFORM.
   if entry.builtin then
+    if entry.builtin:match("^preview%-") then
+      local p = opts.previewer
+      -- Detect fzf previewer when opts.previewer is not yet resolved:
+      --   opts.previewer is set → check directly (string/function/table = fzf)
+      --   opts.previewer is nil → check opts.preview (fzf --preview command)
+      --     if opts.preview is a string → fzf previewer (e.g. git show)
+      --     if opts.preview is nil → builtin previewer
+      local is_builtin = (p == nil or p == true or p == "hidden" or p == "nohidden")
+          and not opts.preview
+      -- Whitelist of preview actions valid in fzf
+      local fzf_preview_action = ({
+        ["preview-up"]             = true,
+        ["preview-down"]           = true,
+        ["preview-page-up"]        = true,
+        ["preview-page-down"]      = true,
+        ["preview-half-page-up"]   = true,
+        ["preview-half-page-down"] = true,
+        ["preview-top"]            = true,
+        ["preview-bottom"]         = true,
+        ["focus-preview"]          = true,
+      })[entry.builtin]
+      if not is_builtin and fzf_preview_action then
+        entry.fzf_action = entry.builtin
+        return M.DIRECT
+      end
+    end
     return M.TRANSFORM
   end
 

--- a/lua/fzf-lua/core.lua
+++ b/lua/fzf-lua/core.lua
@@ -263,7 +263,7 @@ end
 M.fzf_wrap = function(cmd, opts, convert_actions)
   opts = opts or {}
   M.set_header(opts)
-  if convert_actions and type(opts.actions) == "table" then
+  if convert_actions and (binds.can_unified(opts) or type(opts.actions) == "table") then
     if binds.can_unified(opts) then
       -- Store contents for reload cmd before build_transform_binds
       opts._contents = opts._contents or cmd

--- a/lua/fzf-lua/core.lua
+++ b/lua/fzf-lua/core.lua
@@ -3,6 +3,7 @@ local path = require "fzf-lua.path"
 local utils = require "fzf-lua.utils"
 local config = require "fzf-lua.config"
 local actions = require "fzf-lua.actions"
+local binds = require "fzf-lua.binds"
 local win = require "fzf-lua.win"
 local libuv = require "fzf-lua.libuv"
 local shell = require "fzf-lua.shell"
@@ -263,8 +264,14 @@ M.fzf_wrap = function(cmd, opts, convert_actions)
   opts = opts or {}
   M.set_header(opts)
   if convert_actions and type(opts.actions) == "table" then
-    opts = M.convert_reload_actions(cmd, opts)
-    opts = M.convert_exec_silent_actions(opts)
+    if binds.can_unified(opts) then
+      -- Store contents for reload cmd before build_transform_binds
+      opts._contents = opts._contents or cmd
+      opts = binds.build_transform_binds(opts)
+    else
+      opts = M.convert_reload_actions(cmd, opts)
+      opts = M.convert_exec_silent_actions(opts)
+    end
   end
   -- Do not strt fzf, return the stringified contents and opts onlu
   -- used by the "combine" picker to merge inputs

--- a/lua/fzf-lua/types.lua
+++ b/lua/fzf-lua/types.lua
@@ -236,6 +236,7 @@ local FzfLua = require("fzf-lua")
 ---@field __stringify_cmd? boolean
 ---@field __sigwinches? string[]
 ---@field __sigwinch_cb table<string, function>
+---@field __sigwinch_triggers table<string, string>
 ---@field process1? boolean
 ---@field profiler? boolean
 ---@field use_queue? boolean

--- a/lua/fzf-lua/win.lua
+++ b/lua/fzf-lua/win.lua
@@ -218,6 +218,72 @@ function FzfWin:setup_keybinds()
   self.keymap = type(self.keymap) == "table" and self.keymap or {}
   self.keymap.fzf = type(self.keymap.fzf) == "table" and self.keymap.fzf or {}
   self.keymap.builtin = type(self.keymap.builtin) == "table" and self.keymap.builtin or {}
+
+  -- When using unified binds (fzf >= 0.59), builtin actions are routed
+  -- through the consolidated transform handler. We only need to:
+  -- 1. Register SIGWINCH-bridged terminal keymaps (neovim-only keys)
+  -- 2. Handle the Esc keymap fix
+  local binds = require("fzf-lua.binds")
+  if binds.can_unified(self._o) then
+    -- Register SIGWINCH-bridged terminal keymaps (neovim-only keys)
+    if self._o.__sigwinch_triggers and self.fzf_bufnr then
+      for nvim_key, handler_key in pairs(self._o.__sigwinch_triggers) do
+        vim.keymap.set("t", nvim_key, function()
+          -- SIGWINCH() sends the signal and sets __sigwinches to the scopes.
+          -- Pass the handler_key as scope so the resize callback knows
+          -- which handler to invoke.
+          self:SIGWINCH({ handler_key })
+        end, { nowait = true, buffer = self.fzf_bufnr })
+      end
+    end
+
+    -- Register SIGWINCH handler for toggle-preview so that direct calls
+    -- to win.toggle_preview() (e.g. from API/tests) can sync fzf state.
+    -- Only needed for split layouts or fzf-native previewers (not builtin
+    -- previewer without split, where fzf's preview pane is size 0).
+    if not utils.__IS_WINDOWS
+        and (self.winopts.split or not self.previewer_is_builtin) then
+      self.on_SIGWINCH(self._o, "toggle-preview", function(args)
+        if tonumber(args[1]) then
+          return "toggle-preview"
+        else
+          return string.format("change-preview-window(%s)", self:normalize_preview_layout().str)
+        end
+      end)
+      self.on_SIGWINCH(self._o, "toggle-preview-cw", function(args)
+        if not tonumber(args[1]) then return end
+        return string.format("change-preview-window(%s)", self:normalize_preview_layout().str)
+      end)
+      -- Set _fzf_toggle_prev_bind so toggle_preview() can use SIGWINCH
+      self._fzf_toggle_prev_bind = true
+    elseif utils.__IS_WINDOWS
+        and (self.winopts.split or not self.previewer_is_builtin) then
+      -- On Windows, SIGWINCH is not available. Find toggle-preview in
+      -- keymaps and add to keymap.fzf so toggle_preview() can feed the
+      -- key directly to fzf (same as legacy path).
+      self._fzf_toggle_prev_bind = nil
+      for k, v in pairs(self.keymap.builtin) do
+        if v == "toggle-preview" then
+          self.keymap.fzf[utils.neovim_bind_to_fzf(k)] = v
+        end
+      end
+      for k, v in pairs(self.keymap.fzf) do
+        if v == "toggle-preview" then
+          self._fzf_toggle_prev_bind = utils.fzf_bind_to_neovim(k)
+          self.keymap.builtin[self._fzf_toggle_prev_bind] = v
+        end
+      end
+      self._fzf_toggle_prev_bind = self._fzf_toggle_prev_bind or true
+    end
+
+    -- Esc keymap fix
+    if self.actions["esc"] == actions.dummy_abort and not self.keymap.builtin["<esc>"] then
+      vim.keymap.set("t", "<Esc>", "<Esc>", { buffer = self.fzf_bufnr, nowait = true })
+    end
+    return
+  end
+
+  -- Legacy path (fzf < 0.59 or skim)
   local keymap_tbl = {
     ["hide"]                    = { module = "win", fnc = "hide()" },
     ["toggle-help"]             = { module = "win", fnc = "toggle_help()" },
@@ -1261,7 +1327,9 @@ function FzfWin.on_SIGWINCH(opts, event, cb)
       local events = vim.tbl_keys(vim.list_slice(opts.__sigwinch_cb))
       vim.list_extend(events, opts.__sigwinches or {})
       opts.__sigwinches = nil
-      local acts = vim.tbl_map(function(k) return opts.__sigwinch_cb[k](args) end, events)
+      local acts = vim.tbl_map(function(k)
+        return opts.__sigwinch_cb[k] and opts.__sigwinch_cb[k](args) or ""
+      end, events)
       acts = vim.tbl_filter(function(a) return a and #a > 0 end, acts)
       return table.concat(acts, "+")
     end, opts, utils.__IS_WINDOWS and "%FZF_PREVIEW_LINES%" or "$FZF_PREVIEW_LINES")))

--- a/tests/binds_spec.lua
+++ b/tests/binds_spec.lua
@@ -1,0 +1,561 @@
+local helpers = require("fzf-lua.test.helpers")
+local assert = helpers.assert
+local eq = assert.are.same
+
+local binds = require("fzf-lua.binds")
+
+-- Wrapper for normalize_binds
+local function nb(opts)
+  return binds.normalize_binds(opts)
+end
+
+describe("binds.normalize_binds", function()
+
+  -- ================================================================
+  -- key normalization
+  -- ================================================================
+
+  describe("key normalization", function()
+    it("converts neovim format to fzf format", function()
+      local m = nb({ keymap = { builtin = { ["<C-y>"] = "abort" } } })
+      eq(m["ctrl-y"].fzf_action, "abort")
+    end)
+
+    it("preserves raw fzf format keys", function()
+      local m = nb({ keymap = { fzf = { ["ctrl-y"] = "abort" } } })
+      eq(m["ctrl-y"].fzf_action, "abort")
+    end)
+
+    it("normalizes <C-Enter> to ctrl-enter", function()
+      local m = nb({ keymap = { builtin = { ["<C-Enter>"] = "hide" } } })
+      eq(m["ctrl-enter"].builtin, "hide")
+      eq(m["ctrl-enter"]._nvim_key, "<C-Enter>")
+    end)
+
+    it("normalizes raw ctrl-enter to ctrl-enter", function()
+      local m = nb({ keymap = { fzf = { ["ctrl-enter"] = "abort" } } })
+      eq(m["ctrl-enter"].fzf_action, "abort")
+    end)
+
+    it("collapses shift+letter to uppercase (alt-J)", function()
+      local m = nb({ keymap = { builtin = { ["<M-S-j>"] = "preview-down" } } })
+      eq(m["alt-J"].builtin, "preview-down")
+    end)
+
+    it("preserves shift+special as shift-down", function()
+      local m = nb({ keymap = { builtin = { ["<S-Down>"] = "preview-page-down" } } })
+      eq(m["shift-down"].builtin, "preview-page-down")
+    end)
+
+    it("normalizes <M-Esc> to alt-esc", function()
+      local m = nb({ keymap = { builtin = { ["<M-Esc>"] = "hide" } } })
+      eq(m["alt-esc"].builtin, "hide")
+    end)
+
+    it("handles ctrl-z (no transformation)", function()
+      local m = nb({ keymap = { fzf = { ["ctrl-z"] = "abort" } } })
+      eq(m["ctrl-z"].fzf_action, "abort")
+    end)
+
+    it("handles function keys (f1-f12)", function()
+      local m = nb({ keymap = { builtin = { ["<F4>"] = "toggle-preview" } } })
+      eq(m["f4"].builtin, "toggle-preview")
+      eq(m["f4"]._nvim_key, "<F4>")
+    end)
+
+    it("handles alt keys", function()
+      local m = nb({ keymap = { fzf = { ["alt-a"] = "toggle-all" } } })
+      eq(m["alt-a"].fzf_action, "toggle-all")
+    end)
+  end)
+
+  -- ================================================================
+  -- value normalization
+  -- ================================================================
+
+  describe("value normalization: strings", function()
+    it("fzf action string → fzf_action", function()
+      local m = nb({ keymap = { fzf = { ["ctrl-z"] = "abort" } } })
+      eq(m["ctrl-z"].fzf_action, "abort")
+      eq(m["ctrl-z"]._source, "keymap.fzf")
+    end)
+
+    it("builtin action string → builtin", function()
+      local m = nb({ keymap = { builtin = { ["<F4>"] = "toggle-preview" } } })
+      eq(m["f4"].builtin, "toggle-preview")
+    end)
+
+    it("preview-* builtin action → builtin", function()
+      local m = nb({ keymap = { builtin = { ["<S-Down>"] = "preview-page-down" } } })
+      eq(m["shift-down"].builtin, "preview-page-down")
+    end)
+
+    it("hide builtin action → builtin", function()
+      local m = nb({ keymap = { builtin = { ["<M-Esc>"] = "hide" } } })
+      eq(m["alt-esc"].builtin, "hide")
+    end)
+  end)
+
+  describe("value normalization: functions", function()
+    it("function from actions → accept=true", function()
+      local fn = function() end
+      local m = nb({ actions = { enter = fn } })
+      eq(m["enter"].accept, true)
+      eq(type(m["enter"].fn), "function")
+    end)
+
+    it("function from keymap.fzf → exec_silent=true", function()
+      local fn = function() end
+      local m = nb({ keymap = { fzf = { enter = fn } } })
+      eq(m["enter"].exec_silent, true)
+      eq(type(m["enter"].fn), "function")
+    end)
+
+    it("function from keymap.builtin → accept=true", function()
+      local fn = function() end
+      local m = nb({ keymap = { builtin = { ["<C-j>"] = fn } } })
+      eq(m["ctrl-j"].accept, true)
+    end)
+
+    it("function from binds → accept=true", function()
+      local fn = function() end
+      local m = nb({ binds = { enter = fn } })
+      eq(m["enter"].accept, true)
+    end)
+  end)
+
+  describe("value normalization: tables with fn", function()
+    it("table with fn → metadata preserved", function()
+      local fn = function() end
+      local m = nb({ actions = { enter = { fn = fn, desc = "edit" } } })
+      eq(type(m["enter"].fn), "function")
+      eq(m["enter"].desc, "edit")
+    end)
+
+    it("table with fn and exec_silent → exec_silent preserved", function()
+      local fn = function() end
+      local m = nb({ actions = { enter = { fn = fn, exec_silent = true } } })
+      eq(m["enter"].exec_silent, true)
+      eq(m["enter"].accept, nil)
+    end)
+
+    it("table with fn and reload → reload preserved", function()
+      local fn = function() end
+      local m = nb({ actions = { enter = { fn = fn, reload = true } } })
+      eq(m["enter"].reload, true)
+    end)
+
+    it("table with fn and reuse → reuse preserved", function()
+      local fn = function() end
+      local m = nb({ actions = { enter = { fn = fn, reuse = "test" } } })
+      eq(m["enter"].reuse, "test")
+    end)
+
+    it("table with fn and prefix/postfix → preserved", function()
+      local fn = function() end
+      local m = nb({ actions = { enter = { fn = fn, reload = true, prefix = "sel+", postfix = "+acc" } } })
+      eq(m["enter"].prefix, "sel+")
+      eq(m["enter"].postfix, "+acc")
+    end)
+
+    it("table with fn and header/field_index → preserved", function()
+      local fn = function() end
+      local m = nb({ actions = { enter = { fn = fn, header = "files", field_index = "{+}" } } })
+      eq(m["enter"].header, "files")
+      eq(m["enter"].field_index, "{+}")
+    end)
+  end)
+
+  describe("value normalization: table with string [1]", function()
+    it("fzf action string [1] → fzf_action + desc", function()
+      local m = nb({ keymap = { fzf = { ["alt-g"] = { "first", desc = "Go to first" } } } })
+      eq(m["alt-g"].fzf_action, "first")
+      eq(m["alt-g"].desc, "Go to first")
+    end)
+
+    it("builtin action string [1] → builtin + desc", function()
+      local m = nb({ keymap = { builtin = { ["<F4>"] = { "toggle-preview", desc = "Toggle" } } } })
+      eq(m["f4"].builtin, "toggle-preview")
+      eq(m["f4"].desc, "Toggle")
+    end)
+
+    it("string [1] without desc → fzf_action", function()
+      local m = nb({ keymap = { fzf = { ["alt-g"] = { "first" } } } })
+      eq(m["alt-g"].fzf_action, "first")
+      eq(m["alt-g"].desc, nil)
+    end)
+  end)
+
+  describe("value normalization: function arrays (chain)", function()
+    it("array of functions → accept + chain", function()
+      local fn1 = function() end
+      local fn2 = function() end
+      local m = nb({ actions = { enter = { fn1, fn2 } } })
+      eq(m["enter"].accept, true)
+      eq(type(m["enter"].fn), "function")
+      eq(#m["enter"].chain, 1)
+    end)
+
+    it("array of 3 functions → accept + chain of 2", function()
+      local fn1, fn2, fn3 = function() end, function() end, function() end
+      local m = nb({ actions = { enter = { fn1, fn2, fn3 } } })
+      eq(#m["enter"].chain, 2)
+    end)
+
+    it("{ fn, actions.resume } → reload (backward compat)", function()
+      local fn = function() end
+      local resume = require("fzf-lua.actions").resume
+      local m = nb({ actions = { enter = { fn, resume } } })
+      eq(m["enter"].reload, true)
+      eq(m["enter"].accept, nil)
+    end)
+
+    it("single function array → accept, no chain", function()
+      local fn = function() end
+      local m = nb({ actions = { enter = { fn } } })
+      eq(m["enter"].accept, true)
+      eq(m["enter"].chain, nil)
+    end)
+  end)
+
+  describe("value normalization: removal", function()
+    it("false value → nil (removed)", function()
+      local m = nb({ keymap = { fzf = { enter = false } } })
+      eq(m["enter"], nil)
+    end)
+
+    it("nil value → nil (removed)", function()
+      local m = nb({ keymap = { fzf = { enter = nil } } })
+      eq(m["enter"], nil)
+    end)
+
+    it("true in keymap.builtin → nil (skipped)", function()
+      local m = nb({ keymap = { builtin = { ["<F4>"] = true } } })
+      eq(m["f4"], nil)
+    end)
+  end)
+
+  -- ================================================================
+  -- merge precedence
+  -- ================================================================
+
+  describe("merge precedence", function()
+    it("binds > actions", function()
+      local m = nb({
+        actions = { enter = function() end },
+        binds = { enter = "abort" },
+      })
+      eq(m["enter"].fzf_action, "abort")
+      eq(m["enter"]._source, "binds")
+    end)
+
+    it("binds > keymap.fzf", function()
+      local m = nb({
+        keymap = { fzf = { enter = "abort" } },
+        binds = { enter = "first" },
+      })
+      eq(m["enter"].fzf_action, "first")
+    end)
+
+    it("binds > keymap.builtin", function()
+      local m = nb({
+        keymap = { builtin = { ["<F4>"] = "toggle-preview" } },
+        binds = { f4 = "abort" },
+      })
+      eq(m["f4"].fzf_action, "abort")
+    end)
+
+    it("actions > keymap.fzf", function()
+      local m = nb({
+        keymap = { fzf = { enter = "abort" } },
+        actions = { enter = function() end },
+      })
+      eq(m["enter"].accept, true)
+      eq(m["enter"]._source, "actions")
+    end)
+
+    it("actions > keymap.builtin", function()
+      local m = nb({
+        keymap = { builtin = { ["<C-y>"] = "abort" } },
+        actions = { ["ctrl-y"] = function() end },
+      })
+      eq(m["ctrl-y"].accept, true)
+    end)
+
+    it("keymap.fzf > keymap.builtin", function()
+      local m = nb({
+        keymap = {
+          builtin = { ["<C-y>"] = "preview-page-down" },
+          fzf = { ["ctrl-y"] = "half-page-down" },
+        },
+      })
+      eq(m["ctrl-y"].fzf_action, "half-page-down")
+      eq(m["ctrl-y"]._source, "keymap.fzf")
+    end)
+
+    it("only keymap.builtin → lowest precedence", function()
+      local m = nb({
+        keymap = { builtin = { ["<C-y>"] = "preview-page-down" } },
+      })
+      eq(m["ctrl-y"].builtin, "preview-page-down")
+      eq(m["ctrl-y"]._source, "keymap.builtin")
+    end)
+
+    it("same key different format resolves to one entry", function()
+      local m = nb({
+        keymap = {
+          builtin = { ["<C-y>"] = "preview-page-down" },
+          fzf = { ["ctrl-y"] = "abort" },
+        },
+      })
+      eq(m["ctrl-y"].fzf_action, "abort")
+      eq(#vim.tbl_keys(m), 1)
+    end)
+  end)
+
+  -- ================================================================
+  -- unbind
+  -- ================================================================
+
+  describe("unbind (value=false)", function()
+    it("removes key from merged", function()
+      local m = nb({
+        keymap = { fzf = { enter = "abort" } },
+        binds = { enter = false },
+      })
+      eq(m["enter"], nil)
+    end)
+
+    it("removes even higher-precedence source", function()
+      local m = nb({
+        actions = { enter = function() end },
+        binds = { enter = false },
+      })
+      eq(m["enter"], nil)
+    end)
+
+    it("removes with neovim format key", function()
+      local m = nb({
+        keymap = { builtin = { ["<C-Enter>"] = "hide" } },
+        binds = { ["<C-Enter>"] = false },
+      })
+      eq(m["ctrl-enter"], nil)
+    end)
+
+    it("clears opts.actions for unbound key", function()
+      local opts = {
+        actions = { enter = function() end },
+        binds = { enter = false },
+      }
+      nb(opts)
+      eq(opts.actions.enter, nil)
+    end)
+
+    it("clears opts.keymap.fzf for unbound key", function()
+      local opts = {
+        keymap = { fzf = { enter = "abort" } },
+        binds = { enter = false },
+      }
+      nb(opts)
+      eq(opts.keymap.fzf.enter, nil)
+    end)
+
+    it("unbind does not affect other keys", function()
+      local m = nb({
+        keymap = { fzf = { enter = "abort", ["ctrl-z"] = "abort" } },
+        binds = { enter = false },
+      })
+      eq(m["enter"], nil)
+      eq(m["ctrl-z"].fzf_action, "abort")
+    end)
+  end)
+
+  -- ================================================================
+  -- source tracking
+  -- ================================================================
+
+  describe("source tracking", function()
+    it("keymap.builtin: _source and _nvim_key", function()
+      local m = nb({ keymap = { builtin = { ["<F4>"] = "toggle-preview" } } })
+      eq(m["f4"]._source, "keymap.builtin")
+      eq(m["f4"]._nvim_key, "<F4>")
+    end)
+
+    it("keymap.fzf: _source and _nvim_key", function()
+      local m = nb({ keymap = { fzf = { ["ctrl-z"] = "abort" } } })
+      eq(m["ctrl-z"]._source, "keymap.fzf")
+      eq(m["ctrl-z"]._nvim_key, "ctrl-z")
+    end)
+
+    it("actions: _source and _nvim_key", function()
+      local m = nb({ actions = { enter = function() end } })
+      eq(m["enter"]._source, "actions")
+      eq(m["enter"]._nvim_key, "enter")
+    end)
+
+    it("binds: _source and _nvim_key", function()
+      local m = nb({ binds = { ["ctrl-z"] = "abort" } })
+      eq(m["ctrl-z"]._source, "binds")
+      eq(m["ctrl-z"]._nvim_key, "ctrl-z")
+    end)
+
+    it("override updates _source", function()
+      local m = nb({
+        keymap = { builtin = { ["<F4>"] = "toggle-preview" } },
+        binds = { f4 = "abort" },
+      })
+      eq(m["f4"]._source, "binds")
+    end)
+  end)
+
+  -- ================================================================
+  -- empty / missing tables
+  -- ================================================================
+
+  describe("empty and missing tables", function()
+    it("empty opts → empty merged", function()
+      local m = nb({})
+      eq(#vim.tbl_keys(m), 0)
+    end)
+
+    it("empty keymap tables → empty merged", function()
+      local m = nb({ keymap = { fzf = {}, builtin = {} } })
+      eq(#vim.tbl_keys(m), 0)
+    end)
+
+    it("empty actions → empty merged", function()
+      local m = nb({ actions = {} })
+      eq(#vim.tbl_keys(m), 0)
+    end)
+
+    it("empty binds → empty merged", function()
+      local m = nb({ binds = {} })
+      eq(#vim.tbl_keys(m), 0)
+    end)
+
+    it("nil keymap → empty merged", function()
+      local m = nb({ keymap = nil })
+      eq(#vim.tbl_keys(m), 0)
+    end)
+  end)
+
+  -- ================================================================
+  -- internal actions
+  -- ================================================================
+
+  describe("internal actions", function()
+    it("underscore prefix → not merged", function()
+      local m = nb({
+        actions = { _internal = function() end, enter = function() end },
+      })
+      eq(m["_internal"], nil)
+      eq(m["enter"].accept, true)
+    end)
+
+    it("underscore prefix with table → not merged", function()
+      local m = nb({
+        actions = { _resume = { fn = function() end, reload = true } },
+      })
+      eq(m["_resume"], nil)
+    end)
+  end)
+
+  -- ================================================================
+  -- fzf events
+  -- ================================================================
+
+  describe("fzf events", function()
+    it("load event fn → event=true", function()
+      local fn = function() end
+      local m = nb({ binds = { load = fn } })
+      eq(m["load"].event, true)
+      eq(type(m["load"].fn), "function")
+    end)
+
+    it("resize event table → event=true + field_index", function()
+      local fn = function() end
+      local m = nb({ binds = { resize = { fn = fn, field_index = "$FZF_PROMPT" } } })
+      eq(m["resize"].event, true)
+      eq(m["resize"].field_index, "$FZF_PROMPT")
+    end)
+
+    it("start event with exec_silent → both flags", function()
+      local fn = function() end
+      local m = nb({ binds = { start = { fn = fn, exec_silent = true } } })
+      eq(m["start"].event, true)
+      eq(m["start"].exec_silent, true)
+    end)
+
+    it("non-event key → event=nil", function()
+      local fn = function() end
+      local m = nb({ binds = { enter = fn } })
+      eq(m["enter"].event, nil)
+      eq(m["enter"].accept, true)
+    end)
+
+    it("known fzf events: load, start, resize, change, focus, result", function()
+      local fn = function() end
+      local m = nb({
+        binds = {
+          load = fn, start = fn, resize = fn,
+          change = fn, focus = fn, result = fn,
+        },
+      })
+      eq(m["load"].event, true)
+      eq(m["start"].event, true)
+      eq(m["resize"].event, true)
+      eq(m["change"].event, true)
+      eq(m["focus"].event, true)
+      eq(m["result"].event, true)
+    end)
+  end)
+
+  -- ================================================================
+  -- complex real-world scenarios
+  -- ================================================================
+
+  describe("complex scenarios", function()
+    it("mixed sources coexist on different keys", function()
+      local fn = function() end
+      local opts = {
+        keymap = { builtin = { ["<F1>"] = "toggle-help" } },
+        actions = { enter = fn },
+        binds = { ["ctrl-z"] = "abort" },
+      }
+      -- Add keymap.fzf separately since Lua tables can't have duplicate keys
+      opts.keymap.fzf = { ["ctrl-f"] = "half-page-down" }
+      local m = nb(opts)
+      eq(m["f1"].builtin, "toggle-help")
+      eq(m["ctrl-f"].fzf_action, "half-page-down")
+      eq(m["enter"].accept, true)
+      eq(m["ctrl-z"].fzf_action, "abort")
+    end)
+
+    it("unbind removes key across all layers", function()
+      local opts = {
+        keymap = { builtin = { ["<F1>"] = "toggle-help" } },
+        actions = { f1 = function() end },
+        binds = { f1 = false },
+      }
+      opts.keymap.fzf = { f1 = "abort" }
+      local m = nb(opts)
+      eq(m["f1"], nil)
+      eq(opts.actions.f1, nil)
+      eq(opts.keymap.fzf.f1, nil)
+    end)
+
+    it("mixed direct/accept/transform entries", function()
+      local fn = function() end
+      local m = nb({
+        binds = {
+          ["ctrl-z"] = "abort",  -- direct
+          enter = fn,            -- accept
+          load = fn,             -- transform (event)
+        },
+      })
+      eq(m["ctrl-z"].fzf_action, "abort")
+      eq(m["enter"].accept, true)
+      eq(m["load"].event, true)
+    end)
+  end)
+end)


### PR DESCRIPTION
... single table routed into a single fzf "transform".

Simplifies the config significantly (no more actions / keymap.{fzf|builtin}), use a single "binds" table instead.

All keybinds/events which require complex handling have a single transform RPC endpoint, this also enables to bind neovim keys using the SIGWINCH method.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unified binds: single binds table with backward-compatible merge of legacy keymaps/actions, auto-normalization into direct/accept/transform/SIGWINCH/dropped routes; consolidated transform dispatch and SIGWINCH-backed terminal key handling; resume-query and reload support.

* **Documentation**
  * Added design/spec covering normalization rules, precedence, routing modes, dispatch model, and fzf version requirements.

* **Bug Fixes**
  * More robust event/transform handling to avoid errors when callbacks are absent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->