### PR TITLE
fix(preview): don't copy snacks.image buffer

### DIFF
--- a/lua/fzf-lua/previewer/builtin.lua
+++ b/lua/fzf-lua/previewer/builtin.lua
@@ -1032,7 +1032,7 @@ function Previewer.buffer_or_file:populate_preview_buf(entry_str)
     fn.jobstop(self._job_id)
     self._job_id = nil
   end
-  if entry.bufnr and api.nvim_buf_is_loaded(entry.bufnr) then
+  if entry.bufnr and api.nvim_buf_is_loaded(entry.bufnr) and vim.bo[entry.bufnr].filetype ~= "image" then
     -- WE NO LONGER REUSE THE CURRENT BUFFER
     -- this changes the buffer's 'getbufinfo[1].lastused'
     -- which messes up our `buffers()` sort


### PR DESCRIPTION
Fix https://github.com/ibhagwan/fzf-lua/pull/2639


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed preview buffer handling to properly manage image files. Buffers containing images are no longer incorrectly reused during preview operations, ensuring appropriate display behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->