### PR TITLE
feat(git follow): Add option to make git_bcommits follow renames

### DIFF
--- a/README.md
+++ b/README.md
@@ -936,6 +936,8 @@ previewers = {
     },
     bcommits = {
       prompt        = 'BCommits❯ ',
+      -- follow the buffer's history across renames
+      follow        = false,
       -- default preview shows a git diff vs the previous commit
       -- if you prefer to see the entire commit you can use:
       --   git show --color {1} --rotate-to={file}

--- a/lua/fzf-lua/actions.lua
+++ b/lua/fzf-lua/actions.lua
@@ -1116,7 +1116,10 @@ M.git_buf_edit = function(selected, opts)
   local git_root = assert(path.git_root(opts, true), "not in git directory")
   local win = vim.api.nvim_get_current_win()
   local buffer_filetype = vim.bo.filetype
-  local file = path.relative_to(path.normalize(vim.fn.expand("%:p")), git_root)
+  -- `fn_match_file` lets a provider (e.g. bcommits `follow`) resolve the path the
+  -- buffer had at the selected commit; otherwise fall back to the current name.
+  local file = type(opts.fn_match_file) == "function" and opts.fn_match_file(selected[1], opts)
+      or path.relative_to(path.normalize(vim.fn.expand("%:p")), git_root)
   local commit_hash = match_commit_hash(selected[1], opts)
   table.insert(cmd, commit_hash .. ":" .. file)
   local git_file_contents = utils.io_systemlist(cmd)

--- a/lua/fzf-lua/defaults.lua
+++ b/lua/fzf-lua/defaults.lua
@@ -780,9 +780,13 @@ M.defaults.git = {
   },
   ---Git commits (buffer).
   ---@class fzf-lua.config.GitBcommits: fzf-lua.config.GitBase
+  ---Follow the buffer's history across renames.
+  ---@field follow? boolean
   bcommits = {
     cmd           = [[git log --color --pretty=format:"%C(yellow)%h%Creset ]]
         .. [[%Cgreen(%><(12)%cr%><|(12))%Creset %s %C(blue)<%an>%Creset" -- {file}]],
+    -- When true, follow the buffer's history across renames.
+    follow        = false,
     preview       = "git show --color {1} -- {file}",
     preview_pager = M._preview_pager_fn,
     actions       = {

--- a/lua/fzf-lua/providers/git.lua
+++ b/lua/fzf-lua/providers/git.lua
@@ -216,6 +216,46 @@ M.bcommits = function(opts)
   end
   local git_root = path.git_root(opts)
   if not git_root then return end
+  -- `follow`: list (and preview) the buffer's history across renames. We resolve
+  -- the filename the buffer had at each commit via `git log --follow --name-only`
+  -- (which prints the per-commit name with no rename-chain bookkeeping), embedding
+  -- it as a hidden fzf field so the preview/actions reference the correct path for
+  -- commits where the file was named differently.
+  if opts.follow and not utils.mode_is_visual() then
+    local display_fmt = opts.cmd:match('%-%-pretty=format:"(.-)"') or "%C(yellow)%h%Creset %s"
+    local relfile = path.relative_to(vim.fn.expand("%:p"), git_root)
+    -- \1 marks a header line; \31 separates the clean sha from the coloured display
+    local logcmd = path.git_cwd({
+      "git", "-c", "core.quotepath=false",
+      "log", "--follow", "--name-only", "--color=always",
+      "--pretty=format:%x01%h%x1f" .. display_fmt, "--", relfile,
+    }, opts)
+    local entries, sha, disp = {}, nil, nil
+    for _, line in ipairs(utils.io_systemlist(logcmd)) do
+      local s, d = line:match("^\1([^\31]*)\31(.*)$")
+      if s then
+        sha, disp = s, d
+      elseif sha and #line > 0 then
+        local fname = line:gsub("\27%[[%d;]*m", "") -- defensive ANSI strip
+        entries[#entries + 1] = string.format("%s\t%s\t%s", sha, fname, disp)
+        sha = nil
+      end
+    end
+    opts.fzf_opts = opts.fzf_opts or {}
+    if opts.fzf_opts["--delimiter"] == nil then opts.fzf_opts["--delimiter"] = "\t" end
+    if opts.fzf_opts["--with-nth"] == nil then opts.fzf_opts["--with-nth"] = "3.." end
+    opts.preview = "git show --color {1} -- {2}"
+    opts.preview = git_preview(opts)
+    ---@class fzf-lua.config.GitBcommitsFollow: fzf-lua.config.GitBcommits
+    ---@field fn_match_commit_hash? fun(line: string, opts: table): string?
+    ---@field fn_match_file? fun(line: string, opts: table): string?
+    ---@cast opts fzf-lua.config.GitBcommitsFollow
+    opts.fn_match_commit_hash = opts.fn_match_commit_hash
+        or function(l) return l:match("^[^\t]+") end
+    opts.fn_match_file = opts.fn_match_file
+        or function(l) return (l:match("^[^\t]+\t([^\t]+)")) end
+    return core.fzf_exec(entries, opts)
+  end
   local file = libuv.shellescape(path.relative_to(vim.fn.expand("%:p"), git_root))
   local range
   if utils.mode_is_visual() then


### PR DESCRIPTION
Core idea:

* Use `git log --follow --name-only` to print the original filename in another line after each log message
* Combine lines with log messages + lines with filenames in a loop into a single entry
* Use `--with-nth` feature of fzf to hide the filename

Fixes #1544 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `follow` option to the `bcommits` picker to follow a buffer’s history across renames (non-visual mode only).
  * When enabled, entries use commit-aware file resolution and previews.
* **Documentation**
  * Documented the new `follow` option for `bcommits`, explicitly noting its default (`false`).
* **Behavior Changes**
  * Commit-specific file paths are resolved to reflect the filename as it existed at the selected commit, improving renamed-file accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->