### PR TITLE
fix(ctx): when hidden process is terminated

### DIFF
--- a/lua/fzf-lua/ctx.lua
+++ b/lua/fzf-lua/ctx.lua
@@ -45,7 +45,7 @@ M.refresh = function(opts)
       or (not winobj and ctx.bufnr ~= vim.api.nvim_get_current_buf())
       -- we should never get here when fzf process is hidden unless the user requested
       -- not to resume or a different picker, i.e. hide files and open buffers
-      or winobj and winobj:hidden()
+      or winobj and (winobj:hidden() or winobj:was_hidden())
   then
     ctx = {
       mode = vim.api.nvim_get_mode().mode,


### PR DESCRIPTION
fix #2715

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed UI refresh behavior to properly handle hidden windows, ensuring consistent updates to the fzf-lua interface state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->