### PR TITLE
fix(types): winopts is optional

### DIFF
--- a/lua/fzf-lua/defaults.lua
+++ b/lua/fzf-lua/defaults.lua
@@ -120,7 +120,7 @@ local GREP_PERL_REGEXP = utils.is_darwin() and "--extended-regexp" or "--perl-re
 ---@field scrolloff? integer
 ---Debounce time (milliseconds) for displaying the preview buffer in the builtin previewer.
 ---@field delay? integer
----@field winopts fzf-lua.config.PreviewerWinopts Window options for the builtin previewer.
+---@field winopts? fzf-lua.config.PreviewerWinopts Window options for the builtin previewer.
 ---(skim only option), allow preview process run in pty
 ---@field pty? boolean
 


### PR DESCRIPTION
Hello,

I had a warning about missing fields for months! Time to address this ^^

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved support for preview window configuration by allowing optional window options, reducing configuration errors in some setups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->