### PR TITLE
misc previewer fixes

### DIFF
--- a/lua/fzf-lua/actions.lua
+++ b/lua/fzf-lua/actions.lua
@@ -204,8 +204,6 @@ M.vimcmd_entry = function(vimcmd, selected, opts, bufedit)
     (function()
       -- Lua 5.1 goto compatiblity hack (function wrap)
       local entry = path.entry_to_file(sel, opts, opts._uri)
-      -- "<none>" could be set by `autocmds`
-      if entry.path == "<none>" then return end
       local fullpath = entry.bufname
           or entry.uri and entry.uri:match("^[%a%-]+://(.*)")
           or entry.path
@@ -216,17 +214,19 @@ M.vimcmd_entry = function(vimcmd, selected, opts, bufedit)
         -- technically we should never get to the `uv.cwd()` fallback
         fullpath = path.join({ opts.cwd or opts._cwd or utils.cwd(), fullpath })
       end
+      -- Always open files relative to the current win/tab cwd (#1854)
+      -- We normalize the path or Windows will fail with directories starting
+      -- with special characters, for example "C:\app\(web)" will be translated
+      -- by neovim to "c:\app(web)" (#1082)
+      local relpath = path.normalize(path.relative_to(fullpath, utils.cwd()))
+      -- "<none>" could be set by `autocmds`
+      if relpath == "<none>" then return end
       -- Can't be called from term window (for example, "reload" actions) due to
       -- nvim_exec2(): Vim(normal):Can't re-enter normal mode from terminal mode
       -- NOTE: we do not use `opts.__CTX.bufnr` as caller might be the fzf term
       if not utils.is_term_buffer(0) then
         vim.cmd("normal! m`")
       end
-      -- Always open files relative to the current win/tab cwd (#1854)
-      -- We normalize the path or Windows will fail with directories starting
-      -- with special characters, for example "C:\app\(web)" will be translated
-      -- by neovim to "c:\app(web)" (#1082)
-      local relpath = path.normalize(path.relative_to(fullpath, utils.cwd()))
       if bufedit then
         local will_replace_curbuf = #vimcmd == 0 and not buf_edited(entry.bufnr, fullpath)
         if will_replace_curbuf then

--- a/lua/fzf-lua/path.lua
+++ b/lua/fzf-lua/path.lua
@@ -666,9 +666,8 @@ function M.jj_root(opts, noerr)
 end
 
 ---@param str string
----@param opts fzf-lua.config.Resolved
----@return fzf-lua.path.Entry|fzf-lua.keymap.Entry
-function M.keymap_to_entry(str, opts)
+---@return fzf-lua.keymap.Entry
+function M.keymap_to_entry(str)
   local valid_modes = {
     n = true,
     i = true,
@@ -680,21 +679,15 @@ function M.keymap_to_entry(str, opts)
   if not mode or not keymap then return {} end
   mode, keymap = vim.trim(mode), vim.trim(keymap)
   mode = valid_modes[mode] and mode or "" -- only valid modes
-  local out ---@type string[]
-  local vmap, cmd = nil, string.format("verbose %smap %s", mode, keymap)
-  -- Run in the context of the originating buffer or keympas might return
-  -- "No mapping found"
-  pcall(vim.api.nvim_buf_call, opts.__CTX.bufnr, function()
-    out = utils.strsplit(vim.fn.execute(cmd), "\n")
-    _, vmap = next(vim.tbl_map(function(x) return #x > 0 and x or nil end, out))
-  end)
-  local entry
-  for i = #out, 1, -1 do
-    if out[i]:match(utils.lua_regex_escape(keymap)) then
-      entry = out[i]:match("<.-:%s+(.*)>")
+  local vmap = vim.fn.maparg(keymap, mode, false, true)
+  if vmap.callback then
+    local info = debug.getinfo(vmap.callback)
+    if info and info.source then
+      return { path = info.source:gsub("^@", ""), line = info.linedefined }
     end
   end
-  return entry and M.entry_to_file(entry, opts) or { mode = mode, key = keymap, vmap = vmap } or {}
+  -- if entry then return M.entry_to_file(entry, opts) end
+  return { mode = mode, key = keymap, vmap = vim.inspect(vmap) }
 end
 
 -- Minimal functionality so we can hijack during `vim.filetype.match`

--- a/lua/fzf-lua/path.lua
+++ b/lua/fzf-lua/path.lua
@@ -686,6 +686,10 @@ function M.keymap_to_entry(str)
       return { path = info.source:gsub("^@", ""), line = info.linedefined }
     end
   end
+  local cmd = ("verb %smap %s"):format(mode, keymap)
+  local output = vim.split(vim.api.nvim_exec2(cmd, { output = true }).output, "\n")
+  local file, lnum = (output[#output] or ""):match("Last set from (.-) line (%d+)")
+  if file and lnum then return { path = vim.fs.normalize(file), line = utils.tointeger(lnum) or 1 } end
   -- if entry then return M.entry_to_file(entry, opts) end
   return { mode = mode, key = keymap, vmap = vim.inspect(vmap) }
 end

--- a/lua/fzf-lua/previewer/builtin.lua
+++ b/lua/fzf-lua/previewer/builtin.lua
@@ -1879,6 +1879,13 @@ function Previewer.autocmds:parse_entry(entry_str)
   local event, pattern, group, code = unpack(parts, 2)
   content[#content + 1] = "autocmd " .. event .. (pattern ~= "" and (" " .. pattern) or "")
   content[#content + 1] = "\\ " .. code
+  local cmd = ("verb au %s %s %s"):format(group, event, pattern)
+  local output = vim.split(api.nvim_exec2(cmd, { output = true }).output, "\n")
+  local file, lnum = (output[#output] or ""):match("Last set from (.-) line (%d+)")
+  if file and lnum then
+    self._is_vimL_command = false
+    return { path = vim.fs.normalize(file), line = utils.tointeger(lnum) or 1 }
+  end
   if group ~= "" then
     content = vim.tbl_map(function(s) return (" "):rep(fn.shiftwidth()) .. s end, content)
     table.insert(content, 1, "augroup " .. group)

--- a/lua/fzf-lua/previewer/builtin.lua
+++ b/lua/fzf-lua/previewer/builtin.lua
@@ -1888,15 +1888,16 @@ end
 ---@field super fzf-lua.previewer.BufferOrFile,{}
 Previewer.keymaps = Previewer.buffer_or_file:extend()
 
+---@diagnostic disable-next-line: unused
 ---@param entry_str string
----@return fzf-lua.buffer_or_file.Entry
+---@return fzf-lua.keymap.Entry
 function Previewer.keymaps:parse_entry(entry_str)
-  local entry = path.keymap_to_entry(entry_str, self.opts)
+  local entry = path.keymap_to_entry(entry_str)
   if not entry.vmap then return entry end
   return {
-    filetype = "vim",
+    filetype = "lua",
     title = string.format("%s:%s", entry.mode, entry.key),
-    content = utils.strsplit(assert(entry.vmap:match("[^%s]+$")), "\n"),
+    content = utils.strsplit(entry.vmap, "\n"),
   }
 end
 

--- a/lua/fzf-lua/previewer/builtin.lua
+++ b/lua/fzf-lua/previewer/builtin.lua
@@ -1865,23 +1865,26 @@ function Previewer.autocmds:gen_winopts()
   local winopts = {
     wrap       = true,
     cursorline = false,
-    number     = false
+    number     = false,
   }
   return vim.tbl_extend("keep", winopts, self.winopts)
 end
 
 function Previewer.autocmds:parse_entry(entry_str)
-  local entry = self.super:parse_entry(entry_str)
-  if not entry.path or entry.path:sub(-6) ~= "<none>" then
-    self._is_vimL_command = false
-    return entry
+  local entry = self.super.parse_entry(self, entry_str)
+  self._is_vimL_command = entry.path and entry.path:sub(-6) == "<none>"
+  if not self._is_vimL_command then return entry end
+  local content = {}
+  local parts = vim.tbl_map(vim.trim, vim.split(entry_str, "│"))
+  local event, pattern, group, code = unpack(parts, 2)
+  content[#content + 1] = "autocmd " .. event .. (pattern ~= "" and (" " .. pattern) or "")
+  content[#content + 1] = "\\ " .. code
+  if group ~= "" then
+    content = vim.tbl_map(function(s) return (" "):rep(fn.shiftwidth()) .. s end, content)
+    table.insert(content, 1, "augroup " .. group)
+    content[#content + 1] = "augroup END"
   end
-  self._is_vimL_command = true
-  return {
-    path = entry_str:match("[^:|]+│"),
-    filetype = "vim",
-    content = vim.split(assert(entry_str:match("[^│]+$")), "\n")
-  }
+  return { cache_key = false, filetype = "vim", content = content }
 end
 
 ---@class fzf-lua.previewer.Keymaps : fzf-lua.previewer.BufferOrFile,{}

--- a/lua/fzf-lua/providers/colorschemes.lua
+++ b/lua/fzf-lua/providers/colorschemes.lua
@@ -99,8 +99,9 @@ M.highlights = function(opts)
 
   local contents = function(cb)
     local _, hl_dir = utils.ansi_from_hl("Directory", "foo")
-    local highlights =
-        utils.strsplit(vim.api.nvim_exec2("highlight", { output = true }).output, "\n")
+    local highlights = utils.with({ o = { verbose = 0 } }, function()
+      return utils.strsplit(vim.api.nvim_exec2("highlight", { output = true }).output, "\n")
+    end)
 
     local function add_entry(line, co)
       local hl = line:match("^[^%s]+")

--- a/lua/fzf-lua/types.lua
+++ b/lua/fzf-lua/types.lua
@@ -37,7 +37,7 @@ local FzfLua = require("fzf-lua")
 ---@field end_col? integer 1-based
 ---@field open_term? boolean open_term for content (cmd always open_term)
 
----@class fzf-lua.keymap.Entry
+---@class fzf-lua.keymap.Entry: fzf-lua.buffer_or_file.Entry
 ---@field vmap string?
 ---@field mode string?
 ---@field key string?


### PR DESCRIPTION
- **fix(highlights): force verbose=0 to show correct info**
- **feat(previewer): improve vimscript keymap preview**
- **feat(previewer): improve autocmds preview**
- **fix(actions): autocmd "<none>" hacks**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed path normalization and sentinel handling in file actions.
  * Improved autocmd preview rendering and fallback when source file info is unavailable.

* **Improvements**
  * Enhanced keymap lookup and previews (now shown as Lua content for readability).
  * More robust colorscheme highlight detection.
* **Documentation**
  * Expanded keymap entry type to include buffer/file fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->