### PR TITLE
fix(actions): werid issue when set verbose=1

### DIFF
--- a/lua/fzf-lua/utils.lua
+++ b/lua/fzf-lua/utils.lua
@@ -1625,8 +1625,10 @@ end
 ---@return boolean
 function M.jump_to_location(location, offset_encoding, reuse_win)
   if M.__HAS_NVIM_011 then
-    return vim.lsp.util.show_document(location, offset_encoding,
-      { reuse_win = reuse_win, focus = true })
+    return M.with({ o = { verbose = 0 } }, function()
+      return vim.lsp.util.show_document(location, offset_encoding,
+        { reuse_win = reuse_win, focus = true })
+    end)
   else
     ---@diagnostic disable-next-line: deprecated
     return vim.lsp.util.jump_to_location(location, offset_encoding, reuse_win)

--- a/tests/win_spec.lua
+++ b/tests/win_spec.lua
@@ -151,9 +151,9 @@ T["win"]["keymap"]["no error"] = new_set({
       :map(function(key, action) return { key, action } end)
       :totable()
 }, {
-  function(key, _action)
-    local builtin = child.lua_get [[FzfLua.defaults.keymap.builtin]]
+  function(key, action)
     for _, event in ipairs({ "start", "load", "result" }) do
+      if action == "toggle-preview" then helpers.SKIP_IF_WIN() end
       helpers.FzfLua.files(child, {
         __abort_key = key .. "<c-c>",
         __expect_lines = false,
@@ -184,14 +184,9 @@ T["win"]["previewer"]["split flex layout resize"] = function()
       }
     },
     previewer = function() return require("fzf-lua.test.previewer").builtin end,
-    keymap = {
-      fzf = {
-        resize = function()
-          _G._fzf_resize_called = true
-        end
-      }
-    },
+    keymap = { fzf = { resize = function() _G._fzf_resize_called = true end } },
     __after_open = function()
+      if helpers.IS_WIN() then vim.uv.sleep(250) end
       child.wait_until(function()
         return child.lua_get([[FzfLua.utils.fzf_winobj()._previewer.last_entry]]) == "foo"
       end)


### PR DESCRIPTION
Maybe there're other similar issue, to be discovered

Fix https://github.com/ibhagwan/fzf-lua/issues/2679


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable jump-to-location behavior on Neovim 0.11+ to reduce noisy output and improve navigation.
  * Improved stability on Windows by adding short delays to reduce race conditions during rapid file/preview operations.
  * Consistent previewer resize behavior on Windows to prevent flaky layout changes during interactive resizing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->