### PR TITLE
fix: wrong mode after :term then quickly stopi->close->new picker->starti

### DIFF
--- a/lua/fzf-lua/actions.lua
+++ b/lua/fzf-lua/actions.lua
@@ -515,7 +515,9 @@ end
 M.run_builtin = function(selected)
   if not selected[1] then return end
   local method = selected[1]
-  pcall(require "fzf-lua"[method])
+  local func = vim.F.nil_wrap(require "fzf-lua"[method])
+  if not _G.fzf_lua_stopinsert_hack then return func() end
+  _G.fzf_lua_stopinsert_hack(func)
 end
 
 M.ex_run = function(selected)

--- a/lua/fzf-lua/win.lua
+++ b/lua/fzf-lua/win.lua
@@ -1166,6 +1166,25 @@ local restore_altbuf = function(buf)
   end
 end
 
+local stopinsert = function(ctx)
+  _G.fzf_lua_stopinsert_hack = nil
+  if not (ctx.mode == "nt" and api.nvim_get_mode() ~= "nt") then return end
+  vim.cmd "stopinsert"
+  local pat = "FzfLuaStopInsertHack"
+  _G.fzf_lua_stopinsert_hack = function(cb)
+    api.nvim_create_autocmd("User", { pattern = pat, once = true, callback = cb })
+  end
+  api.nvim_create_autocmd("ModeChanged", {
+    pattern = "*:nt",
+    once = true,
+    callback = function()
+      -- nvim_get_mode don't get correct mode without schedule_wrap
+      vim.schedule_wrap(api.nvim_exec_autocmds)("User", { pattern = pat, modeline = false })
+      _G.fzf_lua_stopinsert_hack = nil
+    end,
+  })
+end
+
 ---@param fzf_bufnr? integer
 ---@param hide? boolean
 function FzfWin:close(fzf_bufnr, hide)
@@ -1179,8 +1198,7 @@ function FzfWin:close(fzf_bufnr, hide)
   -- switching from a term win to another term win preserves terminal mode
   -- even if the target window was in normal terminal mode (#2054 #2419)
   local ctx = utils.__CTX() or {}
-  -- if ctx.mode and ctx.mode:match("^n") then vim.cmd "stopinsert" end
-  if ctx.mode == "nt" then vim.cmd "stopinsert" end
+  stopinsert(ctx)
   if self.fzf_winid and api.nvim_win_is_valid(self.fzf_winid) then
     -- restore the original last window
     restore_lastwin(ctx.winid, ctx.last_winid)


### PR DESCRIPTION
Fix https://github.com/ibhagwan/fzf-lua/issues/2685.

`reuse=true` should also work, but it break previewer for some reason.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Safer invocation flow for built-in actions, reducing launch failures and unexpected behavior when invoking features.
  * Improved window-close handling with deferred mode transitions to avoid terminal/insert-mode glitches and stray mode changes during close.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->