### PR TITLE
feat(preview): builtin can list directory content

### DIFF
--- a/lua/fzf-lua/previewer/builtin.lua
+++ b/lua/fzf-lua/previewer/builtin.lua
@@ -1111,6 +1111,10 @@ function Previewer.buffer_or_file:populate_preview_buf(entry_str)
         local fs_stat = entry.path and uv.fs_stat(entry.path)
         if not fs_stat then
           lines = { string.format("Unable to stat file %s", entry.path) }
+        elseif fs_stat.type == "directory" then
+          local cmd = utils._if_win({ "cmd.exe", "/c", "dir" }, { "ls", "-la" })
+          table.insert(cmd, entry.path)
+          lines, _ = utils.io_systemlist(cmd)
         elseif fs_stat.size > 0 and utils.perl_file_is_binary(entry.path) then
           lines = { "Preview is not supported for binary files." }
         elseif tonumber(self.limit_b) > 0 and fs_stat.size > self.limit_b then


### PR DESCRIPTION
The builtin preview shows this message when a directory is selected:
```
Preview is not supported for binary files.
```
In my use case I made it list the directory's content, so I might as well contribute this back if you feel like it's a good behaviour to add.

I'm no nvim lua expert so there might be a better way to list a directory content?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Directory preview now shows a readable listing of folder contents in the preview pane.
* **Bug Fixes**
  * If directory listing fails, a clear "Preview is not supported for this directory." message is shown.
* **Unchanged**
  * Preview behavior for non-directories (binary files, size limits, and missing stat) remains the same.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->