### PR TITLE
fix(actions): don't stay in quickfix on edit actions

### DIFF
--- a/lua/fzf-lua/actions.lua
+++ b/lua/fzf-lua/actions.lua
@@ -204,6 +204,7 @@ end
 ---@param bufedit boolean?
 ---@return string?
 M.vimcmd_entry = function(vimcmd, selected, opts, bufedit)
+  vim.api.nvim_set_current_win(vim.bo.bt == "quickfix" and vim.fn.win_getid(vim.fn.winnr("#")) or 0)
   for i, sel in ipairs(selected) do
     (function()
       -- Lua 5.1 goto compatiblity hack (function wrap)


### PR DESCRIPTION
This seems regression of abacb0693d7a37de9e85e6fcb2d22d848cb75cef.

Before that commit, we actually rely on an old vim behavior:
https://github.com/neovim/neovim/blob/5b0ad4a0607498616b984c63ae1a6903cb835c66/src/nvim/window.c#L3036

When close a window, vim try to avoid to focus a quickfix window:
(even your "last accessed window" is alraedy a quickfix window...)
> If the cursor goes to the preview or the quickfix window, try
> finding another window to go to.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed window context handling when executing commands from search results, ensuring proper cursor and window focus during command execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->