### PR TITLE
fix(preview): typing no longer errors when there is no preview buffer

### DIFF
--- a/lua/fzf-lua/previewer/builtin.lua
+++ b/lua/fzf-lua/previewer/builtin.lua
@@ -1553,7 +1553,7 @@ function Previewer.buffer_or_file:preview_buf_post(entry, min_winopts)
       end
       -- for attach_snacks_image_{inline,buf}
       -- https://github.com/folke/snacks.nvim/pull/1615
-      if vim.b[self.preview_bufnr].snacks_image_attached then
+      if self.preview_bufnr and vim.b[self.preview_bufnr].snacks_image_attached then
         utils.wo[self.win.preview_winid][0].winblend = 0
       end
     end


### PR DESCRIPTION
`self.preview_bufnr` has a chance of not being defined when there are no matches to preview. This PR checks in-advance to prevent any spammy errors during typing.

## Before
https://github.com/user-attachments/assets/a7530457-a11a-4895-bfce-b19ac3a25ba9


## After
https://github.com/user-attachments/assets/de9407d6-63d5-44ba-9ac5-ee269269f173

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed a potential error in preview buffer handling that could occur when image attachments are detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->