### PR TITLE
fix(ui_select): restore callable opts (fix #2770)

### DIFF
--- a/lua/fzf-lua/providers/ui_select.lua
+++ b/lua/fzf-lua/providers/ui_select.lua
@@ -102,6 +102,15 @@ M.ui_select = function(items, ui_opts, on_choice)
 
   local opts = _OPTS or {}
 
+  -- enables customization per kind (#755): the registered opts can be a
+  -- function that returns an opts table based on the `ui_opts` (kind,
+  -- prompt, etc.) and the `items` being selected. `config.normalize_opts`
+  -- calls function opts with no args, so resolve the function here first
+  -- to preserve the historical `opts(ui_opts, items)` signature (#2770).
+  if vim.is_callable(opts) then
+    opts = opts(ui_opts, items)
+  end
+
   opts = config.normalize_opts(opts, "ui_select")
   if not opts then return end
 

--- a/tests/ui_select_spec.lua
+++ b/tests/ui_select_spec.lua
@@ -149,4 +149,26 @@ T["ui_select"]["abort via esc"] = function()
   eq(child.lua_get([[_G._ui_select_choice]]), vim.NIL)
 end
 
+T["ui_select"]["registered function opts receive (ui_opts, items) #2770"] = function()
+  reload({ "default" })
+  -- `config.normalize_opts` calls function opts with no args; the wrapper
+  -- in `M.ui_select` must resolve the function with `(ui_opts, items)`
+  -- before normalizing, preserving the documented interface (#755).
+  exec_lua([[
+    FzfLua.register_ui_select(function(fzf_opts, items)
+      _G._ui_select_args = {
+        kind = fzf_opts.kind,
+        prompt = fzf_opts.prompt,
+        nitems = #items,
+      }
+      return {}
+    end)
+  ]])
+  open_picker({ "alpha", "beta" }, { "preview-line-1", "preview-line-2" },
+    { prompt = "Pick (fn):", kind = "codeaction" })
+  close_picker("<esc>")
+  eq(child.lua_get([[_G._ui_select_args]]),
+    { kind = "codeaction", prompt = "Pick (fn):", nitems = 2 })
+end
+
 return T


### PR DESCRIPTION
@dpetka, can you test and lmk if this solves your issue?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated `ui_select` to correctly handle function-based option values by resolving them with `(ui_opts, items)` before applying the options.
  * Ensured registered function-based options still receive the expected arguments, preserving custom `prompt` and `kind`.

* **Tests**
  * Added a test covering function-based `ui_select` options to confirm the callback receives `(ui_opts, items)` and that item counts and fields are passed through correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->