### PR TITLE
feat(oldfiles): customize shada file

### DIFF
--- a/lua/fzf-lua/defaults.lua
+++ b/lua/fzf-lua/defaults.lua
@@ -1010,6 +1010,8 @@ M.defaults.args = {
 
 ---File history (output of `:oldfiles`).
 ---@class fzf-lua.config.Oldfiles: fzf-lua.config.Base
+---Optional shada file to read, see `:help shada`
+---@field shada_file? string
 ---Only include files that still exist on disk.
 ---@field stat_file? boolean
 ---Include files opened during the current session.

--- a/lua/fzf-lua/providers/oldfiles.lua
+++ b/lua/fzf-lua/providers/oldfiles.lua
@@ -71,6 +71,16 @@ M.oldfiles = function(opts, globals)
       local curr_file = vim.api.nvim_buf_get_name(curr_buf)
       local sess_map = {} -- dedup files from current buffers
 
+      -- read the optional shada file
+      if opts.shada_file then
+        local file = vim.fs.normalize(opts.shada_file)
+        if vim.uv.fs_stat(file) then
+          vim.cmd("rshada! " .. vim.fn.fnameescape(file))
+        else
+          utils.warn("shada file '%s' does not exist, ignoring.", opts.shada_file)
+        end
+      end
+
       local function add_entry(x, co, force)
         x = make_entry.file(x,
           force and vim.tbl_deep_extend("force", {}, opts, { cwd_only = false }) or opts)


### PR DESCRIPTION
Supply custom shada file to read using `:rshada!` (opts.shada), enables oldfiles from the cli.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option to load a specific shada file to populate recent files; the file is validated and a warning is shown if missing.

* **Documentation**
  * Public configuration now documents an optional shada_file setting for the recent-files feature.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->