### PR TITLE
fix(path): convert MSYS2 Unix paths to Windows paths in git_root

### DIFF
--- a/lua/fzf-lua/path.lua
+++ b/lua/fzf-lua/path.lua
@@ -648,6 +648,18 @@ function M.git_root(opts, noerr)
     if not noerr then utils.info(table.concat(output, "\n")) end
     return nil
   end
+  -- On Windows, MSYS2's native git package outputs Unix-style paths
+  -- (e.g. /home/user/repo) rather than Windows-style paths. Use cygpath
+  -- to convert when available. Only run cygpath when the path is not
+  -- already a Windows absolute path to avoid unnecessary overhead
+  -- for users of git-for-windows (which already returns C:\... paths).
+  -- Ref: https://github.com/ibhagwan/fzf-lua/issues/2745
+  if utils.__IS_WINDOWS and not M.is_absolute(output[1]) and vim.fn.executable("cygpath") == 1 then
+    local cyg_out, rc = utils.io_systemlist({ "cygpath", "-w", output[1] })
+    if rc == 0 and cyg_out[1] then
+      return cyg_out[1]
+    end
+  end
   return output[1]
 end
 


### PR DESCRIPTION
On Windows with MSYS2, the native msys2/git package outputs Unix-style paths (e.g. /home/user/repo) from `rev-parse --show-toplevel`. Neovim's `jobstart` expects a valid Windows directory for the `cwd` option, so passing a Unix path causes
`E475: Invalid argument: expected valid directory`.

Use `cygpath -w` to convert the path when:
- We are on Windows (__IS_WINDOWS)
- The path is not already a Windows absolute path (avoids unnecessary overhead for git-for-windows users who already get C:\... paths)
- `cygpath` executable is available (vim.fn.executable == 1)

Also handle the cygpath exit code gracefully: if cygpath fails, fall back to the original path instead of returning an error string.

Fixes #2745

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Git root detection on Windows so paths returned from Git are handled more reliably.
  * Non-Windows path formats are now automatically converted to Windows-compatible paths when possible, reducing path-related issues in mixed environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->