### PR TITLE
fix(utils): hide profile should not inherit default

### DIFF
--- a/lua/fzf-lua/utils.lua
+++ b/lua/fzf-lua/utils.lua
@@ -979,10 +979,6 @@ function M.load_profiles(profiles, silent)
   profiles = type(profiles) == "table" and profiles
       or type(profiles) == "string" and { profiles }
       or {}
-  -- If the use specified only the "hide" profile, inherit the defaults
-  if #profiles == 1 and profiles[1] == "hide" then
-    table.insert(profiles, 1, "default")
-  end
   for _, profile in ipairs(profiles) do
     -- backward compat, renamed "borderless_full" > "borderless-full"
     if profile == "borderless_full" then profile = "borderless-full" end


### PR DESCRIPTION
fix #2661

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed profile loading behavior to prevent automatic injection of the default profile when using the "hide" profile option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->