### PR TITLE
chore: vim.F deprecated

### DIFF
--- a/lua/fzf-lua/actions.lua
+++ b/lua/fzf-lua/actions.lua
@@ -515,7 +515,7 @@ end
 M.run_builtin = function(selected)
   if not selected[1] then return end
   local method = selected[1]
-  local func = vim.F.nil_wrap(require "fzf-lua"[method])
+  local func = utils.nil_wrap(require "fzf-lua"[method])
   if not _G.fzf_lua_stopinsert_hack then return func() end
   _G.fzf_lua_stopinsert_hack(func)
 end

--- a/lua/fzf-lua/make_entry.lua
+++ b/lua/fzf-lua/make_entry.lua
@@ -241,8 +241,8 @@ local glob_filter = function(paths, globs)
   -- globpath() is very slow
   local matchers
   if not globs or not vim.regex then return paths end
-  local pats = vim.tbl_map(vim.F.nil_wrap(vim.fn.glob2regpat), globs)
-  matchers = vim.tbl_map(vim.F.nil_wrap(vim.regex), pats)
+  local pats = vim.tbl_map(utils.nil_wrap(vim.fn.glob2regpat), globs)
+  matchers = vim.tbl_map(utils.nil_wrap(vim.regex), pats)
   -- matchers = vim.tbl_map(vim.F.nil_wrap(vim.glob.to_lpeg), globs)
   if #matchers == 0 then return paths end
   return vim.tbl_filter(function(p)

--- a/lua/fzf-lua/previewer/builtin.lua
+++ b/lua/fzf-lua/previewer/builtin.lua
@@ -47,7 +47,7 @@ Previewer.base = Object:extend()
 ---@param opts table
 ---@return fzf-lua.previewer.Builtin
 function Previewer.base:new(o, opts)
-  local default = vim.F.if_nil
+  local default = utils.nonnil
   o = o or {}
   self.type = "builtin"
   self.opts = opts
@@ -885,7 +885,7 @@ function Previewer.buffer_or_file:_set_preview_lines(tmpbuf, entry)
   extmarks = entry.extmarks or extmarks
   pcall(api.nvim_buf_set_lines, tmpbuf, 0, -1, false, textlines)
   if extmarks and #extmarks > 0 then
-    local setmark = vim.F.nil_wrap(api.nvim_buf_set_extmark)
+    local setmark = utils.nil_wrap(api.nvim_buf_set_extmark)
     local ns = api.nvim_create_namespace("fzf-lua.preview.hl")
     for _, extmark in ipairs(extmarks) do
       setmark(tmpbuf, ns, extmark.row, extmark.col,
@@ -1333,7 +1333,7 @@ function Previewer.buffer_or_file:set_cursor_hl(entry)
   if not extmark and hls.cursor and entry.col and entry.col > 0 then
     local end_lnum, end_col = entry.end_line or lnum, entry.end_col or col + 1
     -- stale line/col can cause out-of-range, e.g. marks
-    vim.F.nil_wrap(api.nvim_buf_set_extmark)(buf, self.ns_previewer, lnum - 1, col - 1, {
+    utils.nil_wrap(api.nvim_buf_set_extmark)(buf, self.ns_previewer, lnum - 1, col - 1, {
       end_line = end_lnum - 1,
       end_col = math.max(1, end_col) - 1,
       hl_group = entry.hlgroup or hls.cursor,

--- a/lua/fzf-lua/profiles/cli.lua
+++ b/lua/fzf-lua/profiles/cli.lua
@@ -4,8 +4,10 @@ if NVIM_RUNTIME then vim.env.VIMRUNTIME = NVIM_RUNTIME end
 
 ---@diagnostic disable-next-line: deprecated
 local api, uv, fn = vim.api, vim.uv or vim.loop, vim.fn
----@module 'ffi'?
-local ffi = vim.F.npcall(require, "ffi")
+local ffi
+if package.preload.ffi then
+  ffi = package.preload.ffi()
+end
 
 pcall(function()
   ffi.cdef [[

--- a/lua/fzf-lua/utils.lua
+++ b/lua/fzf-lua/utils.lua
@@ -1765,5 +1765,15 @@ end
 ---@class fzf-lua.wo: vim.wo,{}
 M.wo = new_win_opt_accessor()
 
+---@diagnostic disable-next-line: deprecated
+M.nonnil = vim.nonnil or vim.F.if_nil
+
+---@diagnostic disable-next-line: deprecated
+M.npcall = vim.npcall or vim.F.npcall
+
+---@diagnostic disable-next-line: deprecated
+M.nil_wrap = not vim.nonnil and vim.F.nil_wrap or function(fn)
+  return function(...) return M.npcall(fn, ...) end
+end
 
 return M

--- a/lua/fzf-lua/win.lua
+++ b/lua/fzf-lua/win.lua
@@ -723,7 +723,7 @@ function FzfWin.new(o)
   self.preview_hidden = not not o.winopts.preview.hidden -- force boolean
   self.keymap = o.keymap
   self.previewer = o.previewer
-  self:set_autoclose(vim.F.if_nil(o.autoclose, true))
+  self:set_autoclose(utils.nonnil(o.autoclose, true))
   self.winopts = self:normalize_winopts()
   self.on_closes = {}
   _self = self

--- a/tests/actions_spec.lua
+++ b/tests/actions_spec.lua
@@ -18,7 +18,6 @@ T["actions"] = new_set({ n_retry = not helpers.IS_LINUX() and 5 or nil })
 T["actions"]["ui don't freeze on error"] = function()
   helpers.SKIP_IF_NOT_NIGHTLY()
   helpers.SKIP_IF_WIN()
-  MiniTest.skip("https://github.com/ibhagwan/fzf-lua/issues/2683")
   -- reload({ "hide" })
   local screen_opts = { start_line = 1, end_line = 10, ignore_text = { 28 } }
   -- fix flaky hit enter prompt on windows


### PR DESCRIPTION
https://github.com/neovim/neovim/pull/39495


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added compatibility helpers to the utilities layer to smooth differences across Neovim versions.

* **Refactor**
  * Internal callers switched to the new compatibility helpers to standardize nil/default handling and module loading.

* **Bug Fixes**
  * Re-enabled a previously skipped error-handling test to improve test coverage and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->