### PR TITLE
fix(btags): limit "excmd=combine" to universal ctags

### DIFF
--- a/lua/fzf-lua/providers/tags.lua
+++ b/lua/fzf-lua/providers/tags.lua
@@ -207,7 +207,8 @@ M.btags = function(opts)
   -- Used as fallback to pipe the tags into fzf from stdout
   opts._btags_cmd = string.format("%s %s %s",
     opts.ctags_bin or "ctags",
-    opts.ctags_args or string.format("-f - %s", utils.is_darwin() and "" or "--excmd=combine"),
+    opts.ctags_args or
+    string.format("-f - %s", utils.ctags_is_universal(opts.ctags_bin) and "--excmd=combine" or ""),
     libuv.shellescape(opts.filename))
   if opts.ctags_autogen then
     opts.cmd = opts.cmd or opts._btags_cmd
@@ -265,7 +266,8 @@ M.grep_cWORD = function(opts)
   if not opts then opts = {} end
   opts.no_esc = true
   -- since we're searching a tags file also search for surrounding literals ^ $
-  opts.search = [[(^|\^|\s)]] .. utils.rg_escape(vim.fn.expand("<cWORD>") --[[@as string]]) .. [[($|\$|\s)]]
+  opts.search = [[(^|\^|\s)]] ..
+      utils.rg_escape(vim.fn.expand("<cWORD>") --[[@as string]]) .. [[($|\$|\s)]]
   return M.grep(opts)
 end
 

--- a/lua/fzf-lua/utils.lua
+++ b/lua/fzf-lua/utils.lua
@@ -1570,6 +1570,15 @@ function M.git_version()
   return tonumber(out:match("(%d+.%d+)."))
 end
 
+  ---@param binary string?
+  ---@return boolean? is universal ctags
+  ---@return number? version
+function M.ctags_is_universal(binary)
+  local out, rc = M.io_system({ binary or "ctags", "--version" })
+  if rc ~= 0 then return end
+  return out:match("Universal") ~= nil, tonumber(out:match("(%d+.%d+).")) 
+end
+
 function M.create_user_command_callback(provider, arg, altmap)
   ---@param o vim.api.keyset.create_user_command.command_args
   ---@return table


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tag searching compatibility by detecting Universal Ctags and adjusting the command options accordingly.
  * Preserved correct handling of `<cWORD>` searches with special characters by keeping the existing escaping behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->