### PR TITLE
feat(git): consistent highlighting in branches/worktrees pickers

### DIFF
--- a/lua/fzf-lua/providers/git.lua
+++ b/lua/fzf-lua/providers/git.lua
@@ -267,12 +267,118 @@ M.blame = function(opts)
   return git_cmd(opts)
 end
 
+---@param line string
+---@return string
+local function highlight_branch_line(line)
+  local u = FzfLua.utils
+  local ansi = u.ansi_codes
+  line = u.strip_ansi_coloring(line)
+  local leader = line:sub(1, 2)
+  local rest = line:sub(3)
+
+  local detached_inner = rest:match("^%(([^)]+)%)")
+  if detached_inner and
+      (detached_inner:match("^HEAD detached") or detached_inner:match("^no branch")) then
+    local head = ansi.grey("(") .. ansi.green(detached_inner) .. ansi.grey(")")
+    local after = rest:sub(#detached_inner + 3)
+    local ws, sha, subject_ws, subject = after:match("^(%s+)(%x%x%x%x%x%x%x+)(%s+)(.*)$")
+    if ws and sha then
+      return leader .. head .. ws .. ansi.yellow(sha) .. subject_ws .. subject
+    end
+    return leader .. head .. after
+  end
+
+  local branch_name, ws_after_name, after = rest:match("^(%S+)(%s+)(.*)$")
+  if not branch_name then return line end
+
+  local colored_branch
+  if leader:sub(1, 1) == "*" then
+    colored_branch = ansi.green(branch_name)
+  elseif leader:sub(1, 1) == "+" then
+    colored_branch = ansi.cyan(branch_name)
+  elseif branch_name:match("^remotes/") then
+    colored_branch = ansi.red(branch_name)
+  else
+    colored_branch = branch_name
+  end
+
+  if after:match("^%->") then
+    return leader .. colored_branch .. ws_after_name .. after
+  end
+
+  local sha, body_ws, body = after:match("^(%x%x%x%x%x%x%x+)(%s+)(.*)$")
+  if not sha then
+    return leader .. colored_branch .. ws_after_name .. after
+  end
+
+  local function color_tracking(content)
+    local ref, suffix = content:match("^([^:]+)(:.*)$")
+    if ref and suffix then
+      return ansi.grey("[") .. ansi.blue(ref) .. ansi.grey(suffix) .. ansi.grey("]")
+    end
+    return ansi.grey("[") .. ansi.blue(content) .. ansi.grey("]")
+  end
+
+  if leader:sub(1, 1) == "+" then
+    local wt_paren, remainder = body:match("^(%b())(.*)$")
+    if wt_paren then
+      local colored_wt = ansi.grey("(") .. ansi.cyan(wt_paren:sub(2, -2)) .. ansi.grey(")")
+      remainder = remainder:gsub("^(%s*)(%[)([^%]]+)(%])", function(ws, _, content, _)
+        return ws .. color_tracking(content)
+      end)
+      body = colored_wt .. remainder
+    end
+  else
+    body = body:gsub("^(%[)([^%]]+)(%])", function(_, content, _)
+      return color_tracking(content)
+    end)
+  end
+
+  return leader .. colored_branch .. ws_after_name .. ansi.yellow(sha) .. body_ws .. body
+end
+
+---@param line string
+---@return string
+local function highlight_worktree_line(line)
+  local ansi = FzfLua.utils.ansi_codes
+  local path_s, padding, rest = line:match("^(%S+)(%s+)(.*)$")
+  if not path_s then return line end
+
+  local sha, sha_ws, body = rest:match("^(%x%x%x%x%x%x%x+)(%s+)(.*)$")
+  if not sha then
+    body = rest
+  end
+
+  body = body:gsub("^(%[)([^%]]+)(%])", function(lb, name, rb)
+    return ansi.grey(lb) .. ansi.green(name) .. ansi.grey(rb)
+  end)
+  body = body:gsub("^(%()(detached HEAD)(%))", function(lp, text, rp)
+    return ansi.grey(lp) .. ansi.green(text) .. ansi.grey(rp)
+  end)
+  body = body:gsub("^(%()(bare)(%))", function(lp, text, rp)
+    return ansi.grey(lp) .. ansi.grey(text) .. ansi.grey(rp)
+  end)
+  body = body:gsub("(%s)(locked)(%s*)$", function(s1, w, s2)
+    return s1 .. ansi.magenta(w) .. s2
+  end)
+  body = body:gsub("(%s)(prunable)(%s*)$", function(s1, w, s2)
+    return s1 .. ansi.red(w) .. s2
+  end)
+
+  local out = ansi.blue(path_s) .. padding
+  if sha then
+    out = out .. ansi.yellow(sha) .. sha_ws
+  end
+  return out .. body
+end
+
 ---@param opts fzf-lua.config.GitBranches|{}?
 ---@return thread?, string?, table?
 M.branches = function(opts)
   ---@type fzf-lua.config.GitBranches
   opts = config.normalize_opts(opts, "git.branches")
   if not opts then return end
+  if opts.fn_transform == nil then opts.fn_transform = highlight_branch_line end
   if opts.preview then
     local preview = path.git_cwd(opts.preview, opts)
     opts.preview = shell.stringify_cmd(function(items)
@@ -301,6 +407,7 @@ M.worktrees = function(opts)
   ---@type fzf-lua.config.GitWorktrees
   opts = config.normalize_opts(opts, "git.worktrees")
   if not opts then return end
+  if opts.fn_transform == nil then opts.fn_transform = highlight_worktree_line end
   if opts.preview then
     local preview_cmd = opts.preview
     opts.preview = shell.stringify_cmd(function(items)


### PR DESCRIPTION
closes #2695

Adds an `fn_transform` to `git_branches` and `git_worktrees` so delimiters render grey and content picks up a semantic color, yellowing SHAs to match `commits`/`bcommits`/`reflog`/`tags`/`stash`. `git_blame` is intentionally skipped since `--color-lines` already encodes same-commit grouping via `color.blame.repeatedLines`.

## worktrees

highlight diff:

| token               | before | after                              |
| ------------------- | ------ | ---------------------------------- |
| path                | plain  | blue                               |
| SHA                 | plain  | yellow                             |
| `[branch]`          | plain  | grey `[` · green branch · grey `]` |
| `(detached HEAD)`   | plain  | grey `(` · green text · grey `)`   |
| `(bare)`            | plain  | grey `(` · grey text · grey `)`    |
| trailing `locked`   | plain  | magenta                            |
| trailing `prunable` | plain  | red                                |

before/after (my config. vs. vanilla patch)

<img width="1920" height="599" alt="image" src="https://github.com/user-attachments/assets/e40f25cb-9f43-46e5-856d-2ac9d7674bb8" />

## branches

highlight diff:

| token                                  | before             | after                                               |
| -------------------------------------- | ------------------ | --------------------------------------------------- |
| branch: current `*`                    | green              | green (unchanged)                                   |
| branch: used in another wt `+`         | cyan               | cyan (unchanged)                                    |
| branch: remote                         | red                | red (unchanged)                                     |
| SHA                                    | plain              | yellow                                              |
| `[origin/ref]`                         | blue refname       | grey `[` · blue refname · grey `]`                  |
| `[origin/ref: ahead/behind/gone]`      | blue refname       | grey `[` · blue refname · grey `:status` · grey `]` |
| `(HEAD detached at X)`                 | green (incl. `()`) | grey `(` · green text · grey `)`                    |
| `(no branch)` / `(no branch, bisect…)` | green (incl. `()`) | grey `(` · green text · grey `)`                    |
| `(/path/to/worktree)` annotation       | cyan inside        | grey `(` · cyan path · grey `)`                     |
| `remotes/.../HEAD -> origin/X`         | unchanged          | unchanged                                           |

before/after (my config. vs. vanilla patch)

<img width="1919" height="601" alt="image" src="https://github.com/user-attachments/assets/c5f6c3ba-b244-4e26-9708-3208ed43f48d" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic syntax highlighting now applied to git branch lists, with color-coded branch names, commit identifiers, tracking status, and reference indicators for improved readability.
  * Automatic syntax highlighting now applied to git worktree lists, with color-coded worktree names, commit references, and status details for enhanced visual clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->