### PR TITLE
fix(ui_select): add native preview for fzf-native/fzf-tmux

### DIFF
--- a/lua/fzf-lua/defaults.lua
+++ b/lua/fzf-lua/defaults.lua
@@ -2208,6 +2208,22 @@ M.defaults.complete_line = vim.tbl_deep_extend("force", M.defaults.blines, {
   complete = true,
 })
 
+
+---@class fzf-lua.config.UISelect: fzf-lua.config.Base
+M.defaults.ui_select = {
+  fzf_opts = { ["--no-multi"] = true },
+  ui_select = { preview_type = "native" },
+  actions = {
+    ["enter"] = {
+      fn = function(...)
+        return require("fzf-lua.providers.ui_select").accept_item(...)
+      end,
+      desc = "accept-item"
+    }
+  }
+}
+
+
 M.defaults.file_icon_padding = ""
 
 -- No need to sset this, already defaults to `nvim_open_win`

--- a/lua/fzf-lua/profiles/fzf-native.lua
+++ b/lua/fzf-lua/profiles/fzf-native.lua
@@ -21,4 +21,5 @@ return {
   lsp = { code_actions = { previewer = "codeaction_native" } },
   tags = { previewer = "bat" },
   btags = { previewer = "bat" },
+  ui_select = { preview_type = "native" },
 }

--- a/lua/fzf-lua/profiles/fzf-tmux.lua
+++ b/lua/fzf-lua/profiles/fzf-tmux.lua
@@ -33,4 +33,5 @@ return {
   btags = { previewer = "bat" },
   lines = { _treesitter = false },
   blines = { _treesitter = false },
+  ui_select = { preview_type = "native" },
 }

--- a/lua/fzf-lua/providers/ui_select.lua
+++ b/lua/fzf-lua/providers/ui_select.lua
@@ -53,6 +53,19 @@ M.accept_item = function(selected, o)
   o._on_choice_called = true
 end
 
