### PR TITLE
fix(grep): grep_cword fails for words starting/ending with non-word chars

### DIFF
--- a/lua/fzf-lua/providers/grep.lua
+++ b/lua/fzf-lua/providers/grep.lua
@@ -266,7 +266,7 @@ M.grep_cword = function(opts)
   opts = opts or {}
   opts.no_esc = true
   -- match whole words only (#968)
-  opts.search = [[\b]] .. utils.rg_escape(vim.fn.expand("<cword>")) .. [[\b]]
+  opts.search = utils.rg_escape_cword(vim.fn.expand("<cword>"))
   return M.grep(opts)
 end
 

--- a/lua/fzf-lua/providers/tags.lua
+++ b/lua/fzf-lua/providers/tags.lua
@@ -251,7 +251,7 @@ end
 M.grep_cword = function(opts)
   if not opts then opts = {} end
   opts.no_esc = true
-  opts.search = [[\b]] .. utils.rg_escape(vim.fn.expand("<cword>")) .. [[\b]]
+  opts.search = utils.rg_escape_cword(vim.fn.expand("<cword>"))
   return M.grep(opts)
 end
 

--- a/lua/fzf-lua/utils.lua
+++ b/lua/fzf-lua/utils.lua
@@ -245,6 +245,17 @@ function M.rg_escape(str)
   return ret
 end
 
+--- Escape a word and wrap it in `\b` word boundaries (#968), but only on edges
+--- that are word characters: a `\b` next to a non-word char (e.g. a cword
+--- ending in `$`) can never match and would yield no results.
+--- @param word string
+--- @return string
+function M.rg_escape_cword(word)
+  local bl = word:match("^[%w_]") and [[\b]] or ""
+  local br = word:match("[%w_]$") and [[\b]] or ""
+  return bl .. M.rg_escape(word) .. br
+end
+
 ---@param str string
 ---@return string
 function M.regex_to_magic(str)


### PR DESCRIPTION
If `iskeyword` contains a character that `rg` does not consider a word character (e.g. `$`) then `grep_cword` will fail if the word starts or ends with such a character.

For example if `$` is in `iskeyword` then for `demo$` the regex will be `\bdemo\$\b` - but `rg` does not consider `$` to be a word character so the `\b` will never match.

The suggested fix here leaves away the `\b` in such cases. It's not as sharp as `\b` matching anymore but I'd say that's more correct than no results at all.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved word-boundary handling when searching for the word under the cursor: searches now use a safer escaping routine and apply word boundaries only when appropriate, preventing missed or incorrect matches.
  * Ensures grep and tag searches produce more accurate results for edge-case words.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->