### PR TITLE
fix(win): "E749: Empty buffer" on closing fzf due to continuous "|"

### DIFF
--- a/lua/fzf-lua/win.lua
+++ b/lua/fzf-lua/win.lua
@@ -1066,11 +1066,14 @@ function FzfWin:create()
       -- if we're not doing this the result might be all over the place
       local winnrs = vim.tbl_map(api.nvim_win_get_number, api.nvim_tabpage_list_wins(0))
       local parts = vim.split(winrestcmd, "|")
-      local cmd = vim.tbl_map(function(cmd_part)
-        local winnr = tonumber(cmd_part:match("(.)resize"))
-        return utils.tbl_contains(winnrs, winnr) and cmd_part or ""
-      end, parts)
-      vim.cmd(table.concat(cmd, "|"))
+      local cmd = {}
+      for _, cmd_part in ipairs(parts) do
+        local winnr = tonumber(cmd_part:match("(%d+)resize"))
+        if utils.tbl_contains(winnrs, winnr) then
+          table.insert(cmd, cmd_part)
+        end
+      end
+      if #cmd > 0 then vim.cmd(table.concat(cmd, "|")) end
       -- Also restore cmdheight, will be wrong if vim resized (#1462)
       vim.o.cmdheight = cmdheight
     end


### PR DESCRIPTION
Bug: If `cmd` contains empty string "", after concatenation the concatenated command will contains continuous separator "|", e.g. ":1resize 9|vert :1resize 103|||:1resize 9|vert :1resize 103|||", running this command through `vim.cmd()` will cause error: "E749: Empty buffer".

<img width="1030" height="577" alt="image" src="https://github.com/user-attachments/assets/25541cbd-7246-4509-8497-81de19e2a4cc" />


Fix: Filter out empty commands in `cmd`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable restoration of split windows and sizes when closing temporary windows; prevents running empty or invalid restore commands to avoid spurious behavior.
  * Ensures only valid resize fragments are applied during restore, reducing edge-case failures.

* **Refactor**
  * Internal cleanup of window-restoration logic for clearer, safer execution and easier maintenance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->