### PR TITLE
ci: autogenerate types

### DIFF
--- a/.github/workflows/vimdoc.yaml
+++ b/.github/workflows/vimdoc.yaml
@@ -26,9 +26,10 @@ jobs:
           echo "${PWD}/emmylua_doc_cli/" >> $GITHUB_PATH
           export PATH="${PWD}/emmylua_doc_cli/:${PATH}"
           emmylua_doc_cli --version
-      - name: Generate OPTIONS.md
+      - name: Generate OPTIONS.md and types
         run: |
           nvim --headless -l scripts/gen_options.lua
+          make gen
       - name: Setup treesitter
         run: |
           mkdir -p ~/.local/share/nvim/site/pack/vendor/start
@@ -54,6 +55,6 @@ jobs:
           git config user.email "actions@github"
           git config user.name "Github Actions"
           git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
-          git add doc OPTIONS.md
+          git add doc OPTIONS.md lua/fzf-lua/types.lua
           # Only commit and push if we have changes
           git diff --quiet && git diff --staged --quiet || (git commit -m "${COMMIT_MSG}"; git push origin HEAD:${GITHUB_REF})


### PR DESCRIPTION
Closes #2647 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI workflow updated to run an additional generation step after documentation is produced; the workflow now stages and commits the newly generated artifacts (including type definitions) alongside docs so generated outputs are consistently included in CI-driven commits and downstream checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->