### PR TITLE
fix: pass opts.name to serpent to correct reference deserialize

### DIFF
--- a/lua/fzf-lua/libuv.lua
+++ b/lua/fzf-lua/libuv.lua
@@ -376,7 +376,7 @@ M.async_spawn = coroutinify(M.spawn)
 ---@param b64? boolean
 ---@return string, boolean -- boolean used for ./scripts/headless_fd.sh
 M.serialize = function(obj, b64)
-  local str = serpent.line(obj, { comment = false, sortkeys = false })
+  local str = serpent.line(obj, { name = "_", comment = false, sortkeys = false })
   str = b64 ~= false and base64.encode(str) or str
   return "return [==[" .. str .. "]==]", (b64 ~= false and true or false)
 end

--- a/lua/fzf-lua/previewer/builtin.lua
+++ b/lua/fzf-lua/previewer/builtin.lua
@@ -1565,13 +1565,12 @@ end
 
 ---@diagnostic disable-next-line: unused
 function Previewer.highlights:parse_entry(entry_str)
-  local serpent = require "fzf-lua.lib.serpent"
   local hl = entry_str:match("^[^%s]+")
   local hlgroup = hl
   local lines = {}
   repeat
     local hl_def = api.nvim_get_hl(0, { name = hl, link = true })
-    local block = utils.strsplit(serpent.block(hl_def, { comment = false, sortkeys = false }), "\n")
+    local block = utils.strsplit(vim.inspect(hl_def, { indent = (" "):rep(fn.shiftwidth()) }), "\n")
     block[1] = string.format("%s = %s", hl, block[1])
     vim.tbl_map(function(l) table.insert(lines, l) end, block)
     hl = hl_def.link

--- a/lua/fzf-lua/test/exec_lua.lua
+++ b/lua/fzf-lua/test/exec_lua.lua
@@ -100,12 +100,12 @@ function M.handler(bytecode, upvalues, ...)
   return ret, new_upvalues, messages
 end
 
---- @param child MiniTest.child
+--- @param exec_lua function
 --- @param lvl integer
 --- @param code function
 --- @param arg table
-function M.run(child, lvl, code, arg)
-  local rv = child.lua(
+function M.run(exec_lua, lvl, code, arg)
+  local rv = exec_lua(
     [[return { require('fzf-lua.test.exec_lua').handler(...) }]],
     { string.dump(code), get_upvalues(code), unpack(arg or {}) })
 
@@ -197,7 +197,7 @@ M.serialize = function(...)
   for _, v in ipairs(args) do
     save_upvalues(v, args)
   end
-  return require("fzf-lua.lib.serpent").block(args, { comment = false, sortkeys = false })
+  return require("fzf-lua.lib.serpent").block(args, { name = "_", comment = false, sortkeys = false })
 end
 
 return M

--- a/lua/fzf-lua/test/helpers.lua
+++ b/lua/fzf-lua/test/helpers.lua
@@ -131,7 +131,7 @@ M.new_child_neovim = function()
   local child_lua = child.lua
   child.lua = function(code, arg)
     if type(code) == "string" then return child_lua(code, arg) end
-    return require("fzf-lua.test.exec_lua").run(child, 2, code, arg)
+    return require("fzf-lua.test.exec_lua").run(child_lua, 2, code, arg)
   end
 
   -- TODO: support "function" upvalue

--- a/tests/headless_spec.lua
+++ b/tests/headless_spec.lua
@@ -38,12 +38,11 @@ local exec_term = function(c, cmd, args)
   cmd = cmd or {}
   args = args or {}
   args.term = true
-  local serpent = require "fzf-lua.lib.serpent"
-  cmd = serpent.block(cmd, { comment = false, sortkeys = false })
-  args = serpent.block(args, { comment = false, sortkeys = false })
-  local id = c.lua_get(string.format("vim.fn.jobstart(%s, %s)", cmd, args))
-  eq(tonumber(id) > 0, true)
-  c.lua(string.format("vim.fn.jobwait({%s})", tostring(id)))
+  c.lua(function()
+    local id = vim.fn.jobstart(cmd, args)
+    assert(tonumber(id) > 0, true)
+    vim.fn.jobwait({ id })
+  end)
   c.wait_until(function()
     if FzfLua.utils.__HAS_NVIM_012 then
       -- https://github.com/neovim/neovim/pull/37987
@@ -92,7 +91,7 @@ T["headless"]["file_icons"]["server"] = new_set({ parametrize = { { "devicons" }
     local fzf_lua_server = child.lua_get("vim.g.fzf_lua_server")
     eq(#fzf_lua_server > 0, true)
     local new_child = helpers.new_child_neovim()
-    new_child.start()
+    new_child.init()
     new_child.o.statusline = "fzf://"
     exec_term(new_child, {
         vim.fs.abspath("./scripts/headless_fd.sh"),

--- a/tests/libuv_spec.lua
+++ b/tests/libuv_spec.lua
@@ -198,4 +198,17 @@ describe("Testing libuv module", function()
     vim.api.nvim_win_close(splitwin, true)
     FzfLua.utils.send_ctrl_c()
   end)
+
+  it("serialize/deserialize with shared function reference", function()
+    local func = function() return "test" end
+    local obj = { fn1 = func, fn2 = func }
+    local serialized = libuv.serialize(obj, false)
+    local deserialized = libuv.deserialize(serialized, false)
+    eq(type(deserialized.fn1), "function")
+    eq(type(deserialized.fn2), "function")
+    -- also verify both return the same value as original
+    eq(deserialized.fn1, deserialized.fn2)
+    eq(deserialized.fn1(), "test")
+    eq(deserialized.fn2(), "test")
+  end)
 end)


### PR DESCRIPTION
Before, obj/func ref is sometimes deserialized as nil since:
1. serpent don't know who fn1 before the full table is returned since
   the serialized data is a compact version to ensure func/obj ref is
   consistant
2. lua table is random, so it's also possible to deserialize fn2
   correctly, but fn1=nil
```
return { fn1 = my_func, fn2 = fn1 }
```

Apply opts.name="_" for serpent, it would be like:
```
  local _ = { fn1 = my_func }
  _.fn2 = _.fn1
  return _
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved serialization and execution wiring to streamline how previews and dynamic code are prepared and run; highlight parsing now uses an inspected/stringified format for clearer output.

* **Tests**
  * Added coverage to verify serialization preserves shared function references and updated headless tests to use the revised execution approach.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->