### PR TITLE
fix: soft deprecated ui_select=true

### DIFF
--- a/lua/fzf-lua/init.lua
+++ b/lua/fzf-lua/init.lua
@@ -220,6 +220,10 @@ function M.setup(opts, do_not_reset_defaults)
   M.setup_highlights()
   -- opt-in register ui.select via setup
   if opts.ui_select then
+    if type(opts.ui_select) == "boolean" then -- back compat #2768
+      opts.ui_select = opts.ui_select and {} or nil
+      vim.deprecate("ui_select = true", "ui_select = {}", "Jan 2027", "FzfLua")
+    end
     M.register_ui_select((type(opts.ui_select) == "table" or type(opts.ui_select) == "function")
       and opts.ui_select or nil,
       true) -- silent


### PR DESCRIPTION
Fix https://github.com/ibhagwan/fzf-lua/issues/2768


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved backward compatibility for the `ui_select` configuration.
  - `ui_select = true` is now treated as an enabled empty configuration, while `ui_select = false` cleanly disables the option.
  - Added a deprecation warning encouraging the newer `ui_select = {}` format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->