### PR TITLE
fix(health): skip --version for Windows built-ins and fix CRLF

### DIFF
--- a/lua/fzf-lua/_health.lua
+++ b/lua/fzf-lua/_health.lua
@@ -17,9 +17,14 @@ function M.check()
         warn("'" .. tool .. "' not found")
       end
     else
-      local version = vim.fn.system(tool .. " --version") or ""
-      version = vim.trim(assert(vim.split(version, "\n")[1]))
-      local is_ok = vim.v.shell_error == 0
+      -- Windows built-in tools don't support --version and output non-UTF-8 error messages
+      if is_win and (tool == "find" or tool == "dir") then
+        ok("'" .. tool .. "' (Windows built-in)")
+        return true
+      end
+      local out, rc = utils.io_system({ tool, "--version" })
+      local version = vim.trim(vim.split(out, "\n")[1] or "")
+      local is_ok = rc == 0
       (is_ok and ok or error)("'" .. tool .. "' `" .. version .. "`")
       return true
     end


### PR DESCRIPTION
1. On Japanese Windows, `find --version` invokes Windows' system `find.exe` which outputs an error in CP932 encoding, causing garbled text in `:checkhealth`. Also, `dir` has the same issue.       

2. Skip `--version` for these Windows built-ins and report them as available without a version string. Also switch to `utils.io_system()` to avoid CRLF-corrupted version strings on Windows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tool detection to use more reliable version checking mechanism.
  * Added Windows compatibility for built-in commands to prevent UTF-8 encoding errors.
  * Enhanced version string retrieval for accurate tool identification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ibhagwan/fzf-lua/pull/2727)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->