### PR TITLE
fix(config): user setup should override profile per-picker options

### DIFF
--- a/OPTIONS.md
+++ b/OPTIONS.md
@@ -541,9 +541,9 @@ Neovim split command to use for fzf-lua interface, e.g `belowright new`.
 
 #### globals.winopts.title
 
-Type: `string`, Default: `nil`
+Type: `string|false`, Default: `nil`
 
-Controls title display in the fzf window, set by the calling picker.
+Controls title display in the fzf window, set by the calling picker. Set to `false` to hide the title and suppress picker label fallbacks.
 
 #### globals.winopts.title_flags
 

--- a/doc/fzf-lua-opts.txt
+++ b/doc/fzf-lua-opts.txt
@@ -759,9 +759,10 @@ Neovim split command to use for fzf-lua interface, e.g `belowright new`.
                                                                               
 globals.winopts.title                     *fzf-lua-opts-globals.winopts.title*
 
-Type: `string`, Default: `nil`
+Type: `string|false`, Default: `nil`
 
-Controls title display in the fzf window, set by the calling picker.
+Controls title display in the fzf window, set by the calling picker. Set to
+`false` to hide the title and suppress picker label fallbacks.
 
 
                                                                               

--- a/lua/fzf-lua/config.lua
+++ b/lua/fzf-lua/config.lua
@@ -65,6 +65,7 @@ end
 -- proxy table (with logic) for accessing the global config
 ---@type fzf-lua.Config|{}
 M.setup_opts = {}
+M.setup_call_opts = {}
 
 ---@type fzf-lua.config.Defaults
 M.globals = setmetatable({}, {
@@ -152,7 +153,6 @@ local eval = function(v, ...)
   return v
 end
 
-
 ---expand opts that were specified with a dot
 ---@param opts table
 local normalize_tbl = function(opts)
@@ -179,6 +179,7 @@ function M.normalize_opts(opts, globals, __resume_key) ---@diagnostic disable
   -- opts can also be a function that returns an opts table
   ---@type fzf-lua.config.Resolved
   opts = eval(opts) or {}
+  local picker = type(globals) == "string" and globals or nil
 
   if opts._normalized then
     return opts
@@ -379,6 +380,37 @@ function M.normalize_opts(opts, globals, __resume_key) ---@diagnostic disable
   }) do
     extend_opts(globals, k)
     extend_opts(M.globals, k)
+  end
+
+  -- Merge priority: the user's top-level setup options should beat profile
+  -- per-picker options. `M.setup_call_opts` is a deepcopy of setup opts taken
+  -- before `load_profiles` merges profile defaults in, so it reflects the
+  -- user's raw intent. Here we overlay user's top-level (and `defaults.*`)
+  -- values over keys that may have been injected per-picker by a profile
+  -- (e.g. `default-title` sets `files.winopts.title = " Files "`). Values the
+  -- user explicitly set at call-time or per-picker setup remain pinned.
+  if type(picker) == "string" and type(M.setup_call_opts) == "table" then
+    for _, k in ipairs({ "winopts", "fzf_opts", "fzf_colors", "fzf_tmux_opts", "hls" }) do
+      local user_picker = utils.map_get(M.setup_call_opts, picker .. "." .. k)
+      local call_v = opts.__call_opts and opts.__call_opts[k]
+      for _, path in ipairs({ "defaults." .. k, k }) do
+        local src = utils.map_get(M.setup_call_opts, path)
+        if vim.is_callable(src) then src = src(opts) end
+        if type(src) == "table" and type(opts[k]) == "table" then
+          for sk, sv in pairs(src) do
+            local pinned = (type(user_picker) == "table" and user_picker[sk] ~= nil)
+                or (type(call_v) == "table" and call_v[sk] ~= nil)
+            if not pinned then
+              if type(sv) == "table" and type(opts[k][sk]) == "table" then
+                opts[k][sk] = vim.tbl_deep_extend("force", opts[k][sk], sv)
+              else
+                opts[k][sk] = sv
+              end
+            end
+          end
+        end
+      end
+    end
   end
 
   -- backward compat: no-value flags should be set to `true`, in the past these

--- a/lua/fzf-lua/defaults.lua
+++ b/lua/fzf-lua/defaults.lua
@@ -57,8 +57,8 @@ end
 ---@field col? number
 ---Border of the fzf-lua float, possible values are `none|single|double|rounded|thicc|thiccc|thicccc` or a custom border character array passed as is to `nvim_open_win`.
 ---@field border? string|table
