### PR TITLE
refactor(buffers): remove spurious nvim-treesitter dependency check

### DIFF
--- a/lua/fzf-lua/providers/buffers.lua
+++ b/lua/fzf-lua/providers/buffers.lua
@@ -495,12 +495,6 @@ M.treesitter = function(opts)
   opts = config.normalize_opts(opts, "treesitter")
   if not opts then return end
 
-  local __has_ts, _ = pcall(require, "nvim-treesitter")
-  if not __has_ts then
-    utils.info("Treesitter requires 'nvim-treesitter'.")
-    return
-  end
-
   -- Default to current buffer
   local bufnr0 = utils.tointeger(opts.bufnr) or vim.api.nvim_get_current_buf()
   local bufname0 = path.basename(vim.api.nvim_buf_get_name(bufnr0))


### PR DESCRIPTION
The `treesitter` picker previously checked for the presence of the external `nvim-treesitter` plugin before proceeding, but this check was unnecessary - since the [current implementation now uses Neovim's built-in `vim.treesitter` API](https://github.com/tienshuoc/fzf-lua/blob/9f5e0a22739697ebe73f27acd4c1897be123056b/lua/fzf-lua/providers/buffers.lua#L505), not `nvim-treesitter`.

This creates an unnecessary dependency for users trying to use the treesitter function.

### Changes
- Removed the `pcall(require, "nvim-treesitter")` check from
  `M.treesitter()` in `lua/fzf-lua/providers/buffers.lua`
- The existing `has_ts_parser()` validation already uses built-in APIs and
  provides appropriate error messaging

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified treesitter integration by removing an explicit dependency availability check from the buffer provider.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ibhagwan/fzf-lua/pull/2734?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->