### PR TITLE
refactor(previewer): unify git_status diff previewer commands

### DIFF
--- a/lua/fzf-lua/defaults.lua
+++ b/lua/fzf-lua/defaults.lua
@@ -310,12 +310,15 @@ M.defaults = {
     ---@class fzf-lua.config.GitDiffPreviewer: fzf-lua.config.Previewer
     git_diff = {
       pager         = M._preview_pager_fn,
-      cmd_deleted   = "git diff --color HEAD --",
-      cmd_modified  = "git diff --color HEAD",
+      -- NOTE: deleted files are handled by cmd_modified as well since
+      -- `git diff HEAD -- <file>` works for both modified and deleted.
+      -- Users can still override cmd_deleted if they wish.
+      cmd_deleted   = nil,
+      cmd_modified  = "git diff --color HEAD --",
       cmd_untracked = "git diff --color --no-index /dev/null",
       -- TODO: modify previewer code to accept table cmd
       -- cmd_deleted   = { "git", "diff", "--color", "HEAD", "--" },
-      -- cmd_modified  = { "git", "diff", "--color", "HEAD" },
+      -- cmd_modified  = { "git", "diff", "--color", "HEAD", "--" },
       -- cmd_untracked = { "git", "diff", "--color", "--no-index", "/dev/null" },
       _fn_git_icons = function() return M.globals.git.icons end,
       _ctor         = previewers.fzf.git_diff,

--- a/lua/fzf-lua/previewer/fzf.lua
+++ b/lua/fzf-lua/previewer/fzf.lua
@@ -331,7 +331,7 @@ Previewer.git_diff = Previewer.base:extend()
 ---@return fzf-lua.previewer.GitDiff
 function Previewer.git_diff:new(o, opts)
   Previewer.git_diff.super.new(self, o, opts)
-  self.cmd_deleted = path.git_cwd(o.cmd_deleted, opts)
+  self.cmd_deleted = o.cmd_deleted and path.git_cwd(o.cmd_deleted, opts) or nil
   self.cmd_modified = path.git_cwd(o.cmd_modified, opts)
   self.cmd_untracked = path.git_cwd(o.cmd_untracked, opts)
   local pager = opts.preview_pager == nil and o.pager or opts.preview_pager
@@ -384,7 +384,7 @@ function Previewer.git_diff:cmdline(o)
     if is_modified then
       cmd = self.cmd_modified
     elseif is_deleted then
-      cmd = self.cmd_deleted
+      cmd = self.cmd_deleted or self.cmd_modified
     elseif is_untracked then
       local stat = entry.path and uv.fs_stat(entry.path)
       ---@diagnostic disable-next-line: undefined-field


### PR DESCRIPTION
`git diff HEAD -- <file>` works correctly for both modified and deleted files (staged or unstaged), so we don't need separate commands.

Changes:
- defaults: set cmd_deleted to nil and add -- to cmd_modified for safety against filenames that look like options.
- previewer: when cmd_deleted is nil, fall back to cmd_modified. Users who have customized cmd_deleted in their config are unaffected.

This simplifies the defaults while preserving backward compatibility for any user overrides.

Fix #2747

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Git diff previews so deleted files now display correctly using the standard diff behavior when no custom deleted-file command is set.
  * Added a safer default for diff preview commands, helping previews work more consistently across modified and deleted files.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->