### PR TITLE
fix(utils): don't corrupt UTF-8 in strip_ansi_coloring #2786

### DIFF
--- a/lua/fzf-lua/utils.lua
+++ b/lua/fzf-lua/utils.lua
@@ -947,7 +947,7 @@ function M.strip_ansi_coloring(str)
   -- NOTE: didn't work with grep's "^[[K"
   -- return str:gsub("%[[%d;]-m", "")
   -- https://stackoverflow.com/a/49209650/368691
-  return str:gsub("[\27\155][][()#;?%d]*[A-PRZcf-ntqry=><~]", "")
+  return str:gsub("[\27\155][%[%]][()#;?%d]*[A-PRZcf-ntqry=><~]", "")
 end
 
 function M.ansi_escseq_len(str)

--- a/tests/path_spec.lua
+++ b/tests/path_spec.lua
@@ -467,6 +467,31 @@ describe("Testing path module", function()
       eq(path.entry_to_file("file:///tmp/test.txt:5:6", {}, true), r)
     end)
 
+    -- #2786: stripping ANSI coloring must not corrupt UTF-8 multibyte chars
+    it("strip_ansi_coloring preserves UTF-8 #2786", function()
+      -- plain ANSI SGR sequences still stripped
+      eq(utils.strip_ansi_coloring("\27[34mfoo\27[0m"), "foo")
+      eq(utils.strip_ansi_coloring("\27[1;34mfoo\27[0m"), "foo")
+      eq(utils.strip_ansi_coloring("\27[mfoo\27[0m"), "foo")
+      -- UTF-8 Polish "ści" (\xC5\x9B\x63\x69) must not have its second
+      -- byte (\x9B) eaten together with the trailing ASCII letter "c"
+      -- by an over-permissive regex
+      local sci = "\197\155" .. "ci.txt"
+      eq(utils.strip_ansi_coloring(sci), sci)
+      -- same but wrapped in SGR escape sequences (typical fzf output)
+      eq(utils.strip_ansi_coloring("\27[0m" .. sci .. "\27[0m"), sci)
+      -- other multibyte characters whose second byte overlaps the
+      -- "final byte" character class of the broken regex
+      eq(utils.strip_ansi_coloring("\195\177"), "\195\177")  -- "ñ"
+      eq(utils.strip_ansi_coloring("\195\184"), "\195\184")  -- "ø"
+      eq(utils.strip_ansi_coloring("\209\134" .. "x.txt"), "\209\134" .. "x.txt") -- "цx.txt"
+      -- entry_to_file must return the path with UTF-8 bytes intact
+      local p = "/tmp/" .. sci
+      eq(path.entry_to_file(p), { stripped = p, path = p, line = 0, col = 0 })
+      local e = "\27[0m" .. p .. "\27[0m:42"
+      eq(path.entry_to_file(e), { stripped = p .. ":42", path = p, line = 42, col = 0 })
+    end)
+
     it("parse loaded path", function()
       helpers.SKIP_IF_WIN()
       local win = vim.api.nvim_get_current_win()


### PR DESCRIPTION
Fix https://github.com/ibhagwan/fzf-lua/issues/2786


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved removal of ANSI color sequences while preserving UTF-8 characters.
  * Fixed handling of ANSI-colored paths so multibyte characters remain intact.

* **Tests**
  * Added coverage for UTF-8 text and ANSI-colored path entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->