### PR TITLE
ci: interrupt on ctrl-c

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,5 +1,10 @@
-on: [push, pull_request]
 name: Lint
+
+on:
+  push:
+    branches: [main, dev]
+  pull_request:
+    branches: "*"
 
 jobs:
   lint:

--- a/lua/fzf-lua/defaults.lua
+++ b/lua/fzf-lua/defaults.lua
@@ -1729,7 +1729,7 @@ M.defaults.lsp.finder = {
 ---Callback to execute after applying a code action.
 ---@field post_action_cb function
 ---Code action context passed to the LSP server.
----@field context lsp.CodeActionContext
+---@field context vim.lsp.buf.code_action.context
 ---Filter function to exclude certain code actions.
 ---@field filter fun(x: lsp.CodeAction|lsp.Command):boolean
 ---@field _ui_select? { kind: string }

--- a/lua/fzf-lua/path.lua
+++ b/lua/fzf-lua/path.lua
@@ -454,6 +454,12 @@ function M.is_uri(str)
   return str:match("^[%a%-]+://") ~= nil
 end
 
+-- path seps behavior https://github.com/neovim/neovim/pull/37729
+-- luv use `\`, `nvim_buf_get_name` use `/` (on windows, by default)
+local buf_get_name = utils.__IS_WINDOWS and
+    function(buf) return (vim.api.nvim_buf_get_name(buf):gsub([[/]], [[\]])) end
+    or vim.api.nvim_buf_get_name
+
 ---@param entry string
 ---@param opts fzf-lua.Config|{}?
 ---@param force_uri boolean?
@@ -566,7 +572,7 @@ function M.entry_to_file(entry, opts, force_uri)
     end
   elseif file and #file > 0 then -- get bufnr from give path
     local buf = vim.fn.bufnr(file)
-    if buf ~= -1 and vim.api.nvim_buf_get_name(buf) == (uv.fs_realpath(file) or file) then
+    if buf ~= -1 and buf_get_name(buf) == (uv.fs_realpath(file) or file) then
       bufnr = buf
       bufname = file
     end

--- a/scripts/make_cli.lua
+++ b/scripts/make_cli.lua
@@ -33,4 +33,8 @@ if filter then
   end
 end
 
+-- https://github.com/neovim/neovim/pull/36557
+local sig = assert(vim.uv.new_signal())
+sig:start(vim.uv.constants.SIGINT, function() MiniTest.stop() end)
+
 MiniTest.run({ collect = { find_files = find_files, filter_cases = filter_cases } })

--- a/tests/path_spec.lua
+++ b/tests/path_spec.lua
@@ -393,14 +393,14 @@ describe("Testing path module", function()
         col = 2,
       })
 
-      utils.__IS_WINDOWS = true
-      eq(path.entry_to_file("C:\\Users\\foo:bar:12:3"), {
-        col = 3,
-        line = 12,
-        path = "C:\\Users\\foo:bar",
-        stripped = "C:\\Users\\foo:bar:12:3"
-      })
-      utils.__IS_WINDOWS = false
+      if utils.__IS_WINDOWS then
+        eq(path.entry_to_file("C:\\Users\\foo:bar:12:3"), {
+          col = 3,
+          line = 12,
+          path = "C:\\Users\\foo:bar",
+          stripped = "C:\\Users\\foo:bar:12:3"
+        })
+      end
     end)
 
     it("tilde expansion", function()


### PR DESCRIPTION
It used to work before https://github.com/neovim/neovim/pull/36557


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Test runner now handles interrupt (Ctrl+C) to stop running tests gracefully.
* **Bug Fixes**
  * File-entry lookup made more permissive when matching existing buffers (may change which buffer is chosen); some debug output may appear.
* **Documentation**
  * Clarified LSP code-action type annotation to match Neovim's LSP context.
* **Chores**
  * Lint and CI workflow triggers refined; CI test matrix and test selection narrowed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->