----Controls title display in the fzf window, set by the calling picker.
----@field title? string
+---Controls title display in the fzf window, set by the calling picker. Set to `false` to hide the title and suppress picker label fallbacks.
+---@field title? string|false
 ---Controls title display in the fzf window, possible values are `left|right|center`.
 ---@field title_pos? "center"|"left"|"right"
 ---Set to `false` to disable fzf window title flags (hidden, ignore, etc).

--- a/lua/fzf-lua/init.lua
+++ b/lua/fzf-lua/init.lua
@@ -181,6 +181,7 @@ M.setup_highlights()
 ---@param do_not_reset_defaults? boolean
 function M.setup(opts, do_not_reset_defaults)
   opts = type(opts) == "table" and opts or {}
+  local call_opts = vim.deepcopy(opts)
   -- Defaults to picker info in win title if neovim version >= 0.9, prompt otherwise
   opts[1] = opts[1] == nil and "default" or opts[1]
   if opts[1] then
@@ -191,6 +192,7 @@ function M.setup(opts, do_not_reset_defaults)
   if do_not_reset_defaults then
     -- no defaults reset requested, merge with previous setup options
     opts = vim.tbl_deep_extend("keep", opts, config.setup_opts or {})
+    call_opts = vim.tbl_deep_extend("keep", call_opts, config.setup_call_opts or {})
   end
   -- backward compat `global_{git|gile|color}_icons`
   -- converts `global_file_icons` to `defaults.file_icons`, etc
@@ -215,6 +217,7 @@ function M.setup(opts, do_not_reset_defaults)
   -- set custom &nbsp if caller requested
   if type(opts.nbsp) == "string" then utils.nbsp = opts.nbsp end
   -- store the setup options
+  config.setup_call_opts = call_opts
   config.setup_opts = opts
   -- setup highlights
   M.setup_highlights()

--- a/lua/fzf-lua/win.lua
+++ b/lua/fzf-lua/win.lua
@@ -1305,7 +1305,8 @@ end
 ---@return string|[string, string?][]|nil
 local function picker_title(title)
   if title == false then return nil end
-  return title or (" %s "):format(tostring(FzfLua.get_info().cmd))
+  local cmd = FzfLua.get_info().cmd
+  return title or (cmd and (" %s "):format(tostring(cmd))) or nil
 end
 
 function FzfWin:update_statusline()

--- a/lua/fzf-lua/win.lua
+++ b/lua/fzf-lua/win.lua
@@ -1301,6 +1301,13 @@ function FzfWin:update_preview_scrollbar()
     self.winopts)
 end
 
+---@param title string|[string, string?][]|false|nil
+---@return string|[string, string?][]|nil
+local function picker_title(title)
+  if title == false then return nil end
+  return title or (" %s "):format(tostring(FzfLua.get_info().cmd))
+end
+
 function FzfWin:update_statusline()
   if not self.winopts.split then
     -- NOTE: 0.12 added float win local statusline, we nullify the statusline here and
@@ -1311,12 +1318,15 @@ function FzfWin:update_statusline()
     end
     return
   end
-  local titlestr = self.winopts.title or (" %s "):format(tostring(FzfLua.get_info().cmd))
-  local title = make_title(titlestr, self.hls.title)
-  local parts = vim.tbl_map(function(p) return ("%%#%s#%s%%#fzf3#"):format(p[2], p[1]) end, title)
-  local picker = table.remove(parts, 1) or ""
-  vim.wo[self.fzf_winid].statusline = "%#fzf1# > %#fzf2#fzf-lua%#fzf3#"
-      .. string.format(" %s %s", picker, table.concat(parts, ""))
+  local titlestr = picker_title(self.winopts.title)
+  local statusline = "%#fzf1# > %#fzf2#fzf-lua%#fzf3#"
+  if titlestr then
+    local title = make_title(titlestr, self.hls.title)
+    local parts = vim.tbl_map(function(p) return ("%%#%s#%s%%#fzf3#"):format(p[2], p[1]) end, title)
+    local picker = table.remove(parts, 1) or ""
+    statusline = statusline .. string.format(" %s %s", picker, table.concat(parts, ""))
+  end
+  vim.wo[self.fzf_winid].statusline = statusline
 end
 
 function FzfWin:update_fzf_border_label()
@@ -1326,7 +1336,8 @@ function FzfWin:update_fzf_border_label()
   then
     return
   end
-  local titlestr = self.winopts.title or (" %s "):format(tostring(FzfLua.get_info().cmd))
+  local titlestr = picker_title(self.winopts.title)
+  if not titlestr then return end
   local title = make_title(titlestr, self.hls.title)
   local parts = vim.tbl_map(function(p) return (utils.ansi_from_hl(p[2], p[1])) end, title)
   self._o.fzf_opts["--border-label"] = table.concat(parts, " ")