+local resolve_preview_type = function(ui_opts, opts)
+  local preview_type = ui_opts.preview_type or opts.preview_type
+  if preview_type == nil then
+    local profile = opts.profile or opts[1]
+    local is_tmux_profile = profile == "fzf-tmux"
+        or (type(profile) == "table" and vim.tbl_contains(profile, "fzf-tmux"))
+    preview_type = (is_tmux_profile
+          or (opts.fzf_opts and opts.fzf_opts["--tmux"]))
+        and "native" or "buffer"
+  end
+  return preview_type
+end
+
 M.ui_select = function(items, ui_opts, on_choice)
   --[[
   -- Code Actions
@@ -89,20 +102,13 @@ M.ui_select = function(items, ui_opts, on_choice)
 
   local opts = _OPTS or {}
 
-  -- enables customization per kind (#755)
-  if type(opts) == "function" then
-    opts = opts(ui_opts, items)
-  end
+  opts = config.normalize_opts(opts, "ui_select")
+  if not opts then return end
 
   -- deepcopy register opts so we don't poullute the original tbl ref (#2241)
   if type(opts) == "table" then
     opts = utils.tbl_deep_clone(opts)
   end
-
-  opts.fzf_opts = vim.tbl_extend("keep", opts.fzf_opts or {}, {
-    ["--no-multi"]       = true,
-    ["--preview-window"] = "hidden:right:0",
-  })
 
   -- Force override prompt or it stays cached (#786)
   local prompt = ui_opts.prompt or "Select one of:"
@@ -112,10 +118,6 @@ M.ui_select = function(items, ui_opts, on_choice)
   opts._items = items
   opts._on_choice = on_choice
   opts._ui_select = ui_opts
-
-  opts.actions = vim.tbl_deep_extend("keep", opts.actions or {}, {
-    ["enter"] = { fn = M.accept_item, desc = "accept-item" }
-  })
 
   -- schedule to avoid our coroutine break external async logic #2719
   opts.fn_selected = vim.schedule_wrap(function(selected, o)
@@ -180,26 +182,78 @@ M.ui_select = function(items, ui_opts, on_choice)
   end
 
   if ui_opts.preview_item then
-    opts.previewer = {
-      _ctor = function()
-        local previewer = require("fzf-lua.previewer.builtin").buffer_or_file:extend()
-        ---@diagnostic disable-next-line: unused
-        function previewer:parse_entry(entry_str, cb)
-          local str = utils.strip_ansi_coloring(entry_str)
-          local res = assert(ui_opts.preview_item(items[reverse_lookup[str]], cb))
-          local pos_start, pos_end = res.pos, res.pos_end
-          return {
-            _scratch_buf = res.buf,
-            line = pos_start and pos_start[1] or 1,
-            col = pos_start and pos_start[2] or 1,
-            end_line = pos_end and pos_end[1] or 1,
-            end_col = pos_end and pos_end[2] or 1,
-          }
-        end
+    local preview_type = resolve_preview_type(ui_opts, opts)
+    if preview_type == "native" then
+      local tmpfile = vim.fn.tempname()
+      opts.preview = {
+        fn = function(s)
+          if not s or not s[1] then return utils.shell_nop() end
+          local idx = reverse_lookup[utils.strip_ansi_coloring(s[1])]
+          if not idx or not items[idx] then return utils.shell_nop() end
+          local res = ui_opts.preview_item(items[idx])
+          if type(res) ~= "table" or not res.buf or not vim.api.nvim_buf_is_valid(res.buf) then
+            return utils.shell_nop()
+          end
+          local fd, _ = io.open(tmpfile, "w")
+          if fd then
+            fd:write(table.concat(vim.api.nvim_buf_get_lines(res.buf, 0, -1, false), "\n"))
+            fd:close()
+          end
+          local ft = vim.bo[res.buf].filetype or vim.filetype.match({ buf = res.buf })
+          local cat = utils.__IS_WINDOWS and "type" or "cat"
+          local nul = utils.__IS_WINDOWS and "NUL" or "/dev/null"
+          local tmp_esc = require("fzf-lua.libuv").shellescape(tmpfile)
+          if ft and ft ~= "" then
+            return ("bat --style=numbers,changes --color=always --language=%s %s 2>%s || %s %s")
+                :format(ft, tmp_esc, nul, cat, tmp_esc)
+          end
+          return ("bat --style=numbers,changes --color=always %s 2>%s || %s %s"):format(
+            tmp_esc, nul, cat, tmp_esc)
+        end,
+        type = "cmd",
+      }
 
-        return previewer
+      -- `preview_offset` is a static fzf flag, so we seed it once from
+      -- the first item's `pos`. The user can scroll within fzf for
+      -- per-entry offsets; the common case is one shared buffer.
+      if items[1] then
+        local first = ui_opts.preview_item(items[1])
+        if first and first.pos and first.pos[1] then
+          opts.preview_offset = ("+%d"):format(first.pos[1])
+        end
       end
-    }
+
+      opts.winopts = opts.winopts or {}
+      local prev_on_close = opts.winopts.on_close
+      opts.winopts.on_close = function(...)
+        if prev_on_close then prev_on_close(...) end
+        pcall(os.remove, tmpfile)
+      end
+    else
+      opts.previewer = {
+        _ctor = function()
+          local previewer = require("fzf-lua.previewer.builtin").buffer_or_file:extend()
+          ---@diagnostic disable-next-line: unused
+          function previewer:parse_entry(entry_str, cb)
+            local str = utils.strip_ansi_coloring(entry_str)
+            local res = ui_opts.preview_item(items[reverse_lookup[str]], cb)
+            if type(res) ~= "table" or (not res.buf and not res.pos) then
+              return { content = { { { "No preview available", "Error" } } }, }
+            end
+            local pos_start, pos_end = res.pos, res.pos_end
+            return {
+              _scratch_buf = res.buf,
+              line = pos_start and pos_start[1] or 1,
+              col = pos_start and pos_start[2] or 1,
+              end_line = pos_end and pos_end[1] or 1,
+              end_col = pos_end and pos_end[2] or 1,
+            }
+          end
+
+          return previewer
+        end,
+      }
+    end
   elseif _OPTS_ONCE then
     -- merge and clear the once opts sent from lsp_code_actions.
     -- We also override actions to guarantee a single default

--- a/tests/ui_select_spec.lua
+++ b/tests/ui_select_spec.lua
@@ -1,0 +1,152 @@
+---@diagnostic disable: unused-local, unused-function, unused
+local MiniTest = require("mini.test")
+local helpers = require("fzf-lua.test.helpers")
+local child = helpers.new_child_neovim()
+local eq = helpers.expect.equality
+local new_set = MiniTest.new_set
+local exec_lua = child.lua
+
+--stylua: ignore start
+---@format disable-next
+local reload = function(config) child.unload(); child.setup(config) end
+local type_keys = function(...) return child.type_keys(...) end
+local sleep = function(ms) helpers.sleep(ms, child) end
+--stylua: ignore end
+
+local T = helpers.new_set_with_child(child, {
+  hooks = {
+    pre_case = function()
+      child.o.shell = "/bin/sh"
+      child.o.termguicolors = true
+      child.o.background = "dark"
+      child.o.statusline = "fzf://"
+    end,
+  },
+})
+
+T["ui_select"] = new_set()
+
+local register = function(opts)
+  local literal = vim.inspect(opts or {}):gsub("\n", " ")
+  exec_lua(([[FzfLua.register_ui_select(%s)]]):format(literal))
+end
+
+-- Wipe any stale /tmp/fzf-lua-ui-select-*.tmp files left by previous
+-- (possibly crashed) test runs. The tmpfile name uses `os.time()`
+-- which has 1-second resolution, so concurrent runs in the same
+-- second would otherwise race on the same path.
+local function cleanup_stale_tmpfiles()
+  for _, f in ipairs(vim.fn.glob("/tmp/fzf-lua-ui-select-*.tmp", true, true)) do
+    pcall(os.remove, f)
+  end
+  exec_lua(([[
+    for _, f in ipairs(vim.fn.glob("/tmp/fzf-lua-ui-select-*.tmp", true, true)) do
+      pcall(os.remove, f)
+    end
+  ]]))
+end
+
+-- Open the picker via `vim.ui.select` and wait for it to appear.
+-- The buffer is created in the child nvim (buffers don't cross the rpc
+-- boundary). `pcall` traps any synchronous crash from the native
+-- preview fn (#2743).
+local function open_picker(items, preview_lines, ui_opts)
+  exec_lua(function(items, preview_lines, ui_opts)
+    _G._ui_select_choice = nil
+    _G._ui_select_errors = nil
+    local buf = vim.api.nvim_create_buf(false, true)
+    vim.api.nvim_buf_set_lines(buf, 0, -1, false, preview_lines)
+    local opts = vim.tbl_extend("keep", ui_opts, {
+      format_item = function(item) return tostring(item) end,
+      preview_item = function() return { buf = buf } end,
+    })
+    local ok, err = pcall(vim.ui.select, items, opts, function(item, idx)
+      _G._ui_select_choice = { item = item, idx = idx }
+    end)
+    if not ok then
+      _G._ui_select_errors = tostring(err); error(err)
+    end
+  end, { items, preview_lines, ui_opts or {} })
+  child.wait_until(function()
+    return child.lua_get([[_G._fzf_lua_on_create]]) == true
+        or child.lua_get([[_G._ui_select_errors]]) ~= nil
+  end, 5000)
+  local errs = child.lua_get([[_G._ui_select_errors]])
+  eq(errs, vim.NIL, { fail_reason = "vim.ui.select errored: " .. tostring(errs) })
+  eq(child.lua_get([[_G._fzf_lua_on_create]]), true)
+end
+
+local function close_picker(key)
+  type_keys(key or "<c-c>")
+  child.wait_until(function()
+    return child.lua_get([[_G._fzf_lua_on_create]]) == vim.NIL
+  end, 5000)
+  eq(child.lua_get([[_G._fzf_lua_on_create]]), vim.NIL)
+end
+
+-- Wait until the picker's previewer reports having rendered the
+-- first entry. `last_entry` is the full fzf line (with the `<n>. `
+-- prefix produced by ui_select).
+local function wait_preview_rendered(expected_entry)
+  child.wait_until(function()
+    local last = child.lua_get([[
+      (FzfLua.utils.fzf_winobj() or {})._previewer
+        and FzfLua.utils.fzf_winobj()._previewer.last_entry or nil
+    ]])
+    return last == expected_entry
+  end, 5000)
+end
+
+T["ui_select"]["buffer preview (default)"] = function()
+  reload({ "default" })
+  register()
+  open_picker({ "alpha", "beta" }, { "preview-line-1", "preview-line-2" },
+    { prompt = "Pick (buffer):" })
+  wait_preview_rendered("1. alpha")
+  local screen = tostring(child.get_screenshot({ redraw = true }))
+  eq(screen:find("alpha", 1, true) ~= nil, true,
+    { fail_reason = "alpha not in screen:\n" .. screen })
+  eq(screen:find("preview-line-1", 1, true) ~= nil, true,
+    { fail_reason = "preview line 1 not in screen:\n" .. screen })
+  close_picker()
+end
+
+T["ui_select"]["native via fzf-tmux profile #2743"] = function()
+  -- The fzf-tmux profile declares `ui_select = { preview_type = "native" }`
+  -- so the picker should use the native backend even without an
+  -- explicit opt (in real tmux the picker runs in a tmux popup; here
+  -- without tmux it degrades to a regular fzf run with the same opts).
+  cleanup_stale_tmpfiles()
+  reload({ "fzf-tmux" })
+  register()
+  open_picker({ "alpha", "beta" }, { "tmux-line" })
+  sleep(300)
+  close_picker()
+end
+
+T["ui_select"]["async preview_item opens without crash"] = function()
+  reload({ "default" })
+  register()
+  exec_lua(function()
+    vim.ui.select({ "alpha", "beta" }, {
+      prompt = "Pick (async):",
+      preview_item = function(_) return {} end,
+      format_item = function(item) return tostring(item) end,
+    }, function() end)
+  end)
+  child.wait_until(function()
+    return child.lua_get([[_G._fzf_lua_on_create]]) == true
+  end, 5000)
+  eq(child.lua_get([[_G._fzf_lua_on_create]]), true)
+  close_picker("<esc>")
+end
+
+T["ui_select"]["abort via esc"] = function()
+  reload({ "default" })
+  register()
+  open_picker({ "alpha" }, { "esc-preview" })
+  close_picker("<esc>")
+  eq(child.lua_get([[_G._ui_select_choice]]), vim.NIL)
+end
+
+return T


### PR DESCRIPTION
Close https://github.com/ibhagwan/fzf-lua/issues/2743


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a default `ui_select` configuration for single-select with native preview behavior.
  * Ensured the native and tmux profiles use native preview for `ui_select`.
* **Bug Fixes**
  * Improved `ui_select` preview resolution and rendering for both native and buffer modes, including safer handling when preview data is missing.
  * Improved temporary preview cleanup when the picker closes.
* **Tests**
  * Expanded `ui_select` coverage for native/tmux preview, async preview startup, empty preview regression, and abort via escape.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->