### PR TITLE
feat(blines): add locate option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1116,7 +1116,7 @@ previewers = {
       ["--with-nth"]  = '2..',
     },
   },
-  -- `blines` has the same defaults as `lines` aside from prompt and `show_bufname`
+  -- `blines` has the same defaults as `lines` aside from `prompt`, `show_bufname`, and `locate`
   lines = {
     prompt            = 'Lines❯ ',
     file_icons        = true,
@@ -1125,6 +1125,7 @@ previewers = {
     show_unlisted     = false,        -- exclude 'help' buffers
     no_term_buffers   = true,         -- exclude 'term' buffers
     sort_lastused     = true,         -- sort by most recent
+    locate            = false,        -- jump to current line (blines only)
     winopts  = { treesitter = true }, -- enable TS highlights
     fzf_opts = {
       -- do not include bufnr in fuzzy matching

--- a/lua/fzf-lua/config.lua
+++ b/lua/fzf-lua/config.lua
@@ -983,7 +983,7 @@ function M.normalize_opts(opts, globals, __resume_key) ---@diagnostic disable
     opts.fn_preprocess = [[return require("fzf-lua.make_entry").preprocess]]
   end
 
-  -- set by git_{commits|diff|hunks} actions
+  -- set by git_{commits|diff|hunks} and blines actions
   if utils.get_info().cmd and opts["__pos_" .. utils.get_info().cmd] then
     opts.locate = opts.locate == nil and true or opts.locate
     opts.__locate_pos = opts.__locate_pos or opts["__pos_" .. utils.get_info().cmd]
@@ -993,7 +993,11 @@ function M.normalize_opts(opts, globals, __resume_key) ---@diagnostic disable
     table.insert(opts._fzf_cli_args, "--bind=" .. libuv.shellescape("load:+transform:"
       .. FzfLua.shell.stringify_data(function(_, _, _)
         if opts.__locate_pos then
-          return string.format("pos(%d)", opts.__locate_pos)
+          local action = string.format("pos(%d)", opts.__locate_pos)
+          if opts.__scroll_pos then
+            action = string.format("pos(%d)+", opts.__scroll_pos) .. action
+          end
+          return action
         end
       end, opts)))
   end

--- a/lua/fzf-lua/defaults.lua
+++ b/lua/fzf-lua/defaults.lua
@@ -1245,11 +1245,14 @@ M.defaults.lines                 = {
 ---Current buffer lines.
 ---@diagnostic disable-next-line: param-type-mismatch
 ---@class fzf-lua.config.Blines: fzf-lua.config.Lines
+---Jump to the current line.
+---@field locate? boolean
 M.defaults.blines                = vim.tbl_deep_extend("force", M.defaults.lines, {
   show_bufname    = false,
   show_unloaded   = true,
   show_unlisted   = true,
   no_term_buffers = false,
+  locate          = false,
   fzf_opts        = {
     ["--with-nth"] = "4..",
     ["--nth"]      = "2..",

--- a/lua/fzf-lua/providers/buffers.lua
+++ b/lua/fzf-lua/providers/buffers.lua
@@ -21,6 +21,7 @@ local M = {}
 ---@field start_line? integer
 ---@field end_line? integer
 ---@field start? "cursor"
+---@field locate? boolean
 ---@field show_bufname? boolean|integer
 ---@field show_bufname_len? integer
 ---@field sort_lastused? boolean
@@ -259,6 +260,9 @@ M.blines = function(opts)
     if not sel then return end
     opts.start_line = opts.start_line or sel.start.line
     opts.end_line = opts.end_line or sel["end"].line
+  elseif opts.locate then
+    -- capture viewport bounds while the original window is still current
+    opts.__win_bottom = vim.fn.line("w$")
   end
   return M.buffer_lines(opts)
 end
@@ -348,6 +352,15 @@ M.buffer_lines = function(opts)
           if opts.start == "cursor" then
             -- start display from current line and wrap from bottom (#822)
             offset = utils.CTX().cursor[1] - start_line
+          end
+          if opts.locate and opts.__win_bottom then
+            -- position fzf cursor on current line
+            local cursor_pos = utils.CTX().cursor[1] - start_line + 1
+            opts.__locate_pos = math.max(1, math.min(lines, cursor_pos))
+            if opts.__win_bottom then
+              local bottom_pos = opts.__win_bottom - start_line + 1
+              opts.__scroll_pos = math.max(1, math.min(lines, bottom_pos))
+            end
           end
         end
 


### PR DESCRIPTION
This option keeps the fzf cursor positioned according to the current window viewport, which makes it easier to use keep `blines` a fuzzy replacement for `/`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `locate` option for the blines (buffer lines) picker that defaults to disabled. When enabled, the picker jumps to and displays the current cursor line with proper scroll positioning to show surrounding context.

* **Documentation**
  * Updated configuration documentation to document the new locate option for blines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->