### PR TITLE
fix: correctly vim.schedule the exit

### DIFF
--- a/lua/fzf-lua/libuv.lua
+++ b/lua/fzf-lua/libuv.lua
@@ -547,9 +547,9 @@ M.spawn_stdio = function(opts)
   local on_finish = function(code)
     pipe_close(stdout)
     pipe_close(stderr)
-    if vim.in_fast_event() and fn_postprocess then
+    if vim.in_fast_event() then
       vim.schedule(function()
-        fn_postprocess(opts)
+        if fn_postprocess then fn_postprocess(opts) end
         exit(code)
       end)
     else


### PR DESCRIPTION
https://github.com/neovim/neovim/pull/39895#issuecomment-4504360549

My word here is wrong: https://github.com/ibhagwan/fzf-lua/pull/2728#issuecomment-4459013774.

I didn't look the code carefully.
