### PR TITLE
fix(previewer): use Snacks.image for image preview when buffer is already loaded

### DIFF
--- a/lua/fzf-lua/previewer/builtin.lua
+++ b/lua/fzf-lua/previewer/builtin.lua
@@ -1033,6 +1033,14 @@ function Previewer.buffer_or_file:populate_preview_buf(entry_str)
     self._job_id = nil
   end
   if entry.bufnr and api.nvim_buf_is_loaded(entry.bufnr) then
+    -- For image buffers, use Snacks.image instead of copying buffer lines
+    if vim.bo[entry.bufnr].filetype == "image" then
+      local tmpbuf = reuse_buf or self:get_tmp_buffer()
+      if self:attach_snacks_image_buf(tmpbuf, entry) then
+        self:preview_buf_post(entry)
+        return
+      end
+    end
     -- WE NO LONGER REUSE THE CURRENT BUFFER
     -- this changes the buffer's 'getbufinfo[1].lastused'
     -- which messes up our `buffers()` sort


### PR DESCRIPTION
## Summary

When an image file is already open in a buffer (via nvim-tree, fzf-lua, etc.), previewing the same image in fzf-lua again results in a blank preview window.

**Root cause:** When `entry.bufnr` is set and loaded, the previewer copies buffer lines to a temp buffer (`nvim_buf_get_lines` → `nvim_buf_set_lines`). However, Snacks.image sets the image buffer's filetype to `"image"` with empty/placeholder content — copying these lines produces a blank preview, and `attach_snacks_image_buf` is never reached (it's in the `else` branch).

**Fix:** Detect image buffers (`filetype == "image"`) early in the `entry.bufnr` branch and delegate to `attach_snacks_image_buf` instead of copying lines.

## Steps to reproduce

1. Use fzf-lua to find an image file → preview works ✓
2. Open the image into a buffer
3. Use fzf-lua to preview the same image again → blank preview ✗ (fixed)

## Test plan

- [x] Preview image not yet loaded → works
- [x] Open image to buffer, then preview again → works (was blank before fix)
- [x] Non-image buffers still preview normally via line copying
- [x] No regression for inline image rendering in markdown previews

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved preview handling for image files to display them correctly instead of rendering as text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->