### PR TITLE
fix(lsp): use current buffer path for outgoing call hierarchy items

### DIFF
--- a/lua/fzf-lua/providers/lsp.lua
+++ b/lua/fzf-lua/providers/lsp.lua
@@ -166,11 +166,13 @@ local function call_hierarchy_handler(opts, cb, _, result, ctx, _)
   for _, call_hierarchy_call in pairs(result) do
     --- "from" for incoming calls and "to" for outgoing calls
     local call_hierarchy_item = call_hierarchy_call.from or call_hierarchy_call.to
+    local is_outgoing = call_hierarchy_call.to ~= nil
     for _, range in pairs(call_hierarchy_call.fromRanges) do
       local location = {
-        uri = call_hierarchy_item.uri,
+        uri = is_outgoing and vim.uri_from_bufnr(utils.CTX().bufnr) or call_hierarchy_item.uri,
         range = range,
-        filename = vim.uri_to_fname(call_hierarchy_item.uri),
+        filename = is_outgoing and vim.api.nvim_buf_get_name(utils.CTX().bufnr)
+            or vim.uri_to_fname(call_hierarchy_item.uri),
         text = call_hierarchy_item.name,
         lnum = range.start.line + 1,
         col = range.start.character + 1,


### PR DESCRIPTION
callHierarchy/outgoingCalls returns fromRanges that refer to the *caller* file (the current buffer), while to describes the *callee*. The handler was incorrectly using to.uri for both the uri and filename fields, causing fzf-lua to display and jump to the wrong file path.

Neovim's built-in handler handles this correctly by using ctx.bufnr for outgoing calls instead of the call hierarchy item's URI.

Fix by detecting outgoing calls (call_hierarchy_call.to ~= nil) and using the current buffer's URI and filename for fromRanges.

Fixes #2746

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved call hierarchy navigation so incoming and outgoing results now point to the correct file and location.
  * Fixed cases where call hierarchy entries could open the wrong buffer when browsing relationships between symbols.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->