### PR TITLE
fix(actions): pass nil to can_replace_buf instead of 0

### DIFF
--- a/lua/fzf-lua/actions.lua
+++ b/lua/fzf-lua/actions.lua
@@ -192,7 +192,6 @@ end
 
 ---@return boolean
 local can_replace_buf = function(buf)
-  buf = buf or vim.api.nvim_get_current_buf()
   return vim.o.hidden
       or vim.o.confirm
       or vim.o.autowriteall
@@ -239,7 +238,7 @@ M.vimcmd_entry = function(vimcmd, selected, opts, bufedit)
         end
         if layoutcmd then
           vim.cmd(layoutcmd)
-        elseif not is_curbuf(entry.bufnr, fullpath) and not can_replace_buf(0) then
+        elseif not is_curbuf(entry.bufnr, fullpath) and not can_replace_buf() then
           return utils.warn("Unable to add buffer %s", fullpath)
         end
         -- NOTE: URI entries only execute new buffers (new|vnew|tabnew)

--- a/lua/fzf-lua/utils.lua
+++ b/lua/fzf-lua/utils.lua
@@ -1116,7 +1116,7 @@ end
 ---@param only_if_last_buffer? boolean
 ---@return boolean
 function M.buffer_is_dirty(bufnr, warn, only_if_last_buffer)
-  bufnr = bufnr or vim.api.nvim_get_current_buf()
+  bufnr = (bufnr == nil or bufnr == 0) and vim.api.nvim_get_current_buf() or bufnr
   local info = bufnr and M.getbufinfo(bufnr)
   if info and info.changed ~= 0 then
     if only_if_last_buffer and 1 < #vim.fn.win_findbuf(bufnr) then


### PR DESCRIPTION
## Problem

Fixing https://github.com/ibhagwan/fzf-lua/issues/2670

When `hidden` is not set (default), selecting a file from fzf-lua pickers (e.g. `files`, `grep`) fails with:

```
Unable to add buffer <path>
```

This happens because `can_replace_buf` is called with `0` as the buffer argument at `actions.lua:242`. In Lua, `0` is truthy, so the fallback `buf = buf or nvim_get_current_buf()` inside `can_replace_buf` never triggers — the function proceeds with `buf = 0`.

This propagates down to `buffer_is_dirty` → `getbufinfo(0)`, which returns an empty table (no buffer with id 0 exists). The `changed` field on that empty table is `nil`, and since `nil ~= 0` evaluates to `true`, the function always reports the buffer as dirty, causing `can_replace_buf` to always return `false`.

## Fix

Pass `nil` instead of `0` so that `can_replace_buf` correctly falls back to `nvim_get_current_buf()` and checks the actual current buffer's dirty state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal buffer selection handling to more consistently manage buffer references across operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->