### PR TITLE
feat: port fzf's config parser in lua

### DIFF
--- a/lua/fzf-lua/config.lua
+++ b/lua/fzf-lua/config.lua
@@ -407,6 +407,10 @@ function M.normalize_opts(opts, globals, __resume_key) ---@diagnostic disable
     end
   end
 
+  if opts.fzf_opts["--history"] == nil then
+    opts.fzf_opts["--history"] = require("fzf-lua.config.parse").get()["--history"]
+  end
+
   -- Merge arrays from globals|defaults, can't use 'vim.tbl_xxx'
   -- for these as they only work for maps, ie. '{ key = value }'
   for _, k in ipairs({ "file_ignore_patterns" }) do

--- a/lua/fzf-lua/config/parse.lua
+++ b/lua/fzf-lua/config/parse.lua
@@ -1,0 +1,182 @@
+-- lua version of shellwords https://github.com/junegunn/fzf/blob/f7835825617bd38eb50349bd89fa2f39569c3068/src/options.go#L3854-L3857
+local M = {}
+
+local function isSpace(c)
+  return c == " " or c == "\t" or c == "\r" or c == "\n"
+end
+
+local argNo = 0
+local argSingle = 1
+local argQuoted = 2
+
+--- Parses a shell string into arguments similar to Go's shellwords.
+--- @param line string
+--- @return string[]? args
+--- @return string? err
+M.shellparse = function(line)
+  if not line or type(line) ~= "string" then
+    return {}
+  end
+
+  local args = {}
+  local buf = ""
+  local escaped, doubleQuoted, singleQuoted, backQuote, dollarQuote, comment =
+      false, false, false, false, false, false
+
+  local got = argNo
+
+  local i = 1
+  while i <= #line do
+    local r = line:sub(i, i)
+    local continue = false
+
+    if comment then
+      if r == "\n" then
+        comment = false
+      end
+      continue = true
+    end
+
+    if not continue and escaped then
+      if r == "t" then r = "\t" end
+      if r == "n" then r = "\n" end
+      buf = buf .. r
+      escaped = false
+      got = argSingle
+      continue = true
+    end
+
+    if not continue and r == "\\" then
+      if singleQuoted then
+        buf = buf .. r
+      else
+        escaped = true
+      end
+      continue = true
+    end
+
+    if not continue and isSpace(r) then
+      if singleQuoted or doubleQuoted or backQuote or dollarQuote then
+        buf = buf .. r
+      elseif got ~= argNo then
+        args[#args + 1] = buf
+        buf = ""
+        got = argNo
+      end
+      continue = true
+    end
+
+    if not continue then
+      if r == "`" then
+        if not singleQuoted and not doubleQuoted and not dollarQuote then
+          backQuote = not backQuote
+        end
+      elseif r == ")" then
+        if not singleQuoted and not doubleQuoted and not backQuote then
+          dollarQuote = not dollarQuote
+        end
+      elseif r == "(" then
+        if not singleQuoted and not doubleQuoted and not backQuote then
+          if not dollarQuote and buf:sub(-1) == "$" then
+            dollarQuote = true
+            buf = buf .. "("
+            continue = true
+          else
+            return nil, "invalid command line string"
+          end
+        end
+      elseif r == '"' then
+        if not singleQuoted and not dollarQuote then
+          if doubleQuoted then got = argQuoted end
+          doubleQuoted = not doubleQuoted
+          continue = true
+        end
+      elseif r == "'" then
+        if not doubleQuoted and not dollarQuote then
+          if singleQuoted then got = argQuoted end
+          singleQuoted = not singleQuoted
+          continue = true
+        end
+      elseif r == ";" or r == "&" or r == "|" or r == "<" or r == ">" then
+        if not (escaped or singleQuoted or doubleQuoted or backQuote or dollarQuote) then
+          if r == ">" and #buf > 0 then
+            local c = buf:sub(1, 1)
+            if c >= "0" and c <= "9" then
+              got = argNo
+            end
+          end
+          break
+        end
+      elseif r == "#" then
+        -- ParseComment is true
+        if #buf == 0 and not (escaped or singleQuoted or doubleQuoted) then
+          comment = true
+          continue = true
+        end
+      end
+    end
+
+    if not continue then
+      got = argSingle
+      buf = buf .. r
+    end
+
+    i = i + 1
+  end
+
+  if got ~= argNo then
+    args[#args + 1] = buf
+  end
+
+  if escaped or singleQuoted or doubleQuoted or backQuote or dollarQuote then
+    return nil, "invalid command line string"
+  end
+
+  return args
+end
+
+---@alias fzf-lua.FzfOpts { [string]: string }
+---@param line string
+---@return fzf-lua.FzfOpts
+M.parse = function(line)
+  local words = M.shellparse(line)
+  if not words then return {} end
+  local args = {}
+  -- https://github.com/junegunn/fzf/blob/f7835825617bd38eb50349bd89fa2f39569c3068/src/options.go#L2618-L2622
+  local i = 1
+  while i <= #words do
+    local word = words[i] ---@as string
+    if word:sub(1, 2) == "--" then
+      local field, value = word:match("^(.-)=(.*)$")
+      if field then
+        args[field] = value
+      else -- space-separated: --key value (next token doesn't start with '-')
+        local nxt = words[i + 1]
+        if nxt and nxt:sub(1, 1) ~= "-" then
+          args[word] = nxt
+          i = i + 1
+        else
+          args[word] = true -- bare flag
+        end
+      end
+    end
+    i = i + 1
+  end
+  return args
+end
+
+
+local parsed ---@type fzf-lua.FzfOpts?
+---@return fzf-lua.FzfOpts
+M.get = function()
+  if parsed then return parsed end
+  local default_opts = os.getenv("FZF_DEFAULT_OPTS")
+  local file = os.getenv("FZF_DEFAULT_OPTS_FILE")
+  local content = file and require("fzf-lua.utils").read_file(file) or nil
+  local opts1 = default_opts and M.parse(default_opts) or {}
+  local opts2 = content and M.parse(content) or {}
+  parsed = vim.tbl_deep_extend("keep", opts1, opts2)
+  return parsed
+end
+
+return M

--- a/tests/config_spec.lua
+++ b/tests/config_spec.lua
@@ -1,0 +1,97 @@
+local helpers = require("fzf-lua.test.helpers")
+local assert = helpers.assert
+
+local parse = require("fzf-lua.config.parse")
+local eq = assert.are.equal
+local same = assert.are.same
+
+describe("Testing config parser", function()
+  it("parses empty and simple strings", function()
+    same(parse.shellparse(""), {})
+    same(parse.shellparse("foo"), { "foo" })
+    same(parse.shellparse("foo bar"), { "foo", "bar" })
+    same(parse.shellparse("foo\tbar\n"), { "foo", "bar" })
+  end)
+
+  it("handles single and double quotes", function()
+    same(parse.shellparse("--foo='bar baz'"), { "--foo=bar baz" })
+    same(parse.shellparse('--foo="bar baz"'), { "--foo=bar baz" })
+    same(parse.shellparse([[--foo="bar\"baz"]]), { [[--foo=bar"baz]] })
+    same(parse.shellparse([[--foo=\'bar\ baz\']]), { [[--foo='bar baz']] })
+  end)
+
+  it("handles spaces in quotes and variables", function()
+    same(parse.shellparse("a b `ls`"), { "a", "b", "`ls`" })
+    same(parse.shellparse("a $(echo b)"), { "a", "$(echo b)" })
+    same(parse.shellparse([[$(echo "ab c")]]), { [[$(echo "ab c")]] })
+  end)
+
+  it("handles comments correctly", function()
+    same(parse.shellparse("a #b"), { "a" })
+    same(parse.shellparse("a#b"), { "a#b" })
+    same(parse.shellparse("a #b\nc"), { "a", "c" })
+    same(parse.shellparse("a b#c"), { "a", "b#c" })
+    same(parse.shellparse('--foo="bar #baz"'), { "--foo=bar #baz" })
+    same(parse.shellparse('--foo="bar" #baz'), { "--foo=bar" })
+  end)
+
+  it("stops at certain operators", function()
+    same(parse.shellparse("a ; b"), { "a" })
+    same(parse.shellparse("a & b"), { "a" })
+    same(parse.shellparse("a | b"), { "a" })
+    same(parse.shellparse("a < b"), { "a" })
+    same(parse.shellparse("a > b"), { "a" })
+    same(parse.shellparse("> file"), {})
+    same(parse.shellparse("abc 2>"), { "abc" })
+    same(parse.shellparse("2>"), {})
+    same(parse.shellparse("abc2>"), { "abc2" })
+  end)
+
+  it("returns error on unclosed quotes", function()
+    local res, err = parse.shellparse('"abc')
+    eq(res, nil)
+    eq(err, "invalid command line string")
+
+    res, err = parse.shellparse("'abc")
+    eq(res, nil)
+    eq(err, "invalid command line string")
+
+    res, err = parse.shellparse("a `b")
+    eq(res, nil)
+    eq(err, "invalid command line string")
+
+    res, err = parse.shellparse("a $(b")
+    eq(res, nil)
+    eq(err, "invalid command line string")
+  end)
+
+  it("invalid unclosed bracket command", function()
+    local res, err = parse.shellparse("a (b")
+    eq(res, nil)
+    eq(err, "invalid command line string")
+  end)
+
+  it("tests config parser wrapper", function()
+    local res = parse.parse("")
+    same(res, {})
+
+    res = parse.parse("foo bar")
+    same(res, { foo = nil, bar = nil })
+
+    res = parse.parse("--foo")
+    same(res, { ["--foo"] = true })
+
+    res = parse.parse("--foo=bar")
+    same(res, { ["--foo"] = "bar" })
+
+    res = parse.parse("--foo='bar baz'")
+    same(res, { ["--foo"] = "bar baz" })
+
+    res = parse.parse("--foo 'bar baz'")
+    same(res, { ["--foo"] = "bar baz" })
+
+    -- When tokenizing multiple '='
+    res = parse.parse([[--bind='ctrl-a:execute(echo "==")']])
+    same(res, { ["--bind"] = [[ctrl-a:execute(echo "==")]] })
+  end)
+end)


### PR DESCRIPTION
To respect user config from: $FZF_DEFAULTS_OPTS

Fix https://github.com/ibhagwan/fzf-lua/issues/2711.

AI-assisted: Gemini 2.5 Pro


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved configuration parsing to better handle shell-like option strings (quotes, escapes, command substitutions and comments).

* **Bug Fixes**
  * Ensure the history option is populated from parsed defaults when previously unset.

* **Tests**
  * Added thorough tests covering tokenization, parsing, error cases, and option mappings for configuration parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->