### PR TITLE
fix(previewer): allow diff/git cmd syntax

### DIFF
--- a/lua/fzf-lua/previewer/builtin.lua
+++ b/lua/fzf-lua/previewer/builtin.lua
@@ -1184,6 +1184,11 @@ function Previewer.buffer_or_file:do_syntax(entry)
     if not ft then return end
     did_filetype_detect = true
   end
+  if ft == "diff" or ft == "git" then
+    api.nvim_buf_call(bufnr, function()
+      api.nvim_exec_autocmds("FileType", { pattern = ft, modeline = false })
+    end)
+  end
 
   -- Use buf local var as setting ft might have unintended consequences
   -- used in `update_render_markdown`, `attach_snacks_image`
@@ -1366,24 +1371,22 @@ function Previewer.buffer_or_file:preview_buf_post(entry, min_winopts)
   -- set cursor highlights for line|col or tag
   self:set_cursor_hl(entry)
 
-  if not utils.is_term_buffer(self.preview_bufnr) then
-    local syntax = function()
-      if self.syntax then
-        self:do_syntax(entry)
-        self:update_render_markdown()
-        self:update_ts_context()
-        self:attach_snacks_image_inline()
-      end
-      -- for attach_snacks_image_{inline,buf}
-      -- https://github.com/folke/snacks.nvim/pull/1615
-      if self.preview_bufnr and vim.b[self.preview_bufnr].snacks_image_attached then
-        utils.wo[self.win.preview_winid][0].winblend = 0
-      end
+  local syntax = function()
+    if self.syntax then
+      self:do_syntax(entry)
+      self:update_render_markdown()
+      self:update_ts_context()
+      self:attach_snacks_image_inline()
     end
-
-    -- syntax highlighting
-    self:debounce("syntax", self.syntax_delay, syntax)
+    -- for attach_snacks_image_{inline,buf}
+    -- https://github.com/folke/snacks.nvim/pull/1615
+    if self.preview_bufnr and vim.b[self.preview_bufnr].snacks_image_attached then
+      utils.wo[self.win.preview_winid][0].winblend = 0
+    end
   end
+
+  -- syntax highlighting
+  self:debounce("syntax", self.syntax_delay, syntax)
 
   self:update_title(entry)
 


### PR DESCRIPTION
Related https://github.com/ibhagwan/fzf-lua/issues/2694#issue-4310270827


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed syntax highlighting and treesitter context attachment in file previews—previously these were skipped for terminal buffers.
* Improved handling of diff and git file types to ensure proper syntax highlighting and file type-specific features are correctly applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->