### PR TITLE
fix: add native color support to git diff preview

### DIFF
--- a/lua/fzf-lua/defaults.lua
+++ b/lua/fzf-lua/defaults.lua
@@ -676,10 +676,10 @@ M.defaults.git = {
   ---Git reference used as the base for the comparison.
   ---@field ref1? string
   diff = {
-    cmd               = "git --no-pager diff --name-only {ref1} {ref}",
+    cmd               = "git --no-pager diff --color=always --name-only {ref1} {ref}",
     ref               = nil,
     ref1              = nil,
-    preview           = "git diff {ref1} {ref} {file}",
+    preview           = "git diff --color=always {ref1} {ref} {file}",
     preview_pager     = M._preview_pager_fn,
     multiprocess      = 1, ---@type integer|boolean
     _type             = "file",


### PR DESCRIPTION
Added `--color=always` flag to git diff preview and cmd in order to support native git diff color in `git_commit` when navigating to individual commits making the diff easier to read without needing `delta`.

Fixes issue from discussion https://github.com/ibhagwan/fzf-lua/discussions/2751


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved git diff visualization with color output for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->