--- a/tests/init_spec.lua
+++ b/tests/init_spec.lua
@@ -10,6 +10,21 @@ local T = helpers.new_set_with_child(child, nil, { winopts = { col = 0, row = 1 
 
 T["setup"] = new_set()
 
+---@param picker string
+---@return any
+local picker_title = function(picker)
+  return child.lua(function(name)
+    return FzfLua.config.normalize_opts({}, name).winopts.title
+  end, { picker })
+end
+
+---@param expected table<string, any>
+local expect_picker_titles = function(expected)
+  for picker, title in pairs(expected) do
+    eq(picker_title(picker), title)
+  end
+end
+
 T["setup"]["setup global vars"] = function()
   -- Global vars
   eq(child.lua_get([[type(_G.FzfLua)]]), "table")
@@ -29,6 +44,55 @@ T["setup"]["setup global vars"] = function()
 
   -- "autoload/fzf_lua.vim"
   eq(child.fn.exists("*fzf_lua#getbufinfo") ~= 0, true)
+end
+
+T["setup"]["global winopts.title overrides profile picker titles"] = new_set({
+  parametrize = {
+    {
+      { winopts = { title = false } },
+      { files = false, grep = false, ["git.files"] = false },
+    },
+    {
+      { defaults = { winopts = { title = false } } },
+      { files = false, grep = false, ["git.files"] = false },
+    },
+    {
+      { winopts = { title = " Global " } },
+      { files = " Global ", grep = " Global ", ["git.files"] = " Global " },
+    },
+    {
+      { defaults = { winopts = { title = " Global " } } },
+      { files = " Global ", grep = " Global ", ["git.files"] = " Global " },
+    },
+  },
+}, {
+  function(setup_opts, expected)
+    child.setup(setup_opts)
+    expect_picker_titles(expected)
+  end,
+})
+
+T["setup"]["provider title still overrides global winopts.title"] = function()
+  child.setup({
+    winopts = { title = false },
+    grep = { winopts = { title = " Custom " } },
+  })
+
+  expect_picker_titles({
+    files = false,
+    grep = " Custom ",
+  })
+end
+
+T["setup"]["global winopts.title survives setup(..., true)"] = function()
+  child.setup({ winopts = { title = false } })
+  child.lua([[FzfLua.setup({ hls = { normal = "Normal" } }, true)]])
+
+  expect_picker_titles({
+    files = false,
+    grep = false,
+    ["git.files"] = false,
+  })
 end
 
 T["setup"]["setup highlight groups"] = function()

--- a/tests/win_spec.lua
+++ b/tests/win_spec.lua
@@ -21,8 +21,23 @@ local sleep = function(ms) helpers.sleep(ms, child) end
 local T = helpers.new_set_with_child(child)
 
 T["win"] = new_set()
+T["win"]["title"] = new_set()
 
 T["win"]["hide"] = new_set()
+
+T["win"]["title"]["global title=false hides split title fallbacks"] = function()
+  reload({ winopts = { title = false } })
+  exec_lua([[FzfLua.files { query = "README.md", winopts = { split = "enew" } }]])
+  child.wait_until(function()
+    return child.lua_get([[_G._fzf_load_called]]) == true
+  end)
+  eq(child.lua_get([[string.lower(vim.wo[FzfLua.utils.fzf_winobj().fzf_winid].statusline):match("files")]]), vim.NIL)
+  eq(child.lua_get([=[FzfLua.utils.fzf_winobj()._o.fzf_opts["--border-label"]]=]), vim.NIL)
+  child.type_keys("<c-c>")
+  child.wait_until(function()
+    return child.lua_get([[_G._fzf_lua_on_create]]) == vim.NIL
+  end)
+end
 
 T["win"]["hide"]["ensure gc called after win hidden (#1782)"] = function()
   exec_lua([[_G._fzf_lua_gc_called = nil]])


### PR DESCRIPTION
allows forcing empty titles, which previously was not honored with `winopts.title = false`

example:

<img width="975" height="1199" alt="image" src="https://github.com/user-attachments/assets/110a7575-e7ea-4c72-9379-7adc1fc6e0f2" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `winopts.title` can be set to false to hide the fzf window title and suppress picker label fallbacks (statusline and border-labels are omitted).

* **Documentation**
  * Docs updated to show `winopts.title: string|false` and explain the false behavior.

* **Tests**
  * New tests cover title=false behavior, precedence, and persistence across setups and splits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->