### PR TITLE
fix(actions): stopinsert before swtich buf

### DIFF
--- a/lua/fzf-lua/actions.lua
+++ b/lua/fzf-lua/actions.lua
@@ -174,6 +174,8 @@ local set_buf = function(bufnr)
     bufhidden = vim.bo.bufhidden
     vim.bo.bufhidden = "wipe"
   end
+  -- https://github.com/ibhagwan/fzf-lua/issues/2681#issuecomment-4275010045
+  vim.cmd.stopinsert()
   -- NOTE: nvim_set_current_buf will load the buffer if needed
   -- calling bufload will mess up `BufReadPost` autocmds
   -- vim.fn.bufload(bufnr)


### PR DESCRIPTION
We previous rely on "switch from terminal buffer to normal buffer" to
help us to resume to normal mode, but action set_buf to switch to a
terminal buffer again before the modechange

https://github.com/ibhagwan/fzf-lua/issues/2681#issuecomment-4275010045

Fix #2681


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where insert mode was not properly exited when switching buffers, ensuring smoother buffer transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->