### PR TITLE
fix: pass `cquit` exit code via `count` (closes #2730)

### DIFF
--- a/lua/fzf-lua/libuv.lua
+++ b/lua/fzf-lua/libuv.lua
@@ -502,7 +502,7 @@ M.spawn_stdio = function(opts)
 
   local function exit(exit_code, msg)
     if msg then stderr_write(msg) end
-    vim.cmd.cquit(exit_code)
+    vim.cmd.cquit({ count = exit_code })
   end
 
   local function pipe_open(pipename)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected exit code handling to ensure proper termination behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ibhagwan/fzf-lua/pull/2731?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->