### PR TITLE
emmylua_check as main linter

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        rev: [nightly, v0.12.2, puc-lua]
+        rev: [nightly, stable, puc-lua]
         exclude:
           - os: macos-latest
             rev: puc-lua
@@ -36,11 +36,11 @@ jobs:
           - os: ubuntu-latest
             install-deps: |
               sudo apt-get update && sudo apt-get install -y ripgrep fd-find
-              wget -O - https://github.com/junegunn/fzf/releases/download/v0.67.0/fzf-0.67.0-linux_amd64.tar.gz | tar zxfv -
+              wget -O - https://github.com/junegunn/fzf/releases/download/v0.74.0/fzf-0.74.0-linux_amd64.tar.gz | tar zxfv -
               sudo mv ./fzf /bin
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0 # full clone to test on pinned sha
 

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -26,33 +26,25 @@ jobs:
           neovim: true
           version: nightly
 
-      - name: Install lua-language-server
+      # - name: Install lua-language-server
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #   run: |
+      #     cd
+      #     gh release download 3.16.4 -R sumneko/lua-language-server -p '*-linux-x64.tar.gz' -D lua-language-server
+      #     tar xzf lua-language-server/* -C lua-language-server
+      #     echo "${PWD}/lua-language-server/bin" >> $GITHUB_PATH
+      #     export PATH="${PWD}/lua-language-server/bin:${PATH}"
+      #     lua-language-server --version
+
+      - name: Install emmylua_check
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          cd
-          gh release download 3.16.4 -R sumneko/lua-language-server -p '*-linux-x64.tar.gz' -D lua-language-server
-          tar xzf lua-language-server/* -C lua-language-server
-          echo "${PWD}/lua-language-server/bin" >> $GITHUB_PATH
-          export PATH="${PWD}/lua-language-server/bin:${PATH}"
-          lua-language-server --version
-
-      - name: Install rust toolchain
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: stable
-
-      - name: Install emmylua_check
-        uses: baptiste0928/cargo-install@v3
-        with:
-          crate: emmylua_check
-          git: https://github.com/EmmyLuaLs/emmylua-analyzer-rust
-          commit: 7c96abd684c3d840719c0d9d24ada5e5b1b81288
-          cache-key: emmylua-check-v1
+          make deps/emmylua_check
 
       - name: Lint
         run: |
           export XDG_DATA_HOME="$HOME/.local/share"
           make deps
-          make lint
           make emmylua-check

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -37,11 +37,11 @@ jobs:
       #     export PATH="${PWD}/lua-language-server/bin:${PATH}"
       #     lua-language-server --version
 
-      - name: Install emmylua_check
+      - name: Install Emmylua
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          make deps/emmylua_check
+          make deps/emmylua
 
       - name: Lint
         run: |

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -16,7 +16,7 @@ jobs:
           sudo ln -s /usr/lib/x86_64-linux-gnu/libbfd-2.42-system.so /usr/lib/x86_64-linux-gnu/libbfd-2.38-system.so
 
       - name: checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0 # full clone to test on pinned sha
 

--- a/.github/workflows/luarocks-release.yaml
+++ b/.github/workflows/luarocks-release.yaml
@@ -8,7 +8,7 @@ jobs:
   luarocks-upload:
     runs-on: ubuntu-slim
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Set LuaRocks version

--- a/.github/workflows/sync_remote.yaml
+++ b/.github/workflows/sync_remote.yaml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-slim
     if: github.repository == 'ibhagwan/fzf-lua'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Sync remote repositories

--- a/.github/workflows/vimdoc.yaml
+++ b/.github/workflows/vimdoc.yaml
@@ -8,7 +8,7 @@ jobs:
   generate-docs:
     runs-on: ubuntu-slim
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - uses: rhysd/action-setup-vim@v1

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 doc/tags
 deps/
+.emmylua/

--- a/.luafmt.toml
+++ b/.luafmt.toml
@@ -1,0 +1,112 @@
+#
+#  https://github.com/EmmyLuaLs/emmylua-analyzer-rust/blob/main/docs/emmylua_formatter/options_EN.md
+#
+level = "Lua51"
+
+[indent]
+# Use spaces instead of tabs for indentation.
+kind = "Space"
+# Number of spaces per indentation level.
+width = 2
+
+[layout]
+# Maximum line width before breaking. Matches .editorconfig's max_line_length.
+max_line_width = 100
+# Single new line between functions/statements.
+max_blank_lines = 1
+# Auto-expand multiline arrays/tables when they exceed line width.
+# Matches .editorconfig's trailing_table_separator = keep (avoids collapsing).
+table_expand = "Auto"
+# Never auto-expand call arguments into multiple lines.
+# Matches .editorconfig call_arg_parentheses = which keeps them as-is).
+call_args_expand = "Never"
+# Prefer multiline breaking for fluent method chains in statements.
+# Matches .editorconfig style of keeping chain breaks on the tail of a statement.
+prefer_chain_break_on_statement_tail = true
+# Keep existing multiline array/table layout when the source already shows it.
+# Helps avoid collapsing multi-line arrays/tables.
+prefer_table_layout_from_source = true
+
+[spacing]
+# Do NOT add a space before function definition parentheses.
+# Matches .editorconfig's space_before_function_open_parenthesis = false
+# and space_before_closure_open_parenthesis = false.
+space_before_func_paren = false
+# Do NOT add a space before anonymous function/closure parentheses.
+# Matches .editorconfig's space_before_closure_open_parenthesis = false.
+space_before_lambda_func_paren = false
+# Do NOT add a space before method/function call parentheses.
+# Matches .editorconfig's space_before_function_call_open_parenthesis = false.
+space_before_call_paren = false
+# Add a space inside table braces (e.g., `{ a = 1 }`).
+# Matches .editorconfig's space_around_table_field_list = true.
+space_inside_braces = true
+# Do NOT add spaces inside call/list parentheses.
+# Matches .editorconfig's space_inside_function_call_parentheses = false
+# and space_inside_function_param_list_parentheses = false.
+space_inside_parens = false
+# Do NOT add spaces inside square brackets.
+# Matches .editorconfig's space_inside_square_brackets = false.
+space_inside_brackets = false
+# Add spaces around math operators (+, -, *, /, etc.).
+# Matches .editorconfig's space_around_math_operator = true.
+space_around_math_operator = true
+# Add spaces around string concatenation operator (..).
+# Matches .editorconfig's space_around_concat_operator = true.
+space_around_concat_operator = true
+# Add spaces around assignment operators (=, +=, etc.).
+# Matches .editorconfig behavior.
+space_around_assign_operator = true
+
+[comments]
+# Align line comments that appear at the end of lines.
+# Matches .editorconfig's align_continuous_inline_comment = true.
+align_line_comments = true
+# Do NOT align trailing comments in statements.
+align_in_statements = false
+# Align trailing comments in table fields.
+# Matches .editorconfig's align_continuous_rect_table_field = true.
+align_in_table_fields = true
+# Align trailing comments in function parameters.
+# Matches .editorconfig's align_function_params = true.
+align_in_params = true
+# Align trailing comments in call arguments.
+# Matches .editorconfig's align_call_args = true.
+align_in_call_args = true
+# Disable adding a space after the comment dash prefix.
+# This prevents --[[ block comments from being corrupted into
+# -- [[ (which breaks the block comment syntax).  Note that
+# plain comments such as "--comment" will no longer be
+# auto-corrected to "-- comment".
+# space_after_comment_dash = false
+
+[emmy_doc]
+# Disable aligning EmmyLua @param/@return type columns.
+# Old formatting did not align param/return types.
+align_declaration_tags = false
+# Disable aligning all EmmyLua tag columns.
+# Old formatting did not align tag columns.
+align_tag_columns = false
+
+[align]
+# Disable aligning continuous assignment statements.
+# Matches .editorconfig's align_continuous_assign_statement = false
+# (disabled in the new formatter by default, kept explicit here).
+continuous_assign_statement = false
+# Align table fields when the source shows alignment intent.
+# Matches .editorconfig's align_continuous_rect_table_field = true.
+table_field = true
+
+[output]
+# Always use double quotes for short strings (single quotes otherwise).
+# Matches .editorconfig's quote_style = double.
+quote_style = "Double"
+# Keep trailing commas for multiline tables/arrays.
+# Matches .editorconfig's trailing_table_separator = keep.
+trailing_comma = "Multiline"
+# Always keep the final newline.
+# Matches .editorconfig's insert_final_newline = true.
+insert_final_newline = true
+# Keep single-argument call parentheses.
+# Matches .editorconfig's call_arg_parentheses = keep (don't strip them).
+single_arg_call_parens = "Preserve"

--- a/Makefile
+++ b/Makefile
@@ -57,34 +57,52 @@ deps/fzf-lua:
 	git clone .git $@
 	(cd $@ && git checkout $(SHA))
 
-# Download the emmylua_check linter from upstream if `gh` is
-# available and `emmylua_check` is not already on the system PATH.
-# The binary is extracted into deps/emmylua_check/emmylua_check.
-EMMY_CHECK_DIR=.emmylua
-EMMY_CHECK_BIN=$(EMMY_CHECK_DIR)/emmylua_check
-# Pin the emmylua_check release tag to download. Set to an empty
-# string (EMMY_CHECK_VERSION=) to fetch the latest release instead.
-EMMY_CHECK_VERSION=0.23.1
-# OS arch detection. Falls back to linux-x64 on unknown platforms;
-# override by passing EMMY_CHECK_ASSET=<asset filename> on the make
-# command line.
+# Download the emmylua binaries (emmylua_check + luafmt) from upstream
+# if `gh` is available and they are not already on the system PATH.
+# Binaries are extracted into .emmylua/.
+EMMYLUA_DIR=.emmylua
+EMMY_CHECK_BIN=$(EMMYLUA_DIR)/emmylua_check
+LUA_FMT_BIN=$(EMMYLUA_DIR)/luafmt
+# Pin the emmylua release tag to download. Set to an empty
+# string (EMMYLUA_VERSION=) to fetch the latest release instead.
+EMMYLUA_VERSION=0.23.1
+# OS arch detection for emmylua_check. Falls back to linux-x64 on
+# unknown platforms; override by passing EMMY_CHECK_ASSET=<asset
+# filename> on the make command line.
 EMMY_CHECK_ASSET=$(strip \
 	$(if $(filter Darwin darwin,$(shell uname -s 2>/dev/null)),emmylua_check-darwin-x64.tar.gz,emmylua_check-linux-x64.tar.gz))
-.PHONY: deps/emmylua_check
-deps/emmylua_check:
-	@if [ -x "$(EMMY_CHECK_BIN)" ] || command -v emmylua_check >/dev/null 2>&1; then \
-		: ; \
-	elif command -v gh >/dev/null 2>&1; then \
-		mkdir -p $(EMMY_CHECK_DIR) ; \
-		echo "Downloading emmylua_check $(if $(EMMY_CHECK_VERSION),v$(EMMY_CHECK_VERSION),latest) [$(EMMY_CHECK_ASSET)]..." ; \
+# OS arch detection for luafmt. Falls back to linux-x64 on unknown
+# platforms; override by passing LUA_FMT_ASSET=<asset filename> on
+# the make command line.
+LUA_FMT_ASSET=$(strip \
+	$(if $(filter Darwin darwin,$(shell uname -s 2>/dev/null)),luafmt-darwin-x64.tar.gz,luafmt-linux-x64.tar.gz))
+
+.PHONY: deps/emmylua
+deps/emmylua:
+	@mkdir -p $(EMMYLUA_DIR) ; \
+	if [ ! -x "$(EMMY_CHECK_BIN)" ] && ! command -v emmylua_check >/dev/null 2>&1; then \
+		if ! command -v gh >/dev/null 2>&1; then \
+			echo "gh is required to download emmylua_check" >&2 ; \
+			exit 1 ; \
+		fi ; \
+		echo "Downloading emmylua_check $(if $(EMMYLUA_VERSION),v$(EMMYLUA_VERSION),latest) [$(EMMY_CHECK_ASSET)]..." ; \
 		gh release download -R EmmyLuaLs/emmylua-analyzer-rust \
-			$(if $(EMMY_CHECK_VERSION),"$(EMMY_CHECK_VERSION)") \
-			-p "$(EMMY_CHECK_ASSET)" -D $(EMMY_CHECK_DIR) && \
-		tar xzf "$(EMMY_CHECK_DIR)/$(EMMY_CHECK_ASSET)" -C $(EMMY_CHECK_DIR) && \
-		rm -f "$(EMMY_CHECK_DIR)/$(EMMY_CHECK_ASSET)" ; \
-	else \
-		echo "gh is required to download emmylua_check" >&2 ; \
-		exit 1 ; \
+			$(if $(EMMYLUA_VERSION),"$(EMMYLUA_VERSION)") \
+			-p "$(EMMY_CHECK_ASSET)" -D $(EMMYLUA_DIR) && \
+		tar xzf "$(EMMYLUA_DIR)/$(EMMY_CHECK_ASSET)" -C $(EMMYLUA_DIR) && \
+		rm -f "$(EMMYLUA_DIR)/$(EMMY_CHECK_ASSET)" ; \
+	fi ; \
+	if [ ! -x "$(LUA_FMT_BIN)" ] && ! command -v luafmt >/dev/null 2>&1; then \
+		if ! command -v gh >/dev/null 2>&1; then \
+			echo "gh is required to download luafmt" >&2 ; \
+			exit 1 ; \
+		fi ; \
+		echo "Downloading luafmt $(if $(EMMYLUA_VERSION),v$(EMMYLUA_VERSION),latest) [$(LUA_FMT_ASSET)]..." ; \
+		gh release download -R EmmyLuaLs/emmylua-analyzer-rust \
+			$(if $(EMMYLUA_VERSION),"$(EMMYLUA_VERSION)") \
+			-p "$(LUA_FMT_ASSET)" -D $(EMMYLUA_DIR) && \
+		tar xzf "$(EMMYLUA_DIR)/$(LUA_FMT_ASSET)" -C $(EMMYLUA_DIR) && \
+		rm -f "$(EMMYLUA_DIR)/$(LUA_FMT_ASSET)" ; \
 	fi
 
 .PHONY: lint
@@ -93,7 +111,7 @@ lint:
 		lua-language-server --configpath=../.luarc.jsonc --check=.
 
 .PHONY: emmylua-check
-emmylua-check: | deps/emmylua_check
+emmylua-check: | deps/emmylua
 	@if [ -x "$(EMMY_CHECK_BIN)" ]; then \
 		EMMY="$(EMMY_CHECK_BIN)" ; \
 	else \
@@ -101,6 +119,23 @@ emmylua-check: | deps/emmylua_check
 	fi ; \
 	VIMRUNTIME="$$(nvim --clean --headless +'echo $$VIMRUNTIME' +q 2>&1)" \
 		$$EMMY . --ignore 'deps/**/*' --warnings-as-errors
