### PR TITLE
fix(buffers): assertion failed when buflist is nil

### DIFF
--- a/lua/fzf-lua/providers/buffers.lua
+++ b/lua/fzf-lua/providers/buffers.lua
@@ -216,7 +216,7 @@ M.buffers = function(opts)
   if not opts then return end
 
   local contents = function(cb)
-    local buflist = assert(utils.CTX().buflist)
+    local buflist = utils.CTX({ includeBuflist = true }).buflist
     local filtered, _, max_bufnr = filter_buffers(opts, buflist)
 
     if next(filtered) then


### PR DESCRIPTION
Problem: `contents` callback calls `utils.CTX()` without `includeBuflist`,
so if the context was recreated between `core.lua:346` (which passes
`includeBuflist=true`) and the async `contents` invocation, `buflist` is
nil and the assertion crashes. The same file already handles this at
`line 282` with `utils.CTX().buflist or {}`.

Solution: pass `{ includeBuflist = true }` explicitly, ensuring the ctx
always has `buflist` populated when accessed inside the callback.

Closes #2736


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**No user-visible changes** in this update. Internal implementation adjustments have been made to improve code reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->