### PR TITLE
fix(keymaps): resume precompile module path is possible

### DIFF
--- a/lua/fzf-lua/path.lua
+++ b/lua/fzf-lua/path.lua
@@ -683,9 +683,14 @@ function M.keymap_to_entry(str)
   mode = valid_modes[mode] and mode or "" -- only valid modes
   local vmap = vim.fn.maparg(keymap, mode, false, true)
   if vmap.callback then
-    local info = debug.getinfo(vmap.callback)
-    if info and info.source then
-      return { path = info.source:gsub("^@", ""), line = info.linedefined }
+    local info = debug.getinfo(vmap.callback, "Sl")
+    if info and info.source and info.linedefined and info.linedefined > 0 then
+      local source = info.source:gsub("^@", "")
+      -- https://github.com/neovim/neovim/blob/64d55b74d83d566975e269bed0810d9008119ddf/src/nvim/lua/executor.c#L671-L680
+      if source:match("vim/") and package.preload[source:gsub("%.lua$", ""):gsub("/", ".")] then
+        source = vim.env.VIMRUNTIME .. "/lua/" .. source .. ".lua"
+      end
+      return { path = source, line = info.linedefined }
     end
   end
   local cmd = ("verb %smap %s"):format(mode, keymap)


### PR DESCRIPTION
Fix https://github.com/ibhagwan/fzf-lua/issues/2674

https://github.com/neovim/neovim/blob/64d55b74d83d566975e269bed0810d9008119ddf/src/nvim/lua/executor.c#L671-L680


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Refined keymapping source detection with enhanced validation for more reliable results.
  * Improved resolution of Neovim's internal Lua module sources to correctly map them to their runtime file paths, providing better source file tracking for keymaps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->