### PR TITLE
ci: fix macos-latest brew lock take 2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,8 +27,12 @@ jobs:
         include:
           - os: macos-latest
             install-deps: |
-              brew update
-              brew install fzf ripgrep fd gnu-getopt
+              # setup-vim action uses brew to install stable which may lock brew
+              while pgrep -f "[b]rew" >/dev/null; do
+                echo "Waiting for another brew process to finish..."
+                sleep 2
+              done
+              brew update && brew install fzf ripgrep fd gnu-getopt
               brew link --force gnu-getopt
           - os: windows-latest
             install-deps: |


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS continuous integration reliability by preventing conflicts with concurrent Homebrew activity.
  * CI now waits for any ongoing Homebrew process to finish before running dependency updates/installs, reducing transient pipeline failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->