### PR TITLE
fix(previewer/swiper): guard out-of-range buffer index in highlight_matches

### DIFF
--- a/lua/fzf-lua/previewer/swiper.lua
+++ b/lua/fzf-lua/previewer/swiper.lua
@@ -155,7 +155,8 @@ function M.base:highlight_matches()
   for r = l_s, l_e do
     (function()
       local buf_lnum = r - l_s + 2
-      local lnum, _, col_valid_idx, col_off = self:parse_lnum_col(assert(buf_lines[buf_lnum]))
+      if not buf_lines[buf_lnum] then return end
+      local lnum, _, col_valid_idx, col_off = self:parse_lnum_col(buf_lines[buf_lnum])
       if not lnum or lnum < 1 then return end
       local state = { bytelen = 0 }
       for c = 1, max_columns do


### PR DESCRIPTION
## Bug

Opening a swiper-previewer picker (`git_blame`, `blines`, `treesitter`,
`grep_curbuf`, `lsp_document_symbols`) crashes on preview when a global
`winbar` is set, spamming this on every preview/result event:

```
vim.schedule callback: .../previewer/swiper.lua:158: assertion failed!
    [C]: in function 'assert'
    .../swiper.lua:158
    .../swiper.lua:184: in function 'highlight_matches'
    .../swiper.lua:111
```

## Root cause

`highlight_matches()` builds its screen-row range from the fzf window
height and maps rows to buffer lines:

```lua
local height = vim.api.nvim_win_get_height(fzf_win)
local l_s = lines - height - off + 1
```

local buf_lnum = r - l_s + 2
local lnum = self:parse_lnum_col(assert(buf_lines[buf_lnum]))

nvim_win_get_height includes the winbar row, but that row has no entry
in buf_lines, so the range is one longer than the buffer. The last
iteration hits buf_lines[buf_lnum] == nil and the hard assert aborts
the deferred callback.

## Fix

Skip rows without a backing buffer line instead of asserting — mirrors
the if not lnum ... return guard immediately below, and such a row has
nothing to highlight anyway.

local buf_lnum = r - l_s + 2
if not buf_lines[buf_lnum] then return end
local lnum = self:parse_lnum_col(buf_lines[buf_lnum])
nothing to highlight anyway.

local buf_lnum = r - l_s + 2
if not buf_lines[buf_lnum] then return end
local lnum = self:parse_lnum_col(buf_lines[buf_lnum])

## Reproduce

```lua
vim.o.winbar = ' '                       -- any non-empty global winbar
require('fzf-lua').setup()      
-- :lua require('fzf-lua').git_blame({profile="ivy"})   -- move the cursor -> crash
```

With winbar unset (or without the ivy profile, which is what routes
git_blame through swiper) the range matches the buffer and the crash
does not occur.

### screenshot of minimal repro

<img width="1455" height="1253" alt="screenshot-2026-07-01_23-15-02" src="https://github.com/user-attachments/assets/6212b6c1-3d20-4aa4-8320-a49562dca396" />

