### PR TITLE
fix: replace os.exit with :cquit for nvim -l

### DIFF
--- a/lua/fzf-lua/libuv.lua
+++ b/lua/fzf-lua/libuv.lua
@@ -502,7 +502,7 @@ M.spawn_stdio = function(opts)
 
   local function exit(exit_code, msg)
     if msg then stderr_write(msg) end
-    os.exit(exit_code)
+    vim.cmd.cquit(exit_code)
   end
 
   local function pipe_open(pipename)


### PR DESCRIPTION
https://github.com/ibhagwan/fzf-lua/pull/2727#issuecomment-4457133021


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved application exit handling for better compatibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ibhagwan/fzf-lua/pull/2728)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->