### PR TITLE
ci: sync mini.test upstream change

### DIFF
--- a/lua/fzf-lua/test/screenshot.lua
+++ b/lua/fzf-lua/test/screenshot.lua
@@ -47,11 +47,18 @@ end
 
 ---@param s string
 ---@return string[]
-local function string_to_chars(s)
+local function string_to_screenchars(s)
   -- Can't use `vim.split(s, '')` because of multibyte characters
   local res = {}
   for i = 1, vim.fn.strchars(s) do
-    table.insert(res, vim.fn.strcharpart(s, i - 1, 1))
+    local ch = vim.fn.strcharpart(s, i - 1, 1)
+    table.insert(res, ch)
+    -- Not single-width characters are read as a single char, but result into
+    -- `{ ch, '', ... }` when computing observed screenshot (as this is how
+    -- `vim.fn.screenstring()` works)
+    for _ = 1, vim.fn.strdisplaywidth(ch) - 1 do
+      table.insert(res, "")
+    end
   end
   return res
 end
@@ -66,10 +73,7 @@ function M.from_lines(text_lines, opts)
   if opts and opts.normalize_paths then
     text_lines = vim.tbl_map(function(x) return (x:gsub([[\]], [[/]])) end, text_lines)
   end
-  local f = function(x)
-    return string_to_chars(x)
-  end
-  return screenshot_new({ text = vim.tbl_map(f, text_lines) }, opts)
+  return screenshot_new({ text = vim.tbl_map(string_to_screenchars, text_lines) }, opts)
 end
 
 ---@param child MiniTest.child
@@ -109,7 +113,7 @@ local screenshot_read = function(path)
   local lines = vim.fn.readfile(path)
   local text_lines = vim.list_slice(lines, 2, #lines)
 
-  local f = function(x) return H.string_to_chars(x:gsub("^%d+|", "")) end
+  local f = function(x) return string_to_screenchars(x:gsub("^%d+|", "")) end
   return screenshot_new({ text = vim.tbl_map(f, text_lines) }, opts)
 end
 

--- a/scripts/make_cli.lua
+++ b/scripts/make_cli.lua
@@ -33,9 +33,6 @@ if filter then
   end
 end
 
--- make _G.FzfLua usable in test (e.g. headless_spec.lua)
-require("fzf-lua")
-
 -- https://github.com/neovim/neovim/pull/36557
 local sig = assert(vim.uv.new_signal())
 sig:start(vim.uv.constants.SIGINT, function() MiniTest.stop() end)

--- a/scripts/minimal_init.lua
+++ b/scripts/minimal_init.lua
@@ -17,3 +17,6 @@ vim.env.FZF_DEFAULT_OPTS_FILE = nil
 vim.env.FZF_DEFAULT_COMMAND = nil
 vim.env.FZF_API_KEY = nil
 vim.env.LC_ALL = "C"
+
+-- make _G.FzfLua usable in test (e.g. headless_spec.lua)
+require("fzf-lua")


### PR DESCRIPTION
https://github.com/echasnovski/mini.nvim/commit/2a8e1f65760c4c6ce3de63f322e5ffe0ef9175fc
Fix failure in https://github.com/ibhagwan/fzf-lua/actions/runs/26711878681/job/78723449441?pr=2739.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved screenshot comparison to correctly handle multi-width characters by aligning and padding display cells, improving visual regression accuracy for wide-character content.
* **Chores**
  * Adjusted test startup: ensure the code is loaded in minimal test environments and remove redundant early loading from the CLI test runner.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->