### PR TITLE
fix: check if winid is valid before using it

### DIFF
--- a/lua/fzf-lua/win.lua
+++ b/lua/fzf-lua/win.lua
@@ -1143,12 +1143,18 @@ end
 ---@param winid? integer
 ---@param last_winid? integer
 local restore_lastwin = function(winid, last_winid)
-  if winid and last_winid and api.nvim_win_is_valid(last_winid) then
-    utils.eventignore(function()
-      api.nvim_set_current_win(last_winid)
-      api.nvim_set_current_win(winid)
-    end)
+  if
+      not winid
+      or not last_winid
+      or not api.nvim_win_is_valid(last_winid)
+      or not api.nvim_win_is_valid(winid)
+  then
+    return
   end
+  utils.eventignore(function()
+    api.nvim_set_current_win(last_winid)
+    api.nvim_set_current_win(winid)
+  end)
 end
 
 ---@param buf? integer


### PR DESCRIPTION
If the window with id `winid` is closed before this function is called (may happen when opening fzf-lua from a `mini.files` buffer, for example), `api.nvim_set_current_win()` throws an error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved window restoration validation to ensure both source and target window identifiers are valid before performing operations. This prevents potential errors and edge case failures when managing multiple windows, enhancing stability and reliability in window focus restoration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->