### PR TITLE
fix(helptags): `:help help-tags`

### DIFF
--- a/lua/fzf-lua/providers/helptags.lua
+++ b/lua/fzf-lua/providers/helptags.lua
@@ -71,6 +71,7 @@ M.helptags = function(opts)
       end)
     end
 
+    local tagpath = vim.env.VIMRUNTIME .. "/doc/tags"
     coroutine.wrap(function()
       local co = coroutine.running()
       ---@cast co thread
@@ -87,7 +88,7 @@ M.helptags = function(opts)
                 add_tag({
                   tag = fields[1],
                   filename = fields[2],
-                  filepath = help_files[fields[2]],
+                  filepath = help_files[fields[2]] or tagpath,
                   cmd = fields[3],
                   lang = lang,
                 }, cb, co)


### PR DESCRIPTION
Use puc lua then add an assert on coroutine.resume we can get the trace
```
Lua callback:
providers/helptags.lua:70: providers/helptags.lua:67: bad argument #5 to
'format' (string expected, got nil)
stack traceback:
	[C]: in function 'assert'
	providers/helptags.lua:70: in function 'cb'
	shell.lua:379: in function <shell.lua:377>
```

https://github.com/neovim/neovim/blob/92b2a267723922a60f0716a31d06d7d36115e103/src/gen/gen_helptags.lua#L58


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved help tag navigation by falling back to Neovim’s runtime documentation path when a specific help file cannot be resolved.
  * Ensured more help tags open with a valid file location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->