+
+.PHONY: fmt fmtcheck
+fmt: | deps/emmylua
+	@if [ -x "$(LUA_FMT_BIN)" ]; then \
+		FMT="$(LUA_FMT_BIN)" ; \
+	else \
+		FMT="luafmt" ; \
+	fi ; \
+	$$FMT --config .luafmt.toml --write --recursive ./lua ./tests
+
+fmtcheck: | deps/emmylua
+	@if [ -x "$(LUA_FMT_BIN)" ]; then \
+		FMT="$(LUA_FMT_BIN)" ; \
+	else \
+		FMT="luafmt" ; \
+	fi ; \
+	$$FMT --config .luafmt.toml --check --recursive ./lua ./tests
 
 gen:
 	nvim --clean -l lua/fzf-lua/init.lua

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,11 @@ deps:
 	git clone --depth=1 --single-branch https://github.com/mfussenegger/nvim-dap.git deps/nvim-dap
 
 
-# Target to clone the repository and checkout the specific SHA
+# Target to clone the repository and checkout the specific SHA.
+# Pinning a fixed SHA ensures that fzf test screenshots remain
+# deterministic — the screenshots include total file counts and
+# file ordering, both of which would change if the working tree's
+# current state (or different commits) were used instead.
 SHA=abe5ecafebb4e24feb162384d5f492431036e791
 .PHONY: deps/fzf-lua
 deps/fzf-lua:
@@ -53,15 +57,50 @@ deps/fzf-lua:
 	git clone .git $@
 	(cd $@ && git checkout $(SHA))
 
+# Download the emmylua_check linter from upstream if `gh` is
+# available and `emmylua_check` is not already on the system PATH.
+# The binary is extracted into deps/emmylua_check/emmylua_check.
+EMMY_CHECK_DIR=.emmylua
+EMMY_CHECK_BIN=$(EMMY_CHECK_DIR)/emmylua_check
+# Pin the emmylua_check release tag to download. Set to an empty
+# string (EMMY_CHECK_VERSION=) to fetch the latest release instead.
+EMMY_CHECK_VERSION=0.23.1
+# OS arch detection. Falls back to linux-x64 on unknown platforms;
+# override by passing EMMY_CHECK_ASSET=<asset filename> on the make
+# command line.
+EMMY_CHECK_ASSET=$(strip \
+	$(if $(filter Darwin darwin,$(shell uname -s 2>/dev/null)),emmylua_check-darwin-x64.tar.gz,emmylua_check-linux-x64.tar.gz))
+.PHONY: deps/emmylua_check
+deps/emmylua_check:
+	@if [ -x "$(EMMY_CHECK_BIN)" ] || command -v emmylua_check >/dev/null 2>&1; then \
+		: ; \
+	elif command -v gh >/dev/null 2>&1; then \
+		mkdir -p $(EMMY_CHECK_DIR) ; \
+		echo "Downloading emmylua_check $(if $(EMMY_CHECK_VERSION),v$(EMMY_CHECK_VERSION),latest) [$(EMMY_CHECK_ASSET)]..." ; \
+		gh release download -R EmmyLuaLs/emmylua-analyzer-rust \
+			$(if $(EMMY_CHECK_VERSION),"$(EMMY_CHECK_VERSION)") \
+			-p "$(EMMY_CHECK_ASSET)" -D $(EMMY_CHECK_DIR) && \
+		tar xzf "$(EMMY_CHECK_DIR)/$(EMMY_CHECK_ASSET)" -C $(EMMY_CHECK_DIR) && \
+		rm -f "$(EMMY_CHECK_DIR)/$(EMMY_CHECK_ASSET)" ; \
+	else \
+		echo "gh is required to download emmylua_check" >&2 ; \
+		exit 1 ; \
+	fi
+
 .PHONY: lint
 lint:
-	VIMRUNTIME="$$(nvim --clean --headless +'echo $$VIMRUNTIME' +q 2>&1)" lua-language-server --configpath=../.luarc.jsonc --check=.
+	VIMRUNTIME="$$(nvim --clean --headless +'echo $$VIMRUNTIME' +q 2>&1)" \
+		lua-language-server --configpath=../.luarc.jsonc --check=.
 
 .PHONY: emmylua-check
-emmylua-check:
+emmylua-check: | deps/emmylua_check
+	@if [ -x "$(EMMY_CHECK_BIN)" ]; then \
+		EMMY="$(EMMY_CHECK_BIN)" ; \
+	else \
+		EMMY="emmylua_check" ; \
+	fi ; \
 	VIMRUNTIME="$$(nvim --clean --headless +'echo $$VIMRUNTIME' +q 2>&1)" \
-		emmylua_check . \
-			--ignore 'deps/**/*'
+		$$EMMY . --ignore 'deps/**/*' --warnings-as-errors
 
 gen:
 	nvim --clean -l lua/fzf-lua/init.lua

--- a/lua/fzf-lua/_health.lua
+++ b/lua/fzf-lua/_health.lua
@@ -110,7 +110,7 @@ function M.check()
   if vim.env.FZF_DEFAULT_OPTS == nil then
     ok("`FZF_DEFAULT_OPTS` is not set")
   else
-    ok("`$FZF_DEFAULT_OPTS` is set to:\n" .. M.format(vim.env.FZF_DEFAULT_OPTS))
+    ok("`$FZF_DEFAULT_OPTS` is set to:\n" .. M.format(vim.env.FZF_DEFAULT_OPTS --[[@as string]]))
   end
   if vim.env.FZF_DEFAULT_OPTS_FILE == nil then
     ok("`FZF_DEFAULT_OPTS_FILE` is not set")

--- a/lua/fzf-lua/actions.lua
+++ b/lua/fzf-lua/actions.lua
@@ -6,8 +6,8 @@ local path = require "fzf-lua.path"
 local libuv = require "fzf-lua.libuv"
 
 ---@class fzf-lua.actions
----@field expect fun(actions: table, opts: fzf-lua.config.Resolved|{}):string[]?, string[]?
----@field [string] fun(items: string[], opts: fzf-lua.config.Resolved|{}):any
+---@field expect fun(actions: table, opts: fzf-lua.config.Resolved):string[]?, string[]?
+---@field [string] fun(items: string[], opts: fzf-lua.config.Resolved):any
 local M = {}
 
 -- return fzf '--expect=' string from actions keyval tbl
@@ -62,13 +62,14 @@ M.expect = function(actions, opts)
 end
 
 ---@param selected string[]
----@param opts fzf-lua.config.Resolved|{}
+---@param opts fzf-lua.config.Resolved
 ---@return string?, string[]?
 M.normalize_selected = function(selected, opts)
   -- The below separates the keybind from the item(s)
   -- and makes sure 'selected' contains only item(s) or {}
   -- so it can always be enumerated safely
   if not selected then return end
+  ---@diagnostic disable-next-line: unnecessary-assert
   local actions = assert(opts.actions)
   -- Backward compat, "default" action trumps "enter"
   if actions.default then actions.enter = actions.default end
@@ -202,7 +203,7 @@ end
 
 ---@param vimcmd string?
 ---@param selected string[]
----@param opts fzf-lua.config.Resolved|{}
+---@param opts fzf-lua.config.Resolved
 ---@param bufedit boolean?
 ---@return string?
 M.vimcmd_entry = function(vimcmd, selected, opts, bufedit)
@@ -343,6 +344,7 @@ local sel_to_qf = function(selected, opts, is_loclist)
 end
 
 M.list_del = function(selected, opts)
+  ---@diagnostic disable-next-line: unnecessary-assert
   local winid = assert(opts.__CTX.winid)
   local list = opts.is_loclist and vim.fn.getloclist(winid) or vim.fn.getqflist()
   local bufs = vim.tbl_map(function(s) return tonumber(s:match("%[(%d+)%]")) end, selected)
@@ -561,6 +563,7 @@ end
 ---@param opts fzf-lua.config.CommandHistory|{}
 local hist_del = function(kind, selected, opts)
   if not vim.iter then return end
+  ---@diagnostic disable-next-line: redundant-parameter, call-non-callable
   local iter = opts.reverse_list and vim.iter(selected) or vim.iter(selected):rev()
   iter:each(function(e)
     local idx = assert(utils.tointeger(opts.reverse_list and e or -e - 1))
@@ -631,8 +634,9 @@ M.goto_jump = function(selected, opts)
     if not ok then
       filepath = ""
     else
-      filepath = res
+      filepath = res --[[@as string]]
     end
+    ---@diagnostic disable-next-line: param-type-mismatch, missing-parameter
     if not filepath or not uv.fs_stat(filepath) then
       -- no accessible file
       -- jump is in current
@@ -655,6 +659,7 @@ for _, fname in ipairs({ "edit", "split", "vsplit", "tabedit" }) do
   ---@param opts fzf-lua.config.Resolved
   M["keymap_" .. fname] = function(selected, opts)
     if not selected[1] then return end
+    ---@diagnostic disable-next-line: redundant-parameter
     local entry = path.keymap_to_entry(selected[1], opts)
     if entry.path then
       M["file_" .. fname]({ entry.stripped }, opts)
@@ -753,9 +758,11 @@ local function helptags(s, opts)
     local entry = path.entry_to_file(x, opts)
     if entry and entry.path and package.loaded.lazy then
       -- make sure the plugin is loaded. This won't do anything if already loaded
+      ---@diagnostic disable-next-line: unresolved-require
       local lazyConfig = require("lazy.core.config")
       local _, plugin = path.normalize(entry.path):match("(/([^/]+)/doc/)")
       if plugin and lazyConfig.plugins[plugin] then
+        ---@diagnostic disable-next-line: unresolved-require
         require("lazy").load({ plugins = { plugin } })
       end
     end
@@ -872,6 +879,7 @@ M.git_branch_add = function(selected, opts)
   -- so the prompt input will be found in `selected[1]`
   -- previous fzf versions (or skim) restart the process instead
   -- so the prompt input will be found in `opts.last_query`
+  ---@diagnostic disable-next-line: undefined-field
   local branch = selected[1] or opts.last_query
   if type(branch) ~= "string" or #branch == 0 then
     utils.warn("Branch name cannot be empty, use prompt for input.")
@@ -1119,7 +1127,7 @@ M.git_buf_edit = function(selected, opts)
   -- `fn_match_file` lets a provider (e.g. bcommits `follow`) resolve the path the
   -- buffer had at the selected commit; otherwise fall back to the current name.
   local file = type(opts.fn_match_file) == "function" and opts.fn_match_file(selected[1], opts)
-      or path.relative_to(path.normalize(vim.fn.expand("%:p")), git_root)
+      or path.relative_to(path.normalize(vim.fn.expand("%:p") --[[@as string]]), git_root)
   local commit_hash = match_commit_hash(selected[1], opts)
   table.insert(cmd, commit_hash .. ":" .. file)
   local git_file_contents = utils.io_systemlist(cmd)
@@ -1162,7 +1170,7 @@ M.grep_lgrep = function(_, opts)
     __resume_key = opts.__resume_key,
     rg_glob = opts.rg_glob or opts.__call_opts.rg_glob,
     -- globs always require command processing with 'multiprocess'
-    multiprocess = opts.multiprcess and (opts.rg_glob or opts.__call_opts.rg_glob) and 1,
+    multiprocess = opts.multiprocess and (opts.rg_glob or opts.__call_opts.rg_glob) and 1,
     -- when used with tags pass the resolved ctags_file from tags-option as
     -- `tagfiles()` might not return the correct file called from the float (#700)
     ctags_file = opts.ctags_file,
@@ -1179,13 +1187,14 @@ M.toggle_flag = function(_, opts)
   local o = vim.tbl_deep_extend("keep", {
     -- grep|live_grep sets `opts._cmd` to the original
     -- command without the search argument
+    ---@diagnostic disable-next-line: param-type-mismatch
     cmd = utils.toggle_cmd_flag(assert(opts._cmd or opts.cmd), assert(opts.toggle_flag)),
     resume = true
   }, opts.__call_opts or {})
   opts.__call_fn(o)
 end
 
----@param opts fzf-lua.config.Resolved|{}
+---@param opts fzf-lua.config.Resolved
 ---@param opt_name string
 M.toggle_opt = function(opts, opt_name)
   -- opts.__call_opts[opt_name] = not opts[opt_name]
@@ -1224,7 +1233,7 @@ end
 M.paste_register = function(selected)
   if not selected[1] then return end
   local reg = selected[1]:match("%[(.-)%]")
-  local data = vim.fn.getreg(reg)
+  local data = vim.fn.getreg(reg) --[[@as string]]
   if #data > 0 then vim.api.nvim_paste(data, false, -1) end
 end
 
@@ -1335,6 +1344,7 @@ local parse_entry = function(e)
 end
 
 M.serverlist_kill = function(sel)
+  ---@diagnostic disable-next-line: redundant-parameter, call-non-callable
   vim.iter(sel):map(parse_entry):each(function(addr)
     local ok, err = utils.rpcexec(addr, "nvim_exec2", "qa!", {})
     assert(ok
@@ -1345,8 +1355,9 @@ M.serverlist_kill = function(sel)
 end
 
 M.serverlist_spawn = function()
-  libuv.uv_spawn(
-    vim.fn.exepath("nvim"), { args = { "--headless" }, env = { NVIM = "" }, detached = true })
+  libuv.uv_spawn(vim.fn.exepath("nvim"),
+    ---@diagnostic disable-next-line: missing-parameter, assign-type-mismatch
+    { args = { "--headless" }, env = { NVIM = "" }, detached = true })
 end
 
 M.serverlist_connect = function(sel)

--- a/lua/fzf-lua/cmd.lua
+++ b/lua/fzf-lua/cmd.lua
@@ -80,6 +80,7 @@ end
 
 function M._candidates(line, cmp_items)
   local function to_cmp_items(t, data)
+    ---@diagnostic disable-next-line: unresolved-require
     local cmp = require("cmp")
     return vim.tbl_map(function(v)
       return {

--- a/lua/fzf-lua/complete.lua
+++ b/lua/fzf-lua/complete.lua
@@ -23,8 +23,8 @@ local function find_toplevel_cwd(maybe_cwd, postfix, orig_cwd)
   if not orig_cwd then
     orig_cwd = maybe_cwd
   end
-  if vim.fn.isdirectory(libuv.expand(maybe_cwd)) == 1 then
-    local disp_cwd, cwd = maybe_cwd, libuv.expand(maybe_cwd)
+  if vim.fn.isdirectory(libuv.expand(maybe_cwd) --[[@as string]]) == 1 then
+    local disp_cwd, cwd = maybe_cwd, libuv.expand(maybe_cwd) --[[@as string]]
     -- returned cwd must be full path
     if path.has_cwd_prefix(cwd) then
       cwd = utils.cwd() .. (#cwd > 1 and cwd:sub(2) or "")

--- a/lua/fzf-lua/config.lua
+++ b/lua/fzf-lua/config.lua
@@ -144,6 +144,7 @@ do
   -- used by M.globals.__index and M.defaults.<provider>._actions
   local m = require("fzf-lua.defaults")
   M.defaults = m.defaults
+  ---@diagnostic disable-next-line: inject-field
   m.globals = M.globals
 end
 

--- a/lua/fzf-lua/core.lua
+++ b/lua/fzf-lua/core.lua
@@ -117,6 +117,7 @@ local contents_from_arr = function(cont_arr)
     return function(fzf_cb)
       coroutine.wrap(function()
         local co = coroutine.running()
+        ---@cast co thread
         for _, t in ipairs(cont_arr) do
           assert(type(t.contents) == cont_type, "Unable to combine contents of different types")
           local is_async = true
@@ -212,7 +213,9 @@ end
 ---@return thread?, string?, table?
 M.fzf_live = function(contents, opts)
   ---@type fzf-lua.config.Resolved
+  ---@diagnostic disable-next-line: assign-type-mismatch
   opts = opts or {}
+  ---@cast opts fzf-lua.config.Resolved
   opts.is_live = true
   opts = config.normalize_opts(opts, {})
   if not opts then return end
@@ -220,6 +223,7 @@ M.fzf_live = function(contents, opts)
   local cmd ---@type string
   local is_fnc = type(contents) == "function"
   if is_fnc and M.can_transform(opts) then
+    ---@diagnostic disable-next-line: call-non-callable
     cmd = shell.stringify_data(function(items) return contents(items, opts) end, opts,
       fzf_field_index)
   else
@@ -252,6 +256,7 @@ M.fzf_resume = function(opts)
   -- resume a picker when using "hide" and no_resume=true (#2425)
   local query = utils.map_get(opts, opts.is_live and "__call_opts.search" or "__call_opts.query")
   if query and #query > 0 then opts.query = query end
+  ---@diagnostic disable-next-line: unnecessary-assert
   M.fzf_wrap(assert(config.__resume_data.contents), config.__resume_data.opts)
 end
 
@@ -260,11 +265,17 @@ end
 ---@param convert_actions boolean?
 ---@return thread?, string, table
 M.fzf_wrap = function(cmd, opts, convert_actions)
+  ---@diagnostic disable-next-line: assign-type-mismatch
   opts = opts or {}
+  ---@cast opts fzf-lua.config.Resolved
   M.set_header(opts)
   if convert_actions and type(opts.actions) == "table" then
+    ---@diagnostic disable-next-line: assign-type-mismatch
     opts = M.convert_reload_actions(cmd, opts)
+    ---@cast opts fzf-lua.config.Resolved
+    ---@diagnostic disable-next-line: assign-type-mismatch
     opts = M.convert_exec_silent_actions(opts)
+    ---@cast opts fzf-lua.config.Resolved
   end
   -- Do not strt fzf, return the stringified contents and opts onlu
   -- used by the "combine" picker to merge inputs
@@ -272,6 +283,7 @@ M.fzf_wrap = function(cmd, opts, convert_actions)
   local _co, fn_selected
   coroutine.wrap(function()
     _co = coroutine.running()
+    ---@cast _co thread
     -- xpcall to get full traceback https://www.lua.org/pil/8.5.html
     local xpcall = jit and xpcall or
         (utils.__HAS_NVIM_010 and require("coxpcall") or require("fzf-lua.lib.copcall")).xpcall
@@ -298,7 +310,7 @@ M.fzf_wrap = function(cmd, opts, convert_actions)
 end
 
 ---@param contents string?
----@param opts? fzf-lua.config.Resolved|{}
+---@param opts? fzf-lua.config.Resolved
 ---@return string[]?
 ---@return integer? exit_code
 M.fzf = function(contents, opts)
@@ -310,7 +322,9 @@ M.fzf = function(contents, opts)
   end
   -- normalize with globals if not already normalized
   ---@type fzf-lua.config.Resolved
+  ---@diagnostic disable-next-line: assign-type-mismatch
   opts = config.normalize_opts(opts or {}, {})
+  ---@cast opts fzf-lua.config.Resolved
   if not opts then return nil, nil end
   -- Store contents for unhide
   opts._contents = contents
@@ -349,6 +363,7 @@ M.fzf = function(contents, opts)
   -- setup the fzf window and preview layout
   local fzf_win = win.new(opts)
   -- instantiate the previewer
+  ---@diagnostic disable-next-line: param-type-mismatch
   local previewer = require("fzf-lua.previewer").new(opts.previewer, opts)
   if previewer then
     -- Attach the previewer to the windows
@@ -448,7 +463,7 @@ M.fzf = function(contents, opts)
   -- only close the window if autoclose wasn't specified or is 'true'
   -- or if the action wasn't a table or defined with `reload|noclose`
   local do_not_close = type(action) == "table"
-      and (action[1] ~= nil or action.reload or action.noclose or action.reuse)
+      and (action[1] ~= nil or action.reload or action.noclose or action.reuse) ---@diagnostic disable-line: undefined-field
   if (not fzf_win:autoclose() == false) and not do_not_close then
     fzf_win:close(fzf_bufnr)
     -- only clear context if we didn't open a new interface, for example, opening

--- a/lua/fzf-lua/defaults.lua
+++ b/lua/fzf-lua/defaults.lua
@@ -553,9 +553,11 @@ M.defaults.global = vim.tbl_deep_extend("force", M.defaults.files, {
   line_query        = true,
   pickers           = function()
     local clients = utils.lsp_get_clients({ bufnr = utils.CTX().bufnr })
+    ---@diagnostic disable-next-line: redundant-parameter, call-non-callable
     local doc_sym_supported = vim.iter(clients):any(function(client)
       return client:supports_method("textDocument/documentSymbol")
     end)
+    ---@diagnostic disable-next-line: redundant-parameter, call-non-callable
     local wks_sym_supported = vim.iter(clients):any(function(client)
       return client:supports_method("workspace/symbol")
     end)

--- a/lua/fzf-lua/devicons.lua
+++ b/lua/fzf-lua/devicons.lua
@@ -52,9 +52,11 @@ function NvimWebDevicons:load(do_not_lazy_load)
   then
     self._package_loaded, self._package = pcall(require, self._package_name)
     if self._package_loaded then
+      local _info = debug.getinfo(self._package.setup, "S")
+      ---@cast _info {source: string}
       ---@diagnostic disable-next-line: param-type-mismatch
       self._package_path = path.parent(path.parent(path.normalize(
-        debug.getinfo(self._package.setup, "S").source:gsub("^@", ""))))
+        _info.source:gsub("^@", ""))))
     end
   end
   return self._package_loaded
@@ -188,9 +190,11 @@ function MiniIcons:load(do_not_lazy_load)
   then
     self._package_loaded, self._package = pcall(require, self._package_name)
     if self._package_loaded then
+      local _info = debug.getinfo(self._package.setup, "S")
+      ---@cast _info {source: string}
       ---@diagnostic disable-next-line: param-type-mismatch
       self._package_path = path.parent(path.parent(path.parent(path.normalize(
-        debug.getinfo(self._package.setup, "S").source:gsub("^@", "")))))
+        _info.source:gsub("^@", "")))))
     end
   end
   return self._package_loaded
@@ -531,6 +535,7 @@ M.get_devicon = function(filepath, extensionOverride)
 
     if not by_ft then
       -- store default icon in cache to avoid lookup by ft a second time
+      ---@diagnostic disable-next-line: assign-type-mismatch
       by_ft = { icon = STATE.default_icon.icon, color = STATE.default_icon.color }
     end
 

--- a/lua/fzf-lua/fzf.lua
+++ b/lua/fzf-lua/fzf.lua
@@ -103,6 +103,7 @@ function M.raw_fzf(contents, fzf_cli_args, opts)
   end
 
   local co = coroutine.running()
+  ---@cast co thread
   local jobstart = _G.fzf_jobstart or opts.is_fzf_tmux and vim.fn.jobstart or utils.termopen
   local shell_cmd = utils.__IS_WINDOWS
       -- MSYS2 comes with "/usr/bin/cmd" that precedes "cmd.exe" (#1396)

--- a/lua/fzf-lua/init.lua
+++ b/lua/fzf-lua/init.lua
@@ -29,6 +29,7 @@ do
   source_vimL({ vim.g.fzf_lua_root, "autoload", "fzf_lua.vim" })
   -- Set var post source as the top of the file `require` will return 0
   -- due to it potentially being loaded before "autoload/fzf_lua.vim"
+  ---@diagnostic disable-next-line: inject-field
   utils.__HAS_AUTOLOAD_FNS = vim.fn.exists("*fzf_lua#getbufinfo") == 1
 
   -- Create a new RPC server (tmp socket) to listen to messages (actions/headless)
@@ -185,15 +186,17 @@ function M.setup(opts, do_not_reset_defaults)
   opts[1] = opts[1] == nil and "default" or opts[1]
   if opts[1] then
     -- Did the user supply profile(s) to load?
-    opts = vim.tbl_deep_extend("keep", opts,
-      utils.load_profiles(opts[1], opts[2] == nil and 1 or opts[2]))
+    ---@diagnostic disable-next-line: param-type-mismatch
+    opts = vim.tbl_deep_extend("keep", opts, utils.load_profiles(opts[1], opts[2] == nil and 1 or opts[2]))
   end
   if do_not_reset_defaults then
     -- no defaults reset requested, merge with previous setup options
+    ---@diagnostic disable-next-line: generic-constraint-mismatch
     opts = vim.tbl_deep_extend("keep", opts, config.setup_opts or {})
   end
   -- backward compat `global_{git|gile|color}_icons`
   -- converts `global_file_icons` to `defaults.file_icons`, etc
+  ---@cast opts table
   for _, o in ipairs({ "file_icons", "git_icons", "color_icons" }) do
     local gopt = "global_" .. o
     if opts[gopt] ~= nil then

--- a/lua/fzf-lua/libuv.lua
+++ b/lua/fzf-lua/libuv.lua
@@ -22,6 +22,7 @@ end
 
 local function coroutine_callback(fn)
   local co = coroutine.running()
+  ---@cast co thread
   local callback = function(...)
     if coroutine.status(co) == "suspended" then
       coroutine.resume(co, ...)
@@ -65,7 +66,7 @@ M.uv_spawn = function(cmd, opts, on_exit)
       renv[#renv + 1] = string.format("%s=%s", k, tostring(v))
     end
     return renv
-  end)() ---@diagnostic disable-next-line: unnecessary-assert, return-type-mismatch
+  end)() ---@diagnostic disable-next-line: unnecessary-assert, return-type-mismatch, redundant-return-value
   return assert(uv.spawn(cmd, opts, on_exit))
 end
 
@@ -109,6 +110,7 @@ M.spawn = function(opts, fn_transform, fn_done)
   local prev_line_content ---@type string?
   local handle, pid ---@type uv.uv_process_t, integer
   local co = coroutine.running()
+  ---@cast co thread
   local queue = require("fzf-lua.lib.queue").new()
   local work_ctx
 
@@ -188,6 +190,7 @@ M.spawn = function(opts, fn_transform, fn_done)
 
   local function write_cb(data)
     write_cb_count = write_cb_count + 1
+    ---@diagnostic disable-next-line: need-check-nil
     opts.cb_write(data, function(err)
       write_cb_count = write_cb_count - 1
       if err then
@@ -472,6 +475,7 @@ M.spawn_stdio = function(opts)
   end
 
   -- run the preprocessing fn
+  ---@diagnostic disable-next-line: call-non-callable
   if fn_preprocess then fn_preprocess(opts) end
 
   ---@type fzf-lua.content|fzf-lua.shell.data2?
@@ -549,10 +553,12 @@ M.spawn_stdio = function(opts)
     pipe_close(stderr)
     if vim.in_fast_event() then
       vim.schedule(function()
+        ---@diagnostic disable-next-line: call-non-callable
         if fn_postprocess then fn_postprocess(opts) end
         exit(code)
       end)
     else
+      ---@diagnostic disable-next-line: call-non-callable
       if fn_postprocess then fn_postprocess(opts) end
       exit(code)
     end
@@ -599,9 +605,12 @@ M.spawn_stdio = function(opts)
     cmd = content
   else
     local f = fn_transform or function(x) return x end
+    ---@diagnostic disable-next-line: call-non-callable, missing-parameter
     local w = function(s) if s then io.stdout:write(f(s) .. EOL) else on_finish(0) end end
+    ---@diagnostic disable-next-line: call-non-callable, missing-parameter, param-type-mismatch
     local wn = function(s) if s then return io.stdout:write(f(s)) else on_finish(0) end end
     if opts.is_live then ---@cast content fzf-lua.shell.data2
+      ---@diagnostic disable-next-line: param-type-mismatch
       local res = content(args(), opts)
       if not res then return on_finish(0), nil end ---@cast res-?
       content = res
@@ -634,6 +643,7 @@ M.spawn_stdio = function(opts)
       EOL = EOL,
     },
     fn_transform and function(x)
+      ---@diagnostic disable-next-line: call-non-callable
       return fn_transform(x, opts)
     end)
 end

--- a/lua/fzf-lua/make_entry.lua
+++ b/lua/fzf-lua/make_entry.lua
@@ -248,6 +248,7 @@ local glob_filter = function(paths, globs)
   return vim.tbl_filter(function(p)
     local stat = vim.uv.fs_stat(p) -- "--iglob" can filter directory correctly
     return (stat and stat.type == "directory") or
+        ---@diagnostic disable-next-line: redundant-parameter, call-non-callable
         vim.iter(matchers):all(function(m) return m:match_str(p) end)
   end, paths)
 end
@@ -521,11 +522,14 @@ M.preprocess = function(opts)
   -- formatter `to` function
   if opts.formatter and not opts._fmt then
     opts._fmt = opts._fmt or {}
+    ---@diagnostic disable-next-line: inject-field, undefined-field
     opts._fmt.to = opts2._fmt.to
     -- Attempt to load from string value `_to`
+    ---@diagnostic disable-next-line: undefined-field
     if not opts._fmt.to then
       local _to = opts2._fmt._to
       if type(_to) == "string" then
+        ---@diagnostic disable-next-line: inject-field
         opts._fmt.to = assert(loadstring(_to))()
       end
     end
@@ -594,6 +598,7 @@ M.file = function(x, opts)
   end)()
   ---@cast stripped_filepath-?
   local filepath = stripped_filepath
+  ---@cast filepath string
   -- fd v8.3 requires adding '--strip-cwd-prefix' to remove
   -- the './' prefix, will not work with '--color=always'
   -- https://github.com/sharkdp/fd/blob/master/CHANGELOG.md

--- a/lua/fzf-lua/path.lua
+++ b/lua/fzf-lua/path.lua
@@ -628,7 +628,9 @@ function M.git_cwd(cmd, opts)
     for _, a in ipairs(git_args) do
       if o[a[1]] then
         o[a[1]] = a.noexpand and o[a[1]] or libuv.expand(o[a[1]])
+        ---@diagnostic disable-next-line: param-type-mismatch, redundant-parameter
         table.insert(cmd, idx, a[2])
+        ---@diagnostic disable-next-line: param-type-mismatch, redundant-parameter
         table.insert(cmd, idx + 1, o[a[1]])
         idx = idx + 2
       end
@@ -654,6 +656,7 @@ function M.git_root(opts, noerr)
   -- already a Windows absolute path to avoid unnecessary overhead
   -- for users of git-for-windows (which already returns C:\... paths).
   -- Ref: https://github.com/ibhagwan/fzf-lua/issues/2745
+  ---@diagnostic disable-next-line: param-type-mismatch
   if utils.__IS_WINDOWS and not M.is_absolute(output[1]) and vim.fn.executable("cygpath") == 1 then
     local cyg_out, rc = utils.io_systemlist({ "cygpath", "-w", output[1] })
     if rc == 0 and cyg_out[1] then
@@ -773,6 +776,7 @@ end
 
 function M.ft_match_fast_event(args)
   local co = coroutine.running()
+  ---@cast co thread
   if co and vim.in_fast_event() then
     local ft
     vim.schedule(function()

--- a/lua/fzf-lua/previewer/builtin.lua
+++ b/lua/fzf-lua/previewer/builtin.lua
@@ -468,6 +468,7 @@ local copy_extmarks = function(src_buf, buf, win, topline, botline, ns)
     if not ignore[details.ns_id] then
       details.ns_id = nil
       if no_virt_text and details.virt_text then details.virt_text = nil end
+      ---@diagnostic disable-next-line: param-type-mismatch
       pcall(api.nvim_buf_set_extmark, buf, ns, row, col, details)
     end
   end
@@ -576,10 +577,11 @@ function Previewer.buffer_or_file:parse_entry(entry_str, _cb)
     local ext = path.extension(entry.path)
     local cmd = ext and self.extensions[ext:lower()] or nil
     cmd = type(cmd) == "string" and { cmd } or utils.deepcopy(cmd) or {}
+    ---@cast cmd string[]
     if cmd[1] then
       -- special case: we build ueberzug cmd separately
-      entry._is_ueberzug = cmd[1]:match("ueberzug") and true or false
-      if not entry._is_ueberzug and fn.executable(cmd[1]) == 1 then
+      entry._is_ueberzug = (cmd[1] --[[@as string]]):match("ueberzug") and true or false
+      if not entry._is_ueberzug and fn.executable(cmd[1] --[[@as string]]) == 1 then
         entry.cmd = replace_placeholder(cmd, "[<{]file[}>]", entry.path)
         entry.pty = true
       end
@@ -789,6 +791,8 @@ local start_cmd = function(buf, entry, opts)
   end)
   local sopts = entry.cmd_opts or {}
   sopts = vim.tbl_deep_extend("force", sopts, { stdout = stdout, stderr = stdout })
+  ---@diagnostic disable-next-line: param-type-mismatch
+  ---@diagnostic disable-next-line: redundant-parameter
   return vim.system(entry.cmd, sopts, on_exit)
 end
 
@@ -842,6 +846,7 @@ function Previewer.buffer_or_file:_populate_loaded_buffer_preview(tmpbuf, entry)
   -- this changes the buffer's 'getbufinfo[1].lastused'
   -- which messes up our `buffers()` sort
   entry.filetype = vim.bo[entry.bufnr].filetype
+  ---@diagnostic disable-next-line: param-type-mismatch
   local lines = api.nvim_buf_get_lines(entry.bufnr, 0, -1, false)
   vim.bo[tmpbuf].expandtab = vim.bo[entry.bufnr].expandtab
   vim.bo[tmpbuf].shiftwidth = vim.bo[entry.bufnr].shiftwidth
@@ -860,6 +865,7 @@ function Previewer.buffer_or_file:_populate_location_preview(tmpbuf, entry)
   local loc = { uri = entry.uri, range = entry.range }
   local win = self.win.preview_winid
   local ok, res = api.nvim_win_call(win, function()
+    ---@diagnostic disable-next-line: param-type-mismatch
     return pcall(utils.jump_to_location, loc, "utf-16", false)
   end)
   if ok then
@@ -1052,6 +1058,7 @@ function Previewer.base:update_render_markdown()
     return
   end
   if package.loaded["render-markdown"] then
+    ---@diagnostic disable-next-line: unresolved-require
     require("render-markdown").render({ buf = bufnr, event = "FzfLua" })
   elseif package.loaded["markview"] then
     --- Render strictly to save performance.
@@ -1059,6 +1066,7 @@ function Previewer.base:update_render_markdown()
     --- Use `strict:render(bufnr, 1000)` to stop rendering if
     --- line count >= 1000.
     local strict = package.loaded["markview"].strict_render;
+    ---@diagnostic disable-next-line: undefined-field
     if strict then strict:render(bufnr); end
   end
 end
@@ -1302,6 +1310,7 @@ function Previewer.buffer_or_file:set_cursor_hl(entry)
   end
 
   self.orig_pos = { lnum, col - 1 }
+  ---@diagnostic disable-next-line: param-type-mismatch
   if not pcall(api.nvim_win_set_cursor, win, cached_pos or self.orig_pos) then
     return
   end
@@ -1485,6 +1494,7 @@ function Previewer.man_pages:parse_entry(entry_str)
   local entry = require("fzf-lua.providers.manpages").manpage_sh_arg(entry_str)
   local cmd = self.cmd:format(entry) ---@type string|string[]
   if type(cmd) == "string" then cmd = { "sh", "-c", cmd } end
+  ---@cast cmd string[]
   local output, _ = utils.io_systemlist(cmd)
   return { filetype = "man", content = output }
 end
@@ -1532,7 +1542,7 @@ function Previewer.jumps:parse_entry(entry_str)
   if filepath then
     local ok, res = pcall(libuv.expand, filepath)
     if ok then
-      filepath = path.relative_to(res, utils.cwd())
+      filepath = path.relative_to(res --[[@as string]], utils.cwd())
     end
     if not uv.fs_stat(filepath) then
       -- file is not accessible,
@@ -1771,8 +1781,10 @@ function Previewer.vterm:parse_entry(entry_str)
   local entry = Previewer.vterm.super.parse_entry(self, entry_str)
   local spec = self.previewer:cmdline() ---@type fzf-lua.preview.spec
   assert(type(spec) == "table" and spec.fn, "invalid vterm previewer spec")
+  ---@diagnostic disable-next-line: need-check-nil
   local preview = assert(self.win.layout.preview)
   -- usually `{} {q}` is used as most common field index
+  ---@diagnostic disable-next-line: param-type-mismatch
   local res = spec.fn({ entry_str, FzfLua.get_info().query }, preview.height, preview.width)
   if spec.type == "cmd" then
     local cmdspec = type(res) == "table" and res or { cmd = { "sh", "-c", res }, env = nil }
@@ -1780,6 +1792,7 @@ function Previewer.vterm:parse_entry(entry_str)
     return { cmd = cmd, cmd_opts = { env = cmdspec.env }, line = entry.line, col = entry.col }
   else
     assert(type(res) == "table", res)
+    ---@diagnostic disable-next-line: assign-type-mismatch
     return { content = res, open_term = true, line = entry.line, col = entry.col }
   end
 end

--- a/lua/fzf-lua/previewer/codeaction.lua
+++ b/lua/fzf-lua/previewer/codeaction.lua
@@ -292,6 +292,7 @@ function M.native:new(o, opts)
   setmetatable(self, M.native)
   local pager = opts.preview_pager == nil and o.pager or opts.preview_pager
   if type(pager) == "function" then pager = pager() end
+  ---@cast pager string
   local cmd = pager and pager:match("[^%s]+") or nil
   if cmd and vim.fn.executable(cmd) == 1 then self.pager = pager end
   self.diff_opts = o.diff_opts
@@ -306,6 +307,7 @@ end
 function M.native:cmdline(o)
   o = o or {}
   local act = shell.stringify_data(function(entries, _, _)
+    ---@diagnostic disable-next-line: undefined-field
     if not entries[1] then return shell.nop() end
     local idx = utils.tointeger(entries[1]:match("^%s*%d+%."))
     assert(idx)

--- a/lua/fzf-lua/previewer/fzf.lua
+++ b/lua/fzf-lua/previewer/fzf.lua
@@ -336,6 +336,7 @@ function Previewer.git_diff:new(o, opts)
   self.cmd_untracked = path.git_cwd(o.cmd_untracked, opts)
   local pager = opts.preview_pager == nil and o.pager or opts.preview_pager
   if type(pager) == "function" then pager = pager() end
+  ---@cast pager string
   local cmd = pager and pager:match("[^%s]+") or nil
   if cmd and vim.fn.executable(cmd) == 1 then
     -- style 2: as we are unable to use %var% within a "cmd /c" without !var! expansion
@@ -344,6 +345,7 @@ function Previewer.git_diff:new(o, opts)
   end
   do
     -- populate the icon mappings
+    ---@diagnostic disable-next-line: assign-type-mismatch
     local icons_overrides = o._fn_git_icons and o._fn_git_icons()
     self.git_icons = {}
     for _, i in ipairs({ "D", "M", "R", "A", "C", "T", "?" }) do
@@ -509,8 +511,10 @@ local function make_screenshot(screenshot, addr, lines, columns)
   if not ok then -- instance seems died, signal to reload the list
     local winobj = FzfLua.utils.fzf_winobj()
     if winobj then winobj:SIGWINCH({ "win.unhide" }) end
+    ---@diagnostic disable-next-line: missing-return-value
     return
   end
+  ---@diagnostic disable-next-line: redundant-parameter, call-non-callable
   local has_tui = vim.iter(uis):find(function(info) return info.stdout_tty end)
   if has_tui then
     if vim.env.NVIM == addr then -- parent instance
@@ -539,6 +543,7 @@ local function make_screenshot(screenshot, addr, lines, columns)
       vim.defer_fn(function() vim.fn.jobstop(chan0) end, 20)
     end,
   })
+  ---@diagnostic disable-next-line: missing-return-value
   return vim.fn.jobpid(chan)
 end
 

--- a/lua/fzf-lua/previewer/init.lua
+++ b/lua/fzf-lua/previewer/init.lua
@@ -105,6 +105,7 @@ Previewer.normalize_spec = function(preview, opts)
     local field_index = preview.field_index or "{}"
     local stringify = preview.type == "cmd" and FzfLua.shell.stringify_cmd
         or FzfLua.shell.stringify_data
+    ---@cast func fzf-lua.shell.cmd
     return (stringify(func, opts, field_index))
   else
     return preview

--- a/lua/fzf-lua/previewer/tscontext.lua
+++ b/lua/fzf-lua/previewer/tscontext.lua
@@ -19,6 +19,7 @@ function M.setup(opts)
   for k, v in pairs(opts) do
     M._setup_opts[k] = { v }
   end
+  ---@diagnostic disable-next-line: unresolved-require
   local config = require("treesitter-context.config")
   M._config = utils.tbl_deep_clone(config)
   for k, v in pairs(M._setup_opts) do
@@ -35,6 +36,7 @@ function M.deregister()
   for winid, _ in pairs(M._winids) do
     M.close(winid)
   end
+  ---@diagnostic disable-next-line: unresolved-require
   local config = require("treesitter-context.config")
   for k, v in pairs(M._setup_opts) do
     config[k] = v[2]
@@ -54,6 +56,7 @@ end
 ---@param winid integer
 function M.close(winid)
   if not M._setup then return end
+  ---@diagnostic disable-next-line: unresolved-require
   require("treesitter-context.render").close(winid)
   M._winids[winid] = nil
 end
@@ -73,6 +76,7 @@ function M.inc_dec_maxlines(num, winid, bufnr)
   if not M._setup then return end
   local n = tonumber(num)
   if not n then return end
+  ---@diagnostic disable-next-line: unresolved-require
   local config = require("treesitter-context.config")
   local max_lines = config.max_lines or 0
   config.max_lines = math.max(0, max_lines + n)
@@ -105,7 +109,9 @@ function M.update(winid, bufnr, opts)
   opts = opts or {}
   if not M.setup(opts) then return end
   assert(not api.nvim_win_is_valid(winid) or bufnr == api.nvim_win_get_buf(winid))
+  ---@diagnostic disable-next-line: unresolved-require
   local render = require("treesitter-context.render")
+  ---@diagnostic disable-next-line: unresolved-require
   local context_ranges, context_lines = require("treesitter-context.context").get(winid)
   if not context_ranges or #context_ranges == 0 then
     M.close(winid)

--- a/lua/fzf-lua/profiles/cli.lua
+++ b/lua/fzf-lua/profiles/cli.lua
@@ -9,7 +9,9 @@ if package.preload.ffi then
   ffi = package.preload.ffi()
 end
 
+---@diagnostic disable-next-line: call-non-callable, need-check-nil
 pcall(function()
+  ---@diagnostic disable-next-line: call-non-callable, need-check-nil
   ffi.cdef [[
     struct winsize {
       unsigned short ws_row;
@@ -87,6 +89,7 @@ local enable_stdio_inheritance = function()
     local EINTR = 4
     local res
     repeat
+      ---@diagnostic disable-next-line: need-check-nil
       res = ffi.C.fcntl(fd, F_SETFD, 1)
     until not (res == -1 and ffi.errno() == EINTR)
     return res ~= -1

--- a/lua/fzf-lua/profiles/hide.lua
+++ b/lua/fzf-lua/profiles/hide.lua
@@ -23,6 +23,7 @@ return {
         return opts
       end
       opts.actions = opts.actions or {}
+      ---@diagnostic disable-next-line: unnecessary-assert
       assert(opts.keymap)
       assert(opts.keymap.builtin)
       if fzf.utils.has(opts, "sk") and not fzf.utils.has(opts, "sk", { 1, 5, 3 }) then
@@ -63,6 +64,7 @@ return {
         act = type(act) == "table" and type(act[1]) == "function"
             and { fn = act[1], reuse = true } or act
         assert(type(act) == "table" and type(act.fn) == "function" or not act)
+        ---@cast act table
         if type(act) == "table" and
             not act.exec_silent
             and not act.reload

--- a/lua/fzf-lua/providers/buffers.lua
+++ b/lua/fzf-lua/providers/buffers.lua
@@ -277,6 +277,7 @@ M.buffer_lines = function(opts)
 
     coroutine.wrap(function()
       local co = coroutine.running()
+      ---@cast co thread
 
       local buffers = filter_buffers(opts,
         opts.current_buffer_only and { utils.CTX().bufnr } or utils.CTX().buflist or {})
@@ -298,6 +299,7 @@ M.buffer_lines = function(opts)
         bnames[tostring(b)] = bname
       end
       local len_bufnames = math.min(tonumber(opts.show_bufname_len) or 15, longest_bname)
+      ---@cast len_bufnames integer
 
       for _, bufnr in ipairs(buffers) do
         local data = {}
@@ -537,6 +539,7 @@ M.treesitter = function(opts)
       local scope = "local" ---@type string
       ---@diagnostic disable-next-line: param-type-mismatch
       for k, v in pairs(metadata) do
+        ---@cast k string
         if k and vim.endswith(k, "local.scope") and type(v) == "string" then
           scope = v
         end
@@ -585,6 +588,7 @@ M.treesitter = function(opts)
   local contents = function(cb)
     coroutine.wrap(function()
       local co = coroutine.running()
+      ---@cast co thread
       for _, definition in ipairs(get(bufnr0)) do
         local nodes = get_local_nodes(definition)
         for _, node in ipairs(nodes) do
@@ -649,6 +653,7 @@ M.spellcheck = function(opts)
   local contents = function(cb)
     coroutine.wrap(function()
       local co = coroutine.running()
+      ---@cast co thread
       local data = {}
 
       -- Use vim.schedule to avoid

--- a/lua/fzf-lua/providers/colorschemes.lua
+++ b/lua/fzf-lua/providers/colorschemes.lua
@@ -395,6 +395,7 @@ M.apply_awesome_theme = function(dbkey, idx, opts)
     return
   end
   if cs.vim then
+    ---@diagnostic disable-next-line: assign-type-mismatch
     ok, out = pcall(vim.api.nvim_exec2, cs.vim, { output = true })
   elseif cs.lua then ---@diagnostic disable-next-line: need-check-nil
     ok, out = pcall(function() loadstring(cs.lua)() end)
@@ -416,7 +417,7 @@ M.awesome_colorschemes = function(opts)
   local cur_colorscheme = get_current_colorscheme()
   local cur_background = vim.o.background
 
-  local dbfile = vim.fn.expand(opts.dbfile)
+  local dbfile = vim.fn.expand(opts.dbfile) --[[@as string]]
   if not path.is_absolute(dbfile) then
     dbfile = path.normalize(path.join({ vim.g.fzf_lua_directory, opts.dbfile })) or dbfile
   end
@@ -453,6 +454,7 @@ M.awesome_colorschemes = function(opts)
     -- E5560: vimL function must not be called in a lua loop callback
     coroutine.wrap(function()
       local co = coroutine.running()
+      ---@cast co thread
 
       -- make sure our cache is in packpath
       vim.opt.packpath:append(packpath)
@@ -461,6 +463,7 @@ M.awesome_colorschemes = function(opts)
       -- create all sorts of voodoo issues when running resume
       -- HACK: find a better solution (singleton?)
       if config.__resume_data and type(config.__resume_data.opts) == "table" then
+        ---@diagnostic disable-next-line: undefined-field
         config.__resume_data.opts._adm.db = opts._adm.db
       end
 

--- a/lua/fzf-lua/providers/dap.lua
+++ b/lua/fzf-lua/providers/dap.lua
@@ -40,7 +40,7 @@ M.commands = function(opts)
 
   opts.actions = {
     ["enter"] = function(selected, _)
-      _dap[selected[1]]()
+      _dap[selected[1]]() ---@diagnostic disable-line: call-non-callable
     end,
   }
 
@@ -104,6 +104,7 @@ M.breakpoints = function(opts)
   local contents = function(cb)
     coroutine.wrap(function()
       local co = coroutine.running()
+      ---@cast co thread
       local bps = dap_bps.to_qf_list(dap_bps.get())
       for _, b in ipairs(bps) do
         vim.schedule(function()

--- a/lua/fzf-lua/providers/diagnostic.lua
+++ b/lua/fzf-lua/providers/diagnostic.lua
@@ -170,6 +170,7 @@ M.diagnostics = function(opts)
   local contents = function(fzf_cb)
     coroutine.wrap(function()
       local co = coroutine.running()
+      ---@cast co thread
 
       ---@param diags vim.Diagnostic[]
       local function process_diagnostics(diags)

--- a/lua/fzf-lua/providers/files.lua
+++ b/lua/fzf-lua/providers/files.lua
@@ -65,7 +65,7 @@ M.get_files_cmd = function(opts)
           v = [[\! -path '*/.*']]
         end
       end
-      command = utils.toggle_cmd_flag(command, v, toggle, is_find)
+      command = utils.toggle_cmd_flag(command, v --[[@as string]], toggle, is_find)
     end)()
   end
   return command
@@ -116,6 +116,7 @@ M.args = function(opts)
     -- E5560: vimL function must not be called in a lua loop callback
     coroutine.wrap(function()
       local co = coroutine.running()
+      ---@cast co thread
 
       -- local start = os.time(); for _ = 1,10000,1 do
       for i = 0, argc - 1 do

--- a/lua/fzf-lua/providers/git.lua
+++ b/lua/fzf-lua/providers/git.lua
@@ -212,7 +212,7 @@ M.bcommits = function(opts)
   -- but overall it's not a big deal as it's a pretty cheap call
   -- first 'git_root' call won't print a warning to ':messages'
   if not opts.cwd and not opts.git_dir then
-    opts.cwd = path.git_root({ cwd = vim.fn.expand("%:p:h") }, true)
+    opts.cwd = path.git_root({ cwd = vim.fn.expand("%:p:h") --[[@as string]] }, true)
   end
   local git_root = path.git_root(opts)
   if not git_root then return end
@@ -223,7 +223,7 @@ M.bcommits = function(opts)
   -- commits where the file was named differently.
   if opts.follow and not utils.mode_is_visual() then
     local display_fmt = opts.cmd:match('%-%-pretty=format:"(.-)"') or "%C(yellow)%h%Creset %s"
-    local relfile = path.relative_to(vim.fn.expand("%:p"), git_root)
+    local relfile = path.relative_to(vim.fn.expand("%:p") --[[@as string]], git_root)
     -- \1 marks a header line; \31 separates the clean sha from the coloured display
     local logcmd = path.git_cwd({
       "git", "-c", "core.quotepath=false",
@@ -256,7 +256,7 @@ M.bcommits = function(opts)
         or function(l) return (l:match("^[^\t]+\t([^\t]+)")) end
     return core.fzf_exec(entries, opts)
   end
-  local file = libuv.shellescape(path.relative_to(vim.fn.expand("%:p"), git_root))
+  local file = libuv.shellescape(path.relative_to(vim.fn.expand("%:p") --[[@as string]], git_root))
   local range
   if utils.mode_is_visual() then
     local _, sel = utils.get_visual_selection()
@@ -287,11 +287,11 @@ M.blame = function(opts)
   end
   -- See "bcommits" for comment
   if not opts.cwd and not opts.git_dir then
-    opts.cwd = path.git_root({ cwd = vim.fn.expand("%:p:h") }, true)
+    opts.cwd = path.git_root({ cwd = vim.fn.expand("%:p:h") --[[@as string]] }, true)
   end
   local git_root = path.git_root(opts)
   if not git_root then return end
-  local file = libuv.shellescape(path.relative_to(vim.fn.expand("%:p"), git_root))
+  local file = libuv.shellescape(path.relative_to(vim.fn.expand("%:p") --[[@as string]], git_root))
   local range
   if utils.mode_is_visual() then
     local _, sel = utils.get_visual_selection()
@@ -330,6 +330,7 @@ local function highlight_branch_line(line)
 
   local branch_name, ws_after_name, after = rest:match("^(%S+)(%s+)(.*)$")
   if not branch_name then return line end
+  ---@cast after string
 
   local colored_branch
   if leader:sub(1, 1) == "*" then
@@ -350,6 +351,7 @@ local function highlight_branch_line(line)
   if not sha then
     return leader .. colored_branch .. ws_after_name .. after
   end
+  ---@cast body string
 
   local function color_tracking(content)
     local ref, suffix = content:match("^([^:]+)(:.*)$")
@@ -362,6 +364,7 @@ local function highlight_branch_line(line)
   if leader:sub(1, 1) == "+" then
     local wt_paren, remainder = body:match("^(%b())(.*)$")
     if wt_paren then
+      ---@cast remainder string
       local colored_wt = ansi.grey("(") .. ansi.cyan(wt_paren:sub(2, -2)) .. ansi.grey(")")
       remainder = remainder:gsub("^(%s*)(%[)([^%]]+)(%])", function(ws, _, content, _)
         return ws .. color_tracking(content)
@@ -383,11 +386,13 @@ local function highlight_worktree_line(line)
   local ansi = FzfLua.utils.ansi_codes
   local path_s, padding, rest = line:match("^(%S+)(%s+)(.*)$")
   if not path_s then return line end
+  ---@cast rest string
 
   local sha, sha_ws, body = rest:match("^(%x%x%x%x%x%x%x+)(%s+)(.*)$")
   if not sha then
     body = rest
   end
+  ---@cast body string
 
   body = body:gsub("^(%[)([^%]]+)(%])", function(lb, name, rb)
     return ansi.grey(lb) .. ansi.green(name) .. ansi.grey(rb)
@@ -453,6 +458,7 @@ M.worktrees = function(opts)
     opts.preview = shell.stringify_cmd(function(items)
       if not items[1] then return utils.shell_nop() end
       local cwd = items[1]:match("^[^%s]+")
+      ---@cast preview_cmd string
       local cmd = path.git_cwd(preview_cmd, { cwd = cwd })
       return cmd
     end, opts, "{}")

--- a/lua/fzf-lua/providers/helptags.lua
+++ b/lua/fzf-lua/providers/helptags.lua
@@ -73,6 +73,7 @@ M.helptags = function(opts)
 
     coroutine.wrap(function()
       local co = coroutine.running()
+      ---@cast co thread
       local tags_map = {}
       local delimiter = string.char(9)
       for _, lang in ipairs(langs) do

--- a/lua/fzf-lua/providers/lsp.lua
+++ b/lua/fzf-lua/providers/lsp.lua
@@ -49,7 +49,7 @@ end
 
 
 ---@param locations lsp.Location[]|lsp.LocationLink[]
----@param enc? 'utf-8'|'utf-16'|'utf-32'
+---@param enc 'utf-8'|'utf-16'|'utf-32'
 ---@return string[]
 local function locations_to_entries(locations, enc)
   local items = vim.lsp.util.locations_to_items(locations, enc)
@@ -514,6 +514,7 @@ local function gen_lsp_contents(opts)
         opts.__contents = function(fzf_cb)
           coroutine.wrap(function()
             local co = coroutine.running()
+            ---@cast co thread
             for _, e in ipairs(results) do
               fzf_cb(e, function() coroutine.resume(co) end)
               coroutine.yield()
@@ -541,6 +542,7 @@ local function gen_lsp_contents(opts)
     opts.__contents = function(fzf_cb)
       coroutine.wrap(function()
         local co = coroutine.running()
+        ---@cast co thread
 
         -- Save no. of attached clients **supporting the capability**
         -- so we can determine if all callbacks were completed (#468)

--- a/lua/fzf-lua/providers/meta.lua
+++ b/lua/fzf-lua/providers/meta.lua
@@ -13,6 +13,7 @@ local M = {}
 M.metatable = function(opts)
   if not opts then return end
 
+  ---@diagnostic disable-next-line: inject-field
   if not opts.metatable then opts.metatable = getmetatable("").__index end
 
   local methods = {}
@@ -66,6 +67,7 @@ M.profiles = function(opts)
   local contents = function(cb)
     coroutine.wrap(function()
       local co = coroutine.running()
+      ---@cast co thread
 
       for _, d in ipairs(dirs) do
         ls(d, function(fname, name, type)
@@ -201,6 +203,7 @@ M.global = function(opts)
       -- Instantiate the previewer, opts isn't guaranteed if the picker
       -- isn't avilable, e.g. `tags` when not tags file exists
       if def.opts and def.opts.previewer then
+        ---@diagnostic disable-next-line: inject-field
         def.previewer = require("fzf-lua.previewer").new(def.opts.previewer, def.opts)
       end
     else

--- a/lua/fzf-lua/providers/nvim.lua
+++ b/lua/fzf-lua/providers/nvim.lua
@@ -68,10 +68,13 @@ M.commands = function(opts)
   end
 
   local add_subcommand = function(k, ansi_color)
+    ---@diagnostic disable-next-line: call-non-callable
     local flattened = vim.is_callable(opts.flatten[k]) and opts.flatten[k](opts)
         or opts.flatten[k] and vim.fn.getcompletion(k .. " ", "cmdline")
         or {}
+    ---@cast flattened table
     vim.list_extend(entries,
+      ---@diagnostic disable-next-line: param-type-mismatch
       vim.tbl_map(function(cmd) return ansi_color(k .. " " .. cmd) end,
         flattened))
   end
@@ -119,6 +122,7 @@ local history = function(opts, str)
   local from, to, delta = dr, dr * histnr, dr * bulk
   local content         = function(cb)
     local co = coroutine.running()
+    ---@cast co thread
     for i = from, to, delta do
       vim.schedule(function()
         local count = bulk
@@ -301,7 +305,9 @@ M.marks = function(opts)
 
     -- global marks
     for _, m in ipairs(vim.fn.getmarklist()) do
-      local mark, bufnr, lnum, col, file = m.mark:sub(2, 2), m.pos[1], m.pos[2], m.pos[3], m.file
+      local mark, bufnr, lnum, col, file = m.mark:sub(2, 2), m.pos[1], m.pos[2], m.pos[3],
+          m.file --[[@as string]]
+      ---@diagnostic disable-next-line: assign-type-mismatch
       file = make_entry.file(file, opts)
       if bufnr == utils.CTX().bufnr then
         local text = vim.api.nvim_buf_get_lines(bufnr, lnum - 1, lnum, false)[1]
@@ -567,6 +573,7 @@ M.nvim_options = function(opts)
     vim.api.nvim_win_call(opts.__CTX.winid, function()
       coroutine.wrap(function()
         local co = coroutine.running()
+        ---@cast co thread
         local entries = format_option_entries()
         for _, entry in pairs(entries) do
           vim.schedule(function()
@@ -737,6 +744,7 @@ M.autocmds = function(opts)
   local contents = function(cb)
     coroutine.wrap(function()
       local co = coroutine.running()
+      ---@cast co thread
       cb(string.format("%s:%d:%s%s", "<none>", 0, separator, format({
         event = "event",
         pattern = "pattern",
@@ -791,6 +799,7 @@ M.serverlist = function(opts)
       local ok, info = utils.rpcexec(socket, "nvim_get_chan_info", 0)
       return ok and info.id
     end
+    ---@diagnostic disable-next-line: redundant-parameter, call-non-callable
     return vim.iter(socket_paths):filter(filter)
   end
 
@@ -864,10 +873,13 @@ M.serverlist = function(opts)
       cb(nil)
     end, SAMPLE_INTERVAL_MS)
   end
+  ---@cast opts table
   if utils.has(opts, "sk", "3.0.0") then
     opts = vim.tbl_deep_extend("force", opts, { winopts = { preview = { pty = true } } })
   end
+  ---@diagnostic disable-next-line: need-check-nil
   if utils.has(opts, "fzf", "0.73.0") then
+    ---@cast opts table
     opts.actions             = opts.actions or {}
     opts.actions["every(2)"] = { fn = function() end, reload = true }
   end

--- a/lua/fzf-lua/providers/oldfiles.lua
+++ b/lua/fzf-lua/providers/oldfiles.lua
@@ -66,6 +66,7 @@ M.oldfiles = function(opts, globals)
     -- run in a coroutine for async progress indication
     coroutine.wrap(function()
       local co = coroutine.running()
+      ---@cast co thread
 
       local curr_buf = utils.CTX().bufnr
       local curr_file = vim.api.nvim_buf_get_name(curr_buf)
@@ -81,6 +82,7 @@ M.oldfiles = function(opts, globals)
         end
       end
 
+      ---@diagnostic disable-next-line: redefined-local
       local function add_entry(x, co, force)
         x = make_entry.file(x,
           force and vim.tbl_deep_extend("force", {}, opts, { cwd_only = false }) or opts)

--- a/lua/fzf-lua/providers/quickfix.lua
+++ b/lua/fzf-lua/providers/quickfix.lua
@@ -95,6 +95,7 @@ local qfstack_exec = function(opts, cfg)
   local contents = function(cb)
     coroutine.wrap(function()
       local co = coroutine.running()
+      ---@cast co thread
 
       -- Get the list again for accuracy on resume
       opts.__gethist()

--- a/lua/fzf-lua/providers/tags.lua
+++ b/lua/fzf-lua/providers/tags.lua
@@ -83,10 +83,14 @@ local function tags(opts)
 
   -- tags file should always resolve to an absolute path, already "expanded" by
   -- `get_ctags_file` we take care of the case where `opts.ctags_file = "tags"`
+  ---@diagnostic disable-next-line: param-type-mismatch
   if not path.is_absolute(opts._ctags_file) then
+    ---@diagnostic disable-next-line: assign-type-mismatch
     opts._ctags_file = path.join({ opts.cwd or utils.cwd(), opts.ctags_file })
   end
 
+  ---@diagnostic disable-next-line: param-type-mismatch
+  ---@diagnostic disable-next-line: missing-parameter
   if not opts.ctags_autogen and not uv.fs_stat(opts._ctags_file) then
     -- are we using btags and have the `ctags` binary?
     -- btags with no tag file, try to autogen using `ctags`
@@ -118,6 +122,7 @@ local function tags(opts)
     if M._TAGS2CWD[opts._ctags_file] then
       opts.cwd = opts.cwd or M._TAGS2CWD[opts._ctags_file]
     else
+      ---@diagnostic disable-next-line: param-type-mismatch
       opts.cwd = opts.cwd or get_ctags_cwd(opts._ctags_file) or path.parent(opts.ctags_file)
       M._TAGS2CWD[opts._ctags_file] = opts.cwd
     end
@@ -154,6 +159,7 @@ local function tags(opts)
     opts.rg_glob = false
     -- tags has its own formatter
     opts.formatter, opts._fmt = false, { _to = false, to = false, from = false }
+    ---@diagnostic disable-next-line: param-type-mismatch
     opts.filespec = libuv.shellescape(opts._ctags_file)
     return require "fzf-lua.providers.grep".live_grep(opts)
   else
@@ -251,7 +257,7 @@ end
 M.grep_cword = function(opts)
   if not opts then opts = {} end
   opts.no_esc = true
-  opts.search = utils.rg_escape_cword(vim.fn.expand("<cword>"))
+  opts.search = utils.rg_escape_cword(vim.fn.expand("<cword>") --[[@as string]])
   return M.grep(opts)
 end
 
@@ -259,7 +265,7 @@ M.grep_cWORD = function(opts)
   if not opts then opts = {} end
   opts.no_esc = true
   -- since we're searching a tags file also search for surrounding literals ^ $
-  opts.search = [[(^|\^|\s)]] .. utils.rg_escape(vim.fn.expand("<cWORD>")) .. [[($|\$|\s)]]
+  opts.search = [[(^|\^|\s)]] .. utils.rg_escape(vim.fn.expand("<cWORD>") --[[@as string]]) .. [[($|\$|\s)]]
   return M.grep(opts)
 end
 

--- a/lua/fzf-lua/providers/ui_select.lua
+++ b/lua/fzf-lua/providers/ui_select.lua
@@ -108,6 +108,7 @@ M.ui_select = function(items, ui_opts, on_choice)
   -- calls function opts with no args, so resolve the function here first
   -- to preserve the historical `opts(ui_opts, items)` signature (#2770).
   if vim.is_callable(opts) then
+    ---@diagnostic disable-next-line: call-non-callable
     opts = opts(ui_opts, items)
   end
 
@@ -149,7 +150,9 @@ M.ui_select = function(items, ui_opts, on_choice)
         end
       end
 
+      ---@diagnostic disable-next-line: undefined-field
       if opts.post_action_cb then
+        ---@diagnostic disable-next-line: undefined-field
         opts.post_action_cb()
       end
     end
@@ -271,7 +274,10 @@ M.ui_select = function(items, ui_opts, on_choice)
     local previewer = _OPTS_ONCE.previewer
     _OPTS_ONCE.previewer = nil -- can't copy the previewer object
     ---@diagnostic disable-next-line: param-type-mismatch
+    ---@diagnostic disable-next-line: assign-type-mismatch
+    ---@diagnostic disable-next-line: generic-constraint-mismatch
     opts = vim.tbl_deep_extend(opts_merge_strategy, _OPTS_ONCE, opts)
+    ---@cast opts table
     opts.actions = vim.tbl_deep_extend("force", opts.actions or {},
       { ["enter"] = opts.actions.enter })
     opts.previewer = previewer

--- a/lua/fzf-lua/providers/undotree.lua
+++ b/lua/fzf-lua/providers/undotree.lua
@@ -124,7 +124,9 @@ local function draw_tree(opts, cb, tree, nodes, reverse, parents, prefix)
   for i, n in ipairs(nodes) do
     local v = tree[n]
     local is_last = i == #nodes
+    ---@diagnostic disable-next-line: undefined-field
     assert(not v.traversed)
+    ---@diagnostic disable-next-line: inject-field
     v.traversed = true
     -- TODO: IMHO the latter (flattened single) is nicer
     -- local is_single = #parents == 1 and #nodes == 1
@@ -151,6 +153,7 @@ M.undotree = function(opts)
   local contents = function(cb)
     coroutine.wrap(function()
       local co = coroutine.running()
+      ---@cast co thread
       local entries, curseq = get_undotree_entries(utils.CTX().bufnr)
       local tree = treefy(entries)
       local count = 0
@@ -360,6 +363,7 @@ function M.native:new(o, opts)
   self.buf = utils.CTX().bufnr
   local pager = opts.preview_pager == nil and o.pager or opts.preview_pager
   if type(pager) == "function" then pager = pager() end
+  ---@cast pager string
   local cmd = pager and pager:match("[^%s]+") or nil
   if cmd and vim.fn.executable(cmd) == 1 then self.pager = pager end
   self.diff_opts = o.diff_opts
@@ -374,6 +378,7 @@ end
 function M.native:cmdline(o)
   o = o or {}
   local act = shell.stringify_data(function(entries, _, _)
+    ---@diagnostic disable-next-line: undefined-field
     if not entries[1] then return shell.nop() end
     local seq = assert(utils.tointeger(entries[1]:match("%d+")))
     local lines = undo_diff(self.buf, seq, self.diff_opts)

--- a/lua/fzf-lua/shell.lua
+++ b/lua/fzf-lua/shell.lua
@@ -5,7 +5,9 @@ local path = require "fzf-lua.path"
 local libuv = require "fzf-lua.libuv"
 
 -- path to current file
-local __FILE__ = debug.getinfo(1, "S").source:gsub("^@", "")
+local _info = debug.getinfo(1, "S")
+---@cast _info {source: string}
+local __FILE__ = _info.source:gsub("^@", "")
 
 ---@class fzf-lua.lru
 ---@field max_size integer
@@ -283,6 +285,7 @@ end
 ---@param fzf_field_index string? Fzf field index expression, e.g. "{+}" (selected), "{q}" (query)
 ---@return string, integer?
 M.stringify = function(contents, opts, fzf_field_index)
+  ---@cast opts fzf-lua.config.Resolved
   -- TODO: should we let this assert?
   -- are there any conditions in which stringify is called subsequently?
   if opts.__stringified then ---@cast contents string
@@ -306,10 +309,13 @@ M.stringify = function(contents, opts, fzf_field_index)
     ---@type fzf-lua.content, table?
     ---@diagnostic disable-next-line: redefined-local, assign-type-mismatch
     local contents, env = (function()
+      ---@diagnostic disable-next-line: param-type-mismatch
       local ret = (opts.is_live and type(contents) == "function" and contents(unpack(args), opts))
+          ---@diagnostic disable-next-line: param-type-mismatch
           or (opts.__stringify_cmd and type(contents) == "function" and contents(unpack(args, 1, n)))
           or contents
       if opts.__stringify_cmd and type(ret) == "table" then
+        ---@diagnostic disable-next-line: undefined-field
         return ret.cmd, (ret.env or opts.env)
       else
         return ret, opts.env
@@ -322,6 +328,7 @@ M.stringify = function(contents, opts, fzf_field_index)
     local fn_preprocess = opts.fn_preprocess
     local fn_postprocess = opts.fn_postprocess
     local co = coroutine.running()
+    ---@cast co thread
 
     -- Run the preprocess function
     if type(fn_preprocess) == "function" then fn_preprocess(opts) end
@@ -355,6 +362,7 @@ M.stringify = function(contents, opts, fzf_field_index)
             -- safely remove items while iterating
             local i = 1
             while i <= #data do
+              ---@diagnostic disable-next-line: call-non-callable
               local v = fn_transform(data[i], opts)
               if not v then
                 table.remove(data, i)
@@ -448,7 +456,7 @@ end
 ---@alias fzf-lua.shell.cmdSpec string|{ cmd: string|string[], env: table? }?
 ---@alias fzf-lua.shell.cmd fun(items: string[], fzf_lines: integer, fzf_columns: integer, ctx?: fzf-lua.rpc.Ctx): fzf-lua.shell.cmdSpec
 ---@alias fzf-lua.shell.data fun(items: string[], fzf_lines: integer, fzf_columns: integer, ctx?: fzf-lua.rpc.Ctx): fzf-lua.content?
----@alias fzf-lua.shell.data2 fun(items: string[], opts: fzf-lua.config.Resolved|{}, ctx?: fzf-lua.rpc.Ctx): fzf-lua.content?
+---@alias fzf-lua.shell.data2 fun(items: string[], opts: fzf-lua.config.Resolved, ctx?: fzf-lua.rpc.Ctx): fzf-lua.content?
 
 ---@param fn fzf-lua.shell.cmd
 ---@param opts table

--- a/lua/fzf-lua/spawn.lua
+++ b/lua/fzf-lua/spawn.lua
@@ -4,7 +4,9 @@ local uv = vim.uv or vim.loop
 assert(#vim.api.nvim_list_uis() == 0)
 
 -- path to this file
-local __FILE__ = debug.getinfo(1, "S").source:gsub("^@", "")
+local _info = debug.getinfo(1, "S")
+---@cast _info {source: string}
+local __FILE__ = _info.source:gsub("^@", "")
 
 -- add the current folder to package.path so we can 'require'
 -- prepend this folder first, so our modules always get first

--- a/lua/fzf-lua/test/exec_lua.lua
+++ b/lua/fzf-lua/test/exec_lua.lua
@@ -123,6 +123,7 @@ function M.run(exec_lua, lvl, code, arg)
   -- Update upvalues
   if next(upvalues) then
     local caller = debug.getinfo(lvl)
+    ---@cast caller {func: function}
     local i = 0
 
     -- On PUC-Lua, if the function is a tail call, then func will be nil.

--- a/lua/fzf-lua/test/helpers.lua
+++ b/lua/fzf-lua/test/helpers.lua
@@ -59,7 +59,7 @@ local os_detect = {
   },
   MAC = { name = "MacOS", fn = function() return vim.fn.has("mac") == 1 end },
   LINUX = { name = "Linux", fn = function() return vim.fn.has("linux") == 1 end },
-  STABLE = { name = "Neovim stable", fn = function() return M.NVIM_VERSION() == "0.12.2" end },
+  STABLE = { name = "Neovim stable", fn = function() return M.NVIM_VERSION() == "0.12.4" end },
   NIGHTLY = { name = "Neovim nightly", fn = function() return vim.fn.has("nvim-0.13") == 1 end },
 }
 

--- a/lua/fzf-lua/test/helpers.lua
+++ b/lua/fzf-lua/test/helpers.lua
@@ -1,11 +1,34 @@
 ---@diagnostic disable: inject-field
 -- lcd so we can run current file even if cwd isn't fzf-lua
-local __FILE__ = debug.getinfo(1, "S").source:gsub("^@", "")
+local _info = debug.getinfo(1, "S")
+---@cast _info {source: string}
+local __FILE__ = _info.source:gsub("^@", "")
 vim.cmd.lcd(vim.fn.fnamemodify(__FILE__, ":p:h:h:h:h"))
 
 local MiniTest = require("mini.test")
 local screenshot = require("fzf-lua.test.screenshot")
 
+---@class fzf-lua.test.helpers
+---@field IS_WIN fun(): boolean
+---@field IS_NOT_WIN fun(): boolean
+---@field SKIP_IF_WIN fun(msg?: string): nil
+---@field SKIP_IF_NOT_WIN fun(msg?: string): nil
+---@field IS_LINUX fun(): boolean
+---@field IS_NOT_LINUX fun(): boolean
+---@field SKIP_IF_LINUX fun(msg?: string): nil
+---@field SKIP_IF_NOT_LINUX fun(msg?: string): nil
+---@field IS_MAC fun(): boolean
+---@field IS_NOT_MAC fun(): boolean
+---@field SKIP_IF_MAC fun(msg?: string): nil
+---@field SKIP_IF_NOT_MAC fun(msg?: string): nil
+---@field IS_STABLE fun(): boolean
+---@field IS_NOT_STABLE fun(): boolean
+---@field SKIP_IF_STABLE fun(msg?: string): nil
+---@field SKIP_IF_NOT_STABLE fun(msg?: string): nil
+---@field IS_NIGHTLY fun(): boolean
+---@field IS_NOT_NIGHTLY fun(): boolean
+---@field SKIP_IF_NIGHTLY fun(msg?: string): nil
+---@field SKIP_IF_NOT_NIGHTLY fun(msg?: string): nil
 local M = {}
 
 -- Busted like expectations
@@ -47,6 +70,7 @@ for k, v in pairs(os_detect) do
     if M[var] == nil then ---@diagnostic disable-next-line: assign-type-mismatch
       M[var] = v.fn()
     end
+    ---@diagnostic disable-next-line: undefined-field
     return M[var]
   end
   M["IS_NOT_" .. k] = function()
@@ -458,6 +482,7 @@ M.FzfLua = setmetatable({}, {
       -- on MacOs but I actually like it that we're testing `fn_postprocess` as well as
       -- RPC connection from child to main instance using with `_G._fzf_lua_server`
       if ci_opts.__postprocess_wait then
+        ---@diagnostic disable-next-line: undefined-field
         opts.fn_postprocess = opts.multiprocess
             and [[return function(opts)
               local chan_id = vim.fn.sockconnect("pipe", _G._fzf_lua_server, { rpc = true })

--- a/lua/fzf-lua/test/screenshot.lua
+++ b/lua/fzf-lua/test/screenshot.lua
@@ -83,7 +83,10 @@ end
 function M.fromChildBufLines(child, buf, opts)
   opts = opts or {}
   if opts and opts.redraw then child.cmd("redraw") end
-  local lines = child.api.nvim_buf_get_lines(buf or 0, opts.start_line and 0, opts.end_line + 1 or -1,
+  local lines = child.api.nvim_buf_get_lines(
+    buf or 0,
+    opts.start_line and 0,
+    opts.end_line and opts.end_line + 1 or -1,
     true)
   return M.from_lines(lines, opts)
 end

--- a/lua/fzf-lua/types.lua
+++ b/lua/fzf-lua/types.lua
@@ -120,7 +120,7 @@ local FzfLua = require("fzf-lua")
 ---generated from the result of `:=FzfLua.config.normalize_opts({}, {})`
 ---@class fzf-lua.config.Base
 ---@field dir_icon? string
----@field enrich? fun(opts: fzf-lua.config.Resolved|{}):fzf-lua.config.Resolved|{}
+---@field enrich? fun(opts: fzf-lua.config.Resolved):fzf-lua.config.Resolved
 ---Path to fzf binary. By default uses fzf found in `$PATH`.
 ---@field fzf_bin? string
 ---Fzf `--color` flag configuration passed to the fzf binary, set `[1]=true` to inherit terminal colorscheme, consult `man fzf` for all available options.
@@ -213,6 +213,17 @@ local FzfLua = require("fzf-lua")
 ---Pager command for shell preview commands (e.g. `delta`).
 ---@field preview_pager? string
 ---@field toggle_flag? string
+---@field reuse_win? boolean
+---@field no_action_set_cursor? boolean
+---@field no_action_zz? boolean
+---@field reverse_search? boolean
+---@field jump_using_norm? boolean
+---@field scope? string
+---@field fn_match_file? function
+---@field fn_match_commit_hash? function
+---@field register? string
+---@field remotes? string
+---@field separator? string
 ---@field _fzf_nth_devicons? boolean
 ---@field _headers? boolean
 
@@ -249,6 +260,14 @@ local FzfLua = require("fzf-lua")
 ---@field _resume_reload? boolean|function
 ---@field _fzf_cli_args string[]
 ---@field _uri? boolean
+---@field is_loclist? boolean
+---@field last_query? string
+---@field cmd_add? string|string[]
+---@field cmd_del? string|string[]
+---@field ctags_file? string
+---@field _cmd? string|string[]
+---@field _is_loclist? boolean
+---@field _apply_awesome_theme? function
 
 ---GENERATED from `make gen`
 

--- a/lua/fzf-lua/utils.lua
+++ b/lua/fzf-lua/utils.lua
@@ -22,15 +22,31 @@ M.__IS_WINDOWS = vim.fn.has("win32") == 1 or vim.fn.has("win64") == 1
 -- `:help shellslash` (for more info see #1055)
 M.__WIN_HAS_SHELLSLASH = M.__IS_WINDOWS and vim.fn.exists("+shellslash") == 1
 
-function M.__FILE__() return debug.getinfo(2, "S").source end
+function M.__FILE__()
+  local info = debug.getinfo(2, "S")
+  ---@cast info {source: string}
+  return info.source
+end
 
-function M.__LINE__() return debug.getinfo(2, "l").currentline end
+function M.__LINE__()
+  local info = debug.getinfo(2, "l")
+  ---@cast info {currentline: integer}
+  return info.currentline
+end
 
-function M.__FNC__() return debug.getinfo(2, "n").name end
+function M.__FNC__()
+  local info = debug.getinfo(2, "n")
+  ---@cast info {name: string}
+  return info.name
+end
 
 -- current function ref, since `M.__FNCREF__` is itself a function
 -- we need to go backwards once in stack (i.e. "2")
-function M.__FNCREF__() return debug.getinfo(2, "f").func end
+function M.__FNCREF__()
+  local info = debug.getinfo(2, "f")
+  ---@cast info {func: function}
+  return info.func
+end
 
 -- calling function ref, go backwards in stack twice first
 -- out of `utils.__FNCREF2__`, second out of calling function
@@ -580,6 +596,7 @@ end
 
 function M.tbl_flatten(T)
   if vim.iter then
+    ---@diagnostic disable-next-line: redundant-parameter, call-non-callable
     return vim.iter(T):flatten(math.huge):totable()
   else
     ---@diagnostic disable-next-line: deprecated
@@ -1085,13 +1102,17 @@ function M.load_profiles(profiles, silent)
     if profile == "borderless_full" then profile = "borderless-full" end
     local fname = path.join({ vim.g.fzf_lua_directory, "profiles", profile .. ".lua" })
     local profile_opts = M.load_profile_fname(fname, nil, silent)
+    ---@cast profile_opts table?
     if type(profile_opts) == "table" then
+      ---@cast profile_opts table
       if profile_opts[1] then
         -- profile requires loading base profile(s)
         -- silent = 1, only warn if failed to load
         profile_opts = vim.tbl_deep_extend("keep",
           profile_opts, M.load_profiles(profile_opts[1], 1))
+        ---@cast profile_opts table
       end
+      ---@cast profile_opts table
       if type(profile_opts.fn_load) == "function" then
         profile_opts.fn_load()
         profile_opts.fn_load = nil
@@ -1131,6 +1152,7 @@ function M.buffer_is_dirty(bufnr, warn, only_if_last_buffer)
   bufnr = (bufnr == nil or bufnr == 0) and vim.api.nvim_get_current_buf() or bufnr
   local info = bufnr and M.getbufinfo(bufnr)
   if info and info.changed ~= 0 then
+    ---@diagnostic disable-next-line: param-type-mismatch
     if only_if_last_buffer and 1 < #vim.fn.win_findbuf(bufnr) then
       return false
     end
@@ -1291,6 +1313,7 @@ function M.eventignore(func, scope)
   local ret = { pcall(func) }
   vim.o.eventignore = save_ei
   if not ret[1] then error(ret[2]) end
+  ---@diagnostic disable-next-line: redundant-return-value
   return select(2, unpack(ret))
 end
 
@@ -1429,6 +1452,7 @@ function M.input(prompt, default)
         res = input
       end)
   else
+    ---@diagnostic disable-next-line: param-type-mismatch
     ok, res = pcall(vim.fn.input, { prompt = prompt, default = default, cancelreturn = 3 })
     if res == 3 then
       ok, res = false, nil
@@ -1623,6 +1647,7 @@ function M.rpcexec(addr, method, ...)
   if fired then return false, "Timeout" end
   vim.fn.chanclose(chan)
   local tonil = function(v) if v == vim.NIL then return nil else return v end end
+  ---@diagnostic disable-next-line: missing-return-value
   return unpack(vim.tbl_map(tonil, ret))
 end
 
@@ -1656,7 +1681,7 @@ function M.jump_to_location(location, offset_encoding, reuse_win)
         { reuse_win = reuse_win, focus = true })
     end)
   else
-    ---@diagnostic disable-next-line: deprecated
+    ---@diagnostic disable-next-line: deprecated, undefined-field
     return vim.lsp.util.jump_to_location(location, offset_encoding, reuse_win)
   end
 end
@@ -1763,6 +1788,7 @@ function M.pid_object(key, opts)
 
   function Pid:set(pid) self.opts[self.key] = pid end
 
+  ---@diagnostic disable-next-line: return-type-mismatch
   return Pid:new(key, opts)
 end
 

--- a/lua/fzf-lua/win.lua
+++ b/lua/fzf-lua/win.lua
@@ -126,6 +126,7 @@ function PathShortener._apply_line(buf, row, shorten_len)
       local conceal_end = line_offset + component_len -- end of component (before separator)
 
       if conceal_end > conceal_start then
+        ---@diagnostic disable-next-line: param-type-mismatch
         pcall(api.nvim_buf_set_extmark, buf, PathShortener._ns, row, conceal_start, {
           end_col = conceal_end,
           conceal = "",
@@ -145,7 +146,9 @@ end
 function PathShortener.attach(winid, bufnr, shorten_len)
   if not winid or not bufnr then return end
   PathShortener.setup()
+  ---@diagnostic disable-next-line: assign-type-mismatch
   shorten_len = (shorten_len == true) and 1 or tonumber(shorten_len) or 1
+  ---@diagnostic disable-next-line: assign-type-mismatch
   PathShortener._wins[winid] = { bufnr = bufnr, shorten_len = shorten_len }
 end
 
@@ -409,6 +412,8 @@ function FzfWin:generate_layout()
   local pwopts
   local row, col = winopts.row, winopts.col
   local height, width = winopts.height, winopts.width
+  ---@cast height integer
+  ---@cast width integer
   local preview_pos, preview_size = layout.pos, layout.size
   local pborder, ph, pw = self:normalize_border(self._o.winopts.preview.border,
     { type = "nvim", name = "prev", layout = preview and layout.pos, nwin = nwin, opts = self._o })
@@ -777,6 +782,7 @@ function FzfWin:attach_previewer(previewer)
     -- won't be closed properly and remain lingering (visible in `:ls!`)
     -- make sure the previewer is aware of this buffer
     if not self._previewer.preview_bufnr and self:validate_preview() then
+      ---@diagnostic disable-next-line: inject-field
       self._previewer.preview_bufnr = api.nvim_win_get_buf(self.preview_winid)
     end
     if self.on_closes.preview then self.on_closes.preview() end
@@ -1282,6 +1288,7 @@ function FzfWin.on_SIGWINCH(opts, event, cb)
       local events = vim.tbl_keys(vim.list_slice(opts.__sigwinch_cb))
       vim.list_extend(events, opts.__sigwinches or {})
       opts.__sigwinches = nil
+      ---@diagnostic disable-next-line: undefined-field
       local acts = vim.tbl_map(function(k) return opts.__sigwinch_cb[k](args) end, events)
       acts = vim.tbl_filter(function(a) return a and #a > 0 end, acts)
       return table.concat(acts, "+")

--- a/lua/fzf-lua/win/border.lua
+++ b/lua/fzf-lua/win/border.lua
@@ -7,7 +7,7 @@ local utils = require "fzf-lua.utils"
 ---@field name? 'fzf'|'prev'
 ---@field nwin? integer
 ---@field layout? fzf-lua.win.previewPos
----@field opts? fzf-lua.config.Resolved|{}
+---@field opts? fzf-lua.config.Resolved
 
 ---@alias fzf-lua.winborder string[]|"none"|"single"|"double"|"rounded"|"solid"|"shadow"
 

--- a/scripts/cli.lua
+++ b/scripts/cli.lua
@@ -1,7 +1,9 @@
 ---@diagnostic disable-next-line: deprecated
 local api, uv, fn = vim.api, vim.uv or vim.loop, vim.fn
 assert(#api.nvim_list_uis() == 0)
-local __FILE__ = debug.getinfo(1, "S").source:gsub("^@", "")
+local _info = debug.getinfo(1, "S")
+---@cast _info {source: string}
+local __FILE__ = _info.source:gsub("^@", "")
 local dir = fn.fnamemodify(fn.resolve(__FILE__), ":h:h:p")
 vim.opt.rtp:append(dir)
 vim.cmd.runtime("plugin/fzf-lua.lua")
@@ -65,7 +67,9 @@ _G.fzf_jobstart = function(cmd, opts)
     end))
 end
 
-require("fzf-lua.cmd").run_command(unpack(_G.arg))
+local _cli_args = _G.arg
+---@cast _cli_args string[]
+require("fzf-lua.cmd").run_command(unpack(_cli_args) --[[@as string]])
 
 while true do
   vim.wait(100)

--- a/scripts/gen_options.lua
+++ b/scripts/gen_options.lua
@@ -53,6 +53,7 @@ local defaults = require("fzf-lua.defaults").defaults
 local res = vim.json.decode(obj.stdout or "") ---@type EmmyDocJson
 
 local tymap = {} ---@type table<string, EmmyDocType?>
+---@diagnostic disable-next-line: redundant-parameter, call-non-callable
 vim.iter(assert(res.types)):each(function(ty) tymap[ty.name] = ty end)
 
 ---@param typ string
@@ -71,6 +72,7 @@ local function fix_typ(typ, default)
   -- Remove outer parentheses from union types for cleaner display
   if typ:match("^%(.*%)$") then
     local ty = typ:sub(2, -2)
+    ---@diagnostic disable-next-line: redundant-parameter, call-non-callable
     local is = vim.iter(vim.split(ty, ",")):all(function(t)
       return t:match([[".-"]])
     end)
@@ -390,6 +392,7 @@ local function generate_globals()
 
   -- Then add Defaults type options
   local ty = assert(tymap["fzf-lua.config.Defaults"], "fzf-lua.config.Defaults type not found")
+  ---@diagnostic disable-next-line: redundant-parameter, call-non-callable
   vim.iter(ty.members)
       :each(function(member)
         -- Skip excluded fields

--- a/scripts/gen_types.lua
+++ b/scripts/gen_types.lua
@@ -23,7 +23,7 @@ for _, v in vim.spairs(exported_modules) do
 end
 write("\n")
 for k, v in vim.spairs(lazyloaded_modules) do
-  write(([[FzfLua.%s = require(%q).%s]] .. "\n"):format(k, v[1], v[2]))
+  write(([[FzfLua.%s = require(%q).%s]] .. "\n"):format(k, v[1], v[2])) ---@diagnostic disable-line: undefined-field
 end
 write("\n")
 
@@ -40,12 +40,14 @@ local write_member = function(m)
   write("---@field " .. m.name .. " ")
   write(m.is_async and "async" or "")
   write("fun(")
+  ---@diagnostic disable-next-line: redundant-parameter, call-non-callable
   local params = vim.iter(m.params)
   local p1 = params:next()
   if p1 then write(("%s: %s"):format(p1.name, p1.typ)) end
   params:each(function(p) write((", %s: %s"):format(p.name, p.typ)) end)
   write(")")
 
+  ---@diagnostic disable-next-line: redundant-parameter, call-non-callable
   local returns = vim.iter(m.returns)
   local r1 = returns:next()
   if r1 then write((": " .. r1.typ)) end
@@ -54,6 +56,7 @@ local write_member = function(m)
 end
 
 write("---@class fzf-lua.win.api: fzf-lua.Win\n")
+---@diagnostic disable-next-line: redundant-parameter, call-non-callable
 vim.iter(res.members):each(write_member)
 
 flush()

--- a/tests/api_spec.lua
+++ b/tests/api_spec.lua
@@ -36,6 +36,7 @@ T["api"]["fzf_exec"]["function"] = new_set({ parametrize = { { "sync" }, { "asyn
       helpers.FzfLua.fzf_exec(child, function(fzf_cb)
           coroutine.wrap(function()
             local co = coroutine.running()
+            ---@cast co thread
             for i = 1, 1000 do
               fzf_cb(tostring(i), function() coroutine.resume(co) end)
               coroutine.yield()
@@ -150,6 +151,7 @@ T["api"]["fzf_live"]["function"] = new_set({ parametrize = { { "sync" }, { "asyn
           local q = args[1]
           return coroutine.wrap(function(fzf_cb)
             local co = coroutine.running()
+            ---@cast co thread
             if not tonumber(q) then
               fzf_cb("Invalid number: " .. tostring(q), function() coroutine.resume(co) end)
               coroutine.yield()

--- a/tests/cache_spec.lua
+++ b/tests/cache_spec.lua
@@ -104,6 +104,7 @@ describe("Testing cache module", function()
   it("size set: err", function()
     local ok, err = pcall(cache.set_size, cache, 10)
     assert.is.False(ok)
+    ---@diagnostic disable-next-line: param-type-mismatch, need-check-nil
     assert.is.True(err and err:match("cannot be smaller than current length") ~= nil)
   end)
 

--- a/tests/codeaction_spec.lua
+++ b/tests/codeaction_spec.lua
@@ -55,6 +55,7 @@ T["codeaction"]["preview does not mutate same-position text edits"] = function()
 
   local ok, err = pcall(function()
     local uri = vim.uri_from_bufnr(bufnr)
+    ---@diagnostic disable-next-line: missing-fields, param-type-mismatch
     codeaction.builtin.preview_action_tuple({
       opts = {
         _items = {

--- a/tests/path_spec.lua
+++ b/tests/path_spec.lua
@@ -669,7 +669,7 @@ describe("Testing path module", function()
     end)
 
     it("sets winopts.title to 'VCS Files (jj)' in a jj repo", function()
-      local received_opts
+      local received_opts ---@cast received_opts table
       path.is_jj_repo = function() return true end
       path.is_git_repo = function() return false end
       jj_provider.files = function(opts) received_opts = opts end
@@ -678,7 +678,7 @@ describe("Testing path module", function()
     end)
 
     it("sets winopts.title to 'VCS Files (git)' in a git repo", function()
-      local received_opts
+      local received_opts ---@cast received_opts table
       path.is_jj_repo = function() return false end
       path.is_git_repo = function() return true end
       git_provider.files = function(opts) received_opts = opts end
@@ -687,7 +687,7 @@ describe("Testing path module", function()
     end)
 
     it("does not set winopts.title when falling back to files", function()
-      local received_opts
+      local received_opts ---@cast received_opts table
       path.is_jj_repo = function() return false end
       path.is_git_repo = function() return false end
       files_provider.files = function(opts) received_opts = opts end
@@ -696,7 +696,7 @@ describe("Testing path module", function()
     end)
 
     it("does not override user-supplied winopts.title", function()
-      local received_opts
+      local received_opts ---@cast received_opts table
       path.is_jj_repo = function() return true end
       path.is_git_repo = function() return false end
       jj_provider.files = function(opts) received_opts = opts end
@@ -717,7 +717,7 @@ describe("Testing path module", function()
       local orig_info = utils.info
       utils.info = function(msg) info_msg = msg end
       -- path.git_root calls utils.info when noerr is falsy
-      path.git_root = function(opts, noerr)
+      path.git_root = function(_opts, noerr)
         if not noerr then
           utils.info("not a git repository")
         end

--- a/tests/ui_select_spec.lua
+++ b/tests/ui_select_spec.lua
@@ -51,6 +51,7 @@ end
 -- boundary). `pcall` traps any synchronous crash from the native
 -- preview fn (#2743).
 local function open_picker(items, preview_lines, ui_opts)
+  ---@diagnostic disable-next-line: redefined-local
   exec_lua(function(items, preview_lines, ui_opts)
     _G._ui_select_choice = nil
     _G._ui_select_errors = nil

--- a/tests/win_spec.lua
+++ b/tests/win_spec.lua
@@ -147,6 +147,7 @@ end
 T["win"]["keymap"] = new_set({ n_retry = not helpers.IS_LINUX() and 5 or nil })
 
 T["win"]["keymap"]["no error"] = new_set({
+  ---@diagnostic disable-next-line: redundant-parameter, call-non-callable
   parametrize = vim.iter(require("fzf-lua.defaults").defaults.keymap.builtin)
       :map(function(key, action) return { key, action } end)
       :totable()


### PR DESCRIPTION

### IDK how coderabbit came out with this summary but it's totally wrong lol

What this PR does
- Removes lua_language_server from lint step
- Sets emmylua_check as main linter and errors on warnings
- Adds a makefile step to automatically download emmylua_check on `make emmylua_check`
- Uses emmyua_check 0.23.1 due to a freeze issue with 0.23.2 (will use latest on next release)
- Fixes all emmylua_check warnings

## The below is the garbage generated by coderabbitai:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the `grep_lgrep` action could ignore the `multiprocess` setting.
  * Improved the health report formatting for `FZF_DEFAULT_OPTS`.
* **Chores**
  * Updated CI linting and Makefile targets to install/run the EmmyLua linter via a dedicated dependency step and the project’s make workflow.
  * Enhanced lint behavior to treat more linter warnings as errors and ignore generated dependency paths.
  * Applied project-wide type/diagnostic annotation cleanups for editor tooling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->