### PR TITLE
fix(previewer): set i keymap only for normal mode

### DIFF
--- a/lua/fzf-lua/previewer/builtin.lua
+++ b/lua/fzf-lua/previewer/builtin.lua
@@ -198,7 +198,7 @@ function Previewer.base:set_preview_buf(newbuf, min_winopts, no_wipe)
   utils.win_set_buf_noautocmd(self.win.preview_winid, newbuf)
   -- to make gc work, don't reference `win._previewer` in a callback
   local winid = self.win.fzf_winid
-  vim.keymap.set("", "i", function()
+  vim.keymap.set("n", "i", function()
     api.nvim_set_current_win(winid)
     vim.cmd("startinsert")
   end, { buffer = newbuf })


### PR DESCRIPTION
Allows for keymaps like `yip` to work. Previously it would focus the prompt terminal window


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed keymap functionality in the preview window to work correctly in normal mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->