### PR TITLE
fix(actions): copy edits before preview

### DIFF
--- a/lua/fzf-lua/previewer/codeaction.lua
+++ b/lua/fzf-lua/previewer/codeaction.lua
@@ -31,7 +31,8 @@ local function diff_text_edits(text_edits, bufnr, offset_encoding, diff_opts)
   local orig_lines = get_lines(bufnr)
   local tmpbuf = vim.api.nvim_create_buf(false, true)
   vim.api.nvim_buf_set_lines(tmpbuf, 0, -1, false, orig_lines)
-  vim.lsp.util.apply_text_edits(text_edits, tmpbuf, offset_encoding)
+  -- deepcopy is necessary due to the apply_text_edits's logic to change the passed edits.
+  vim.lsp.util.apply_text_edits(utils.deepcopy(text_edits), tmpbuf, offset_encoding)
   local new_lines = get_lines(tmpbuf)
   vim.api.nvim_buf_delete(tmpbuf, { force = true })
   ---@diagnostic disable-next-line: deprecated

--- a/tests/codeaction_spec.lua
+++ b/tests/codeaction_spec.lua
@@ -1,0 +1,78 @@
+---@diagnostic disable: unused-local
+local MiniTest = require("mini.test")
+local helpers = require("fzf-lua.test.helpers")
+local eq = helpers.expect.equality
+local new_set = MiniTest.new_set
+
+local T = new_set()
+
+T["codeaction"] = new_set()
+
+T["codeaction"]["preview does not mutate same-position text edits"] = function()
+  local utils = require("fzf-lua.utils")
+  local codeaction = require("fzf-lua.previewer.codeaction")
+  local original_lsp_get_clients = utils.lsp_get_clients
+  local bufnr = vim.api.nvim_create_buf(true, true)
+  local text_edits = {
+    {
+      range = {
+        start = { line = 0, character = 7 },
+        ["end"] = { line = 0, character = 24 },
+      },
+      newText = "strings.CutSuffix",
+    },
+    {
+      range = {
+        start = { line = 0, character = 7 },
+        ["end"] = { line = 0, character = 24 },
+      },
+      newText = "strings.TrimSuffix",
+    },
+  }
+  local before = vim.deepcopy(text_edits)
+
+  vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, {
+    "if strings.HasSuffix(name, suffix) {",
+    "\treturn strings.TrimSuffix(name, suffix)",
+    "}",
+  })
+
+  ---duplication is caused by the stubbign logic.
+  ---@diagnostic disable-next-line: duplicate-set-field
+  utils.lsp_get_clients = function(opts)
+    if opts.id == 1 then
+      return {
+        {
+          offset_encoding = "utf-16",
+          dynamic_capabilities = { get = function() end },
+          supports_method = function() return false end,
+          server_capabilities = {},
+        },
+      }
+    end
+    return original_lsp_get_clients(opts)
+  end
+
+  local ok, err = pcall(function()
+    local uri = vim.uri_from_bufnr(bufnr)
+    codeaction.builtin.preview_action_tuple({
+      opts = {
+        _items = {
+          {
+            ctx = { client_id = 1, bufnr = bufnr },
+            action = { edit = { changes = { [uri] = text_edits } } },
+          },
+        },
+      },
+      diff_opts = { ctxlen = 3 },
+      _resolved_actions = { false },
+    }, 1)
+  end)
+  utils.lsp_get_clients = original_lsp_get_clients
+  vim.api.nvim_buf_delete(bufnr, { force = true })
+
+  if not ok then error(err) end
+  eq(text_edits, before)
+end
+
+return T


### PR DESCRIPTION
Closes: https://github.com/ibhagwan/fzf-lua/issues/2701

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Code action previews no longer mutate shared edit data, preserving the original edits when previewing multiple actions.

* **Tests**
  * Added tests that validate preview behavior to prevent regressions related to edit data mutation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->