### PR TITLE
fix(win): validate last winnr (closes #2714)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        rev: [nightly, v0.12.1, puc-lua]
+        rev: [nightly, v0.12.2, puc-lua]
         exclude:
           - os: macos-latest
             rev: puc-lua

--- a/lua/fzf-lua/ctx.lua
+++ b/lua/fzf-lua/ctx.lua
@@ -11,7 +11,7 @@ local ctx
 ---@field bufnr integer
 ---@field bname string
 ---@field winid integer
----@field last_winid integer
+---@field last_winid integer?
 ---@field alt_bufnr integer
 ---@field tabnr integer
 ---@field tabh integer
@@ -52,7 +52,15 @@ M.refresh = function(opts)
       bufnr = vim.api.nvim_get_current_buf(),
       bname = vim.api.nvim_buf_get_name(0),
       winid = vim.api.nvim_get_current_win(),
-      last_winid = vim.fn.win_getid(vim.fn.winnr("#")),
+      last_winid = (function()
+        local last_winnr = vim.fn.winnr("#")
+        return last_winnr > 0
+            -- we use this to restore the last window
+            -- ignore if both current and last are equal
+            and last_winnr ~= vim.fn.winnr()
+            and vim.fn.win_getid(last_winnr)
+            or nil
+      end)(),
       alt_bufnr = vim.fn.bufnr("#"),
       tabnr = vim.fn.tabpagenr(),
       tabh = vim.api.nvim_win_get_tabpage(0),

--- a/lua/fzf-lua/test/helpers.lua
+++ b/lua/fzf-lua/test/helpers.lua
@@ -36,7 +36,7 @@ local os_detect = {
   },
   MAC = { name = "MacOS", fn = function() return vim.fn.has("mac") == 1 end },
   LINUX = { name = "Linux", fn = function() return vim.fn.has("linux") == 1 end },
-  STABLE = { name = "Neovim stable", fn = function() return M.NVIM_VERSION() == "0.12.1" end },
+  STABLE = { name = "Neovim stable", fn = function() return M.NVIM_VERSION() == "0.12.2" end },
   NIGHTLY = { name = "Neovim nightly", fn = function() return vim.fn.has("nvim-0.13") == 1 end },
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved window-context handling to avoid restoring or referencing an invalid previous window. When no suitable prior window exists, restoration is safely skipped, preventing errors and making window-related features more stable and reliable.

* **Tests**
  * Updated CI and test helpers to use Neovim stable version 0.12.2.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->