### PR TITLE
fix(libuv): duplicated prev_line_content when stream EOF

### DIFF
--- a/lua/fzf-lua/libuv.lua
+++ b/lua/fzf-lua/libuv.lua
@@ -240,7 +240,10 @@ M.spawn = function(opts, fn_transform, fn_done)
   --- Called with nil to process the leftover data
   ---@param data string?
   local process_data = function(data)
-    data = data or prev_line_content and (prev_line_content .. EOL) or nil
+    if not data and prev_line_content then
+      data = prev_line_content .. EOL
+      prev_line_content = nil
+    end
     if not data then
       -- NOTE: this isn't called when prev_line_content is not nil but that's
       -- not a problem as the write_cb will call finish once the callback is done


### PR DESCRIPTION
When the stream ends (signified by `data` being `nil`), the function
checked if there was any `prev_line_content` leftover.

prev_line_content isn't nullified and will be used again in split_lines:
```
prev_line_content .. EOL .. prev_line_content
```

Fix https://github.com/ibhagwan/fzf-lua/issues/2636.
