### PR TITLE
fix(previewer): don't set hl on invalid col

### DIFF
--- a/lua/fzf-lua/previewer/builtin.lua
+++ b/lua/fzf-lua/previewer/builtin.lua
@@ -1329,7 +1329,7 @@ function Previewer.buffer_or_file:set_cursor_hl(entry)
   end
 
   -- Fallback to cursor hl, only if column exists
-  if not extmark and hls.cursor and entry.col then
+  if not extmark and hls.cursor and entry.col > 0 then
     local end_lnum, end_col = entry.end_line or lnum, entry.end_col or col + 1
     -- stale line/col can cause out-of-range, e.g. marks
     vim.F.nil_wrap(api.nvim_buf_set_extmark)(buf, self.ns_previewer, lnum - 1, col - 1, {


### PR DESCRIPTION
regression of 7162adfd208f5ca5a297e4e3d70f2b0c991e8614

`:FzfLua buffers` can notice the difference


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed cursor highlighting in file previews to prevent invalid highlight positions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->