### PR TITLE
fix(help): use action header as desc fallback in F1 keybind help

### DIFF
--- a/lua/fzf-lua/config.lua
+++ b/lua/fzf-lua/config.lua
@@ -1063,8 +1063,14 @@ M.set_action_helpstr = function(fn, helpstr)
   M._action_to_helpstr[fn] = helpstr
 end
 
-M.get_action_helpstr = function(fn)
-  return M._action_to_helpstr[fn]
+---@param v fzf-lua.ActionSpec|any
+---@return string
+M.get_action_helpstr = function(v)
+  local t = M._action_to_helpstr
+  if type(v) ~= "table" or t[v] then return t[v] or tostring(v) end
+  local res = v.desc or t[v[1]] or t[v.fn] or v.header
+  if res then return res end
+  return type(v[1]) == "string" and v[1] or tostring(v)
 end
 
 M._action_to_helpstr = {

--- a/lua/fzf-lua/core.lua
+++ b/lua/fzf-lua/core.lua
@@ -1020,7 +1020,7 @@ M.convert_reload_actions = function(reload_cmd, opts)
           M.can_transform(opts) and "transform" or "reload", -- contents is not "cmd" but "reload:cmd"
           reload_cmd,
           type(v.postfix) == "string" and v.postfix or ""),
-        desc = v.desc or config.get_action_helpstr(v.fn)
+        desc = config.get_action_helpstr(v)
       }
     end
   end
@@ -1075,7 +1075,7 @@ M.convert_exec_silent_actions = function(opts)
           or string.format(":%s", cmd),
           -- can't use postfix since we use "execute-silent:..."
           has_fzf036 and type(v.postfix) == "string" and v.postfix or ""),
-        desc = v.desc or config.get_action_helpstr(v.fn)
+        desc = config.get_action_helpstr(v)
       }
     end
   end

--- a/lua/fzf-lua/profiles/hide.lua
+++ b/lua/fzf-lua/profiles/hide.lua
@@ -73,7 +73,7 @@ return {
         then
           local fn = act.fn
           act.exec_silent = true
-          act.desc = act.desc or fzf.config.get_action_helpstr(fn)
+          act.desc = act.desc or fzf.config.get_action_helpstr(act)
           act.fn = function(...)
             fzf.hide()
             if fn then fn(...) end

--- a/lua/fzf-lua/types.lua
+++ b/lua/fzf-lua/types.lua
@@ -55,6 +55,7 @@ local FzfLua = require("fzf-lua")
 ---@field reload? boolean
 ---@field field_index? string
 ---@field desc? string
+---@field header? string|false
 ---@field prefix? string
 ---@field postfix? string
 ---@field reuse? boolean

--- a/lua/fzf-lua/win/help.lua
+++ b/lua/fzf-lua/win/help.lua
@@ -72,7 +72,7 @@ function M.toggle(keymap, actions, hls, zindex, preview_keymaps, preview_mode, h
   local get_desc = function(v)
     if type(v) == "table" then
       return v.desc or config.get_action_helpstr(v[1]) or config.get_action_helpstr(v.fn) or
-          tostring(v)
+          v.header or tostring(v)
     elseif v then
       return config.get_action_helpstr(v) or tostring(v)
     end

--- a/lua/fzf-lua/win/help.lua
+++ b/lua/fzf-lua/win/help.lua
@@ -47,34 +47,17 @@ function M.toggle(keymap, actions, hls, zindex, preview_keymaps, preview_mode, h
   for _, m in ipairs({ "builtin", "fzf" }) do
     for k, v in pairs(keymap[m]) do
       if not keymap_ignore[k] then
-        -- value can be defined as a table with addl properties (help string)
-        if type(v) == "table" then
-          v = v.desc or v[1]
-        end
+        v = config.get_action_helpstr(v)
         -- only add preview keybinds respective of
         -- the current preview mode
-        if v and (not preview_keymaps[v] or m == preview_mode) then
+        if not preview_keymaps[v] or m == preview_mode then
           if m == "builtin" then
             k = utils.neovim_bind_to_fzf(k)
           end
-          v = type(v) == "function" and config.get_action_helpstr(v) or tostring(v)
           table.insert(keymaps,
             format_bind(m, k, v, opts.mode_width, opts.keybind_width, opts.name_width))
         end
       end
-    end
-  end
-
-  ---TODO: we can always parse the action into table to avoid this duplicated logic
-  ---(e.g. profile/hide.lua, config.lua)
-  ---@param v fzf-lua.ActionSpec
-  ---@return string?
-  local get_desc = function(v)
-    if type(v) == "table" then
-      return v.desc or config.get_action_helpstr(v[1]) or config.get_action_helpstr(v.fn) or
-          v.header or tostring(v)
-    elseif v then
-      return config.get_action_helpstr(v) or tostring(v)
     end
   end
 
@@ -83,7 +66,7 @@ function M.toggle(keymap, actions, hls, zindex, preview_keymaps, preview_mode, h
     for k, v in pairs(actions) do
       if v then -- skips 'v == false'
         if k == "default" then k = "enter" end
-        local desc = get_desc(v)
+        local desc = config.get_action_helpstr(v)
         table.insert(keymaps,
           format_bind("action", k,
             ("%s"):format(desc):gsub(" ", ""),


### PR DESCRIPTION
## Problem

The F1 help window shows `table:0x...` for actions that define a `header` field but not `desc`, when the action's `fn` is an anonymous function not registered in the helpstr table.

The `get_desc` function in `win/help.lua` resolves descriptions via this chain:

```
v.desc -> helpstr(v[1]) -> helpstr(v.fn) -> tostring(v)
```

For actions like `git.commits` `ctrl-d` (which has `header = "git diff"` but no `desc`, and uses an anonymous `fn`), every step before `tostring(v)` returns `nil`, so the help window displays the unhelpful `table:0x...` string.

## Fix

Add `v.header` as a fallback between `config.get_action_helpstr(v.fn)` and `tostring(v)`:

```lua
return v.desc or config.get_action_helpstr(v[1]) or config.get_action_helpstr(v.fn) or
    v.header or tostring(v)
```

This is consistent with how `header` is already used as a human-readable label for actions (it populates the `--header` line at the top of pickers).

## Affected actions

6 built-in actions in `defaults.lua` that have `header` but no `desc`:

| Picker | Key | Header (now shown in F1) |
|---|---|---|
| `git.diff` | `ctrl-q` | `"git commits"` |
| `git.commits` | `ctrl-d` | `"git diff"` |
| `spellcheck` | `ctrl-s` | `"spell suggest"` |
| `serverlist` | `ctrl-o` | `"spawn"` |
| `serverlist` | `ctrl-x` | `"kill"` |
| `serverlist` | `ctrl-r` | `"reload"` |

Actions with `header = false` (used to suppress the header line) are unaffected since `false` is falsy and the chain continues to `tostring(v)`.

## Before / After

**Before:** F1 help shows `table: 0x56327a5de490` for these keybinds.

**After:** F1 help shows the `header` string (e.g. `"git diff"`, `"spell suggest"`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Help/description text is now generated consistently so preview keymaps and action descriptions display correctly and reliably.

* **New Features**
  * Help text resolution supports richer action specifications (including an optional header), improving how actions are labeled and presented in UI lists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->