### PR TITLE
fix(previewer): rg errmsg is mistakenly taken as ctags pattern

### DIFF
--- a/lua/fzf-lua/previewer/builtin.lua
+++ b/lua/fzf-lua/previewer/builtin.lua
@@ -1265,7 +1265,7 @@ function Previewer.buffer_or_file:set_cursor_hl(entry)
   if type(cached_pos) ~= "table" then cached_pos = nil end
   local lnum, col = entry.line, math.max(1, entry.col or 1)
 
-  if (not lnum or lnum == 0) and regex then
+  if (not lnum or lnum == 0) and entry.ctag and regex then
     -- pcall(fn.clearmatches, self.win.preview_winid)
     pcall(api.nvim_win_call, win, function()
       -- start searching at line 1 in case we


### PR DESCRIPTION
Problem:
When rg cmd fail with errmsg e.g. `rg: PCRE2: error`
This will be parsed and treated as an entry(with lnum=0)

`matchadd` will remain even buf changed in window, so
we have to clear the matches on each preview.

To reproduce: `FzfLua live_grep search=\] no_esc=true`
then type `<bs>`, `]`, `<bs>`, `]`... (with rg --pcre2)

Maybe this can also happened in `FzfLua global`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cursor highlighting accuracy in preview mode for entries with missing line numbers by refining condition logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->