### PR TITLE
fix(previewer): only highlight helptags on label

### DIFF
--- a/lua/fzf-lua/previewer/builtin.lua
+++ b/lua/fzf-lua/previewer/builtin.lua
@@ -1428,7 +1428,7 @@ function Previewer.help_tags:parse_entry(entry_str)
         end
       end
     end
-    return tag
+    return ([[*%s*]]):format(tag)
   end)()
   return {
     ctag = ctag,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed formatting of help tag entries in previewer results to display correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->