### PR TITLE
fix(git_branches): drop POSIX single quotes so cmd.exe works on Windows

### DIFF
--- a/lua/fzf-lua/defaults.lua
+++ b/lua/fzf-lua/defaults.lua
@@ -830,7 +830,7 @@ M.defaults.git = {
   ---@field cmd_del? string[]
   branches = {
     cmd        = [[git branch --all --color -vv ]]
-        .. [[--sort=-'committerdate' --sort='refname:rstrip=-2' --sort=-'HEAD']],
+        .. [[--sort=-committerdate --sort=refname:rstrip=-2 --sort=-HEAD]],
     preview    = "git log --graph --pretty=oneline --abbrev-commit --color {1}",
     remotes    = "local",
     actions    = {


### PR DESCRIPTION
Fixes #2781

### Problem

The default `git.branches` command wraps the sort keys in POSIX single quotes:

```lua
cmd = [[git branch --all --color -vv ]]
    .. [[--sort=-'committerdate' --sort='refname:rstrip=-2' --sort=-'HEAD']],
```

On Windows, Neovim's default shell is `cmd.exe` (`shellcmdflag=/s /c`), which does **not** strip single quotes. They reach `git` literally, so the field name is parsed as `'committerdate'` and git fails:

```
fatal: unknown field name: 'committerdate'
```

`:FzfLua git_branches` is therefore broken on Windows out of the box.

### Fix

Drop the decorative single quotes. The field names (`committerdate`, `refname:rstrip=-2`, `HEAD`) contain no shell metacharacters, so the quotes are unnecessary on POSIX shells and harmful on `cmd.exe`.

```lua
cmd = [[git branch --all --color -vv ]]
    .. [[--sort=-committerdate --sort=refname:rstrip=-2 --sort=-HEAD]],
```

### Verification

**Windows** — Neovim 0.12.0-dev headless (`cmd.exe`), `vim.fn.systemlist`:
- Before: exit 128, `fatal: unknown field name: 'committerdate'`
- After: exit 0, branches listed with the intended sort order

**Linux** — WSL Ubuntu (bash), `diff` of original vs fixed command output:
- Byte-identical (no behavior change on POSIX shells)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Git branch sorting in the branch picker to ensure branches are ordered correctly by commit